### PR TITLE
Make examples use stock nuget.org version of `Fluxzy.Core` instead of project reference

### DIFF
--- a/examples/Samples.No001.SimpleCapture/Samples.No001.SimpleCapture.csproj
+++ b/examples/Samples.No001.SimpleCapture/Samples.No001.SimpleCapture.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Include="Fluxzy.Core" Version="1.20.23" />
   </ItemGroup>
 
 </Project>

--- a/examples/Samples.No002.Filtering/Samples.No002.Filtering.csproj
+++ b/examples/Samples.No002.Filtering/Samples.No002.Filtering.csproj
@@ -7,12 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Include="Fluxzy.Core" Version="1.20.23" />
   </ItemGroup>
 
 </Project>

--- a/examples/Samples.No003.RawCapture/Samples.No003.RawCapture.csproj
+++ b/examples/Samples.No003.RawCapture/Samples.No003.RawCapture.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Fluxzy.Core.Pcap\Fluxzy.Core.Pcap.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Include="Fluxzy.Core.Pcap" Version="1.20.23" />
   </ItemGroup>
 
 </Project>

--- a/examples/Samples.No004.BasicAlterations/Samples.No004.BasicAlterations.csproj
+++ b/examples/Samples.No004.BasicAlterations/Samples.No004.BasicAlterations.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Include="Fluxzy.Core" Version="1.20.23" />
   </ItemGroup>
 
 </Project>

--- a/examples/Samples.No005.BasicAlterations_FromConfigurationFile/Samples.No005.BasicAlterations_FromConfigurationFile.csproj
+++ b/examples/Samples.No005.BasicAlterations_FromConfigurationFile/Samples.No005.BasicAlterations_FromConfigurationFile.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Include="Fluxzy.Core" Version="1.20.23" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
… project reference