### PR TITLE
Fix inability to merge PCAP files with enhanced block exceeding 4K

### DIFF
--- a/src/Fluxzy.Core.Pcap/Pcapng/Merge/EnhancedBlockReader.cs
+++ b/src/Fluxzy.Core.Pcap/Pcapng/Merge/EnhancedBlockReader.cs
@@ -8,7 +8,7 @@ namespace Fluxzy.Core.Pcap.Pcapng.Merge
     internal class EnhancedBlockReader : SleepyStreamBlockReader
     {
         private readonly PcapBlockWriter _blockWriter;
-        private readonly byte[] _defaultBuffer = new byte[1024 * 4];
+        private readonly byte[] _defaultBuffer = new byte[FluxzySharedSetting.PcapEnhancedBlockMaxLength];
 
         public EnhancedBlockReader(PcapBlockWriter blockWriter,
             StreamLimiter streamLimiter, IStreamSource streamFactory)

--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -68,5 +68,10 @@ namespace Fluxzy
         ///  The maximum buffer size for request processing, above this value the connection will be abandoned
         /// </summary>
         public static int MaxProcessingBuffer { get;  } = EnvironmentUtility.GetInt32("FLUXZY_MAX_PROCESSING_BUFFER", 1024 * 512);
+
+        /// <summary>
+        ///  Maximum length of an enhanced block in a pcapng file, default is 8KB
+        /// </summary>
+        public static int PcapEnhancedBlockMaxLength { get; } = EnvironmentUtility.GetInt32("FLUXZY_PCAP_ENHANCED_BLOCK_MAX_LENGTH", 8 * 1024);
     }
 }


### PR DESCRIPTION
This update introduces two changes: 
- Default enhanced block buffer length is set to 8K
- The value can be controlled by `FLUXZY_PCAP_ENHANCED_BLOCK_MAX_LENGTH` variable