### PR TITLE
Fix container run by setting `entrypoint.sh` executable

### DIFF
--- a/docker/Dockerfile.alpine-x64
+++ b/docker/Dockerfile.alpine-x64
@@ -23,6 +23,7 @@ RUN apk update && apk add libpcap-dev libc6-compat openssl libgcc libstdc++ ncur
 
 COPY --from=publish /app/output-bin /artefacts
 COPY "docker/entrypoint.sh" "/entrypoint.sh"
+RUN chmod +x /entrypoint.sh
 
 CMD ["./artefacts/fluxzy"]
 


### PR DESCRIPTION
Produces container execution error when build with non windows host