### PR TITLE
Add user level default root certificate, fix #130

### DIFF
--- a/src/Fluxzy.Core/Certificates/FluxzySecurity.cs
+++ b/src/Fluxzy.Core/Certificates/FluxzySecurity.cs
@@ -1,14 +1,57 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Fluxzy.Certificates
 {
+    /// <summary>
+    ///  Solve the default root certificate used by fluxzy in the following order:
+    ///  - From the path specified in the environment variable FLUXZY_ROOT_CERTIFICATE which must be a path to a PKCS12 File
+    ///  - From the static filesystem path %appdata%/.fluxzy/rootca.pfx
+    ///  - If none of the above is available, use the built-in certificate
+    ///
+    ///  For the two first cases, if the PKCS12 file has a password, it must be specified in the environment variable FLUXZY_ROOT_CERTIFICATE_PASSWORD
+    /// </summary>
     internal static class FluxzySecurity
     {
         static FluxzySecurity()
         {
-            BuiltinCertificate = new X509Certificate2(FileStore.Fluxzy, "youshallnotpass");
+            BuiltinCertificate = GetDefaultCertificate();
+        }
+        
+        private static X509Certificate2 GetDefaultCertificate()
+        {
+            var certificatePath = Environment.GetEnvironmentVariable("FLUXZY_ROOT_CERTIFICATE");
+            var certificatePassword = Environment.GetEnvironmentVariable("FLUXZY_ROOT_CERTIFICATE_PASSWORD");
+
+            if (certificatePath != null) {
+                if (!File.Exists(certificatePath)) {
+                    throw new Exception($"The certificate file {certificatePath} (from FLUXZY_ROOT_CERTIFICATE variable) does not exist");
+                }
+            }
+            else
+            {
+                var defaultPath = Environment.ExpandEnvironmentVariables("%appdata%/.fluxzy/rootca.pfx");
+
+                if (File.Exists(defaultPath))
+                {
+                    certificatePath = defaultPath;
+                }
+            }
+
+            if (certificatePath != null)
+            {
+                if (certificatePassword == null)
+                {
+                    return new X509Certificate2(certificatePath);
+                }
+
+                return new X509Certificate2(certificatePath, certificatePassword);
+            }
+
+            return new X509Certificate2(FileStore.Fluxzy, "youshallnotpass");
         }
 
         public static X509Certificate2 BuiltinCertificate { get; }

--- a/src/Fluxzy/Properties/launchSettings.json
+++ b/src/Fluxzy/Properties/launchSettings.json
@@ -4,20 +4,13 @@
             "commandName": "Project",
             "environmentVariables": {
             },
-            "commandLineArgs": "start --llo -sp --use-502 -r e:\\test.yaml -o e:\\ss.fxzy -c --bouncy-castle"
+            "commandLineArgs": "start --llo -sp"
         },
         "launch (normal)": {
             "commandName": "Project",
             "environmentVariables": {
             },
             "commandLineArgs": "start --no-cert-cache --trace"
-        },
-        "launch (dis)": {
-            "commandName": "Project",
-            "environmentVariables": {
-            },
-            "commandLineArgs": "dis d:\\pink-floyd.fxzy  -f \"{pcap}\" -u -i 87"
         }
     }
-
 }


### PR DESCRIPTION
Solve the default root certificate used by fluxzy in the following order:

- From the command line args (Fluxzy CLI)
- From the path specified in the environment variable `FLUXZY_ROOT_CERTIFICATE `which must be a path to a PKCS12 File
- From the static filesystem path `%appdata%/.fluxzy/rootca.pfx`
- If none of the above is available, use the built-in certificate

For the two first cases, if the PKCS12 file is password protected, the passphrase should be provided with the environment variable `FLUXZY_ROOT_CERTIFICATE_PASSWORD`