### PR TITLE
Change exception to return statement in getResponseCompressionType

### DIFF
--- a/src/Fluxzy.Core/Archiving/Extensions/ExchangeExtensions.cs
+++ b/src/Fluxzy.Core/Archiving/Extensions/ExchangeExtensions.cs
@@ -90,11 +90,11 @@ namespace Fluxzy.Extensions
 
         public static CompressionType GetResponseCompressionType(this IExchange exchangeInfo)
         {
-            var headers = exchangeInfo.GetResponseHeaders(); 
+            var headers = exchangeInfo.GetResponseHeaders();
 
             if (headers == null)
-                throw new InvalidOperationException("This exchange does not have response body");
-
+                return CompressionType.None; 
+            
             return InternalGetCompressionType(headers);
         }
 


### PR DESCRIPTION
The code has been refactored to return a default value instead of throwing an exception when the response headers for a data exchange are absent. This change should improve error handling and make the code more resilient to unexpected scenarios. 