### PR TITLE
Make *enchanced packet block* comment deactivatable through EV

### DIFF
--- a/src/Fluxzy.Core.Pcap/Pcapng/PcapngStreamWriter.cs
+++ b/src/Fluxzy.Core.Pcap/Pcapng/PcapngStreamWriter.cs
@@ -98,7 +98,7 @@ namespace Fluxzy.Core.Pcap.Pcapng
                 (uint) (longTimeSpan & 0xFFFFFFFF),
                 capture.Data.Length,
                 capture.Data.Length,
-                "fluxzy"
+                Environment.GetEnvironmentVariable("FLUXZY_PCAP_PACKET_COMMENT") ?? "fluxzy"
             );
 
             // This need to be corrected if MTU is very large


### PR DESCRIPTION
EV `FLUXZY_PCAP_PACKET_COMMENT` can now control packet comment. Set to blank/whitespace to disable commenting. 