### PR TITLE
Fix unwanted  HTTP 100 continue status code not handled in certain case

### DIFF
--- a/src/Fluxzy.Core/Formatters/Producers/Requests/HttpHelper.cs
+++ b/src/Fluxzy.Core/Formatters/Producers/Requests/HttpHelper.cs
@@ -11,6 +11,8 @@ namespace Fluxzy.Formatters.Producers.Requests
 {
     internal static class HttpHelper
     {
+        private static readonly byte[] _100ContinueBytes = { 49, 48, 48 };
+
         public static IReadOnlyCollection<RequestCookie> ReadRequestCookies(ExchangeInfo exchangeInfo)
         {
             var headers = exchangeInfo.GetRequestHeaders()?.ToList();
@@ -98,6 +100,21 @@ namespace Fluxzy.Formatters.Producers.Requests
                            .ToList();
 
             return items;
+        }
+
+        /// <summary>
+        ///  Check if headerline is 100-continue
+        /// </summary>
+        /// <param name="httpLine"></param>
+        /// <returns></returns>
+        public static bool Is100Continue(ReadOnlySpan<byte> httpLine)
+        {
+            if (httpLine.Length < 12)
+                return false;
+
+            var statusLine = httpLine.Slice(9, 3);
+
+            return statusLine.SequenceEqual(_100ContinueBytes);
         }
     }
 }

--- a/test/Fluxzy.Tests/Cases/Expect100ContinueTests.cs
+++ b/test/Fluxzy.Tests/Cases/Expect100ContinueTests.cs
@@ -1,0 +1,43 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    public class Expect100ContinueTests
+    {
+        private static string GetFromBase64(string rawValue)
+        {
+            return Encoding.UTF8.GetString(System.Convert.FromBase64String(rawValue));
+        }
+
+        [Fact]
+        public async Task Should_Get_Response_Event_If_Server_Sent_100_Without_Expected_Header()
+        {
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            var url = GetFromBase64(
+                "aHR0cHM6Ly9kZXZpcy1hc3N1cmFuY2Utc2FudGUuZ21mLmZyL3B1YmxpYy9wYWdlcy9kZXZpcy9EU1AxLmZhY2U=");
+
+            var str = GetFromBase64(
+                "al9pZHQ2Mz1qX2lkdDYzJmpfaWR0NjMlM0FjdXN0b21SYWRpb0NpdmlsaXRlPU1PTlNJRVVSJmpfaWR0NjMlM0Fub209TU5UUk5HU1Qmal9pZHQ2MyUzQXByZW5vbT1QWUdNQUxJT04mal9pZHQ2MyUzQW5haXNzYW5jZT0xNSUyRjAxJTJGMTk4NiZqX2lkdDYzJTNBcG9zdGFsPTkyMzAwJmpfaWR0NjMlM0FwaG9uZT0wMTExMTExMTExJmpfaWR0NjMlM0FlbWFpbD1nbWYlNDAyYmVmZmljaWVudC5jb20mal9pZHQ2MyUzQWN1c3RvbVJhZGlvU3RvcFB1Yj1OT04mamF2YXguZmFjZXMuVmlld1N0YXRlPS0yOTA1MDk3NTk1NTQ1MzA3NDc5JTNBMTkyMTAyOTU4NDUyODQxMDE5NCZqX2lkdDYzJTNBal9pZHQxMDE9al9pZHQ2MyUzQWpfaWR0MTAx");
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, url);
+
+            requestMessage.Content = new StringContent(str, Encoding.UTF8, "application/x-www-form-urlencoded");
+
+            var response = await client.SendAsync(requestMessage);
+
+            var statusCode = response.StatusCode;
+
+            Assert.NotEqual(528, (int)statusCode);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Util/HttpHelperTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/HttpHelperTests.cs
@@ -1,0 +1,26 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Text;
+using Fluxzy.Formatters.Producers.Requests;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Util
+{
+    public class HttpHelperTests
+    {
+        [Theory]
+        [InlineData("HTTP/1.1 100 Continue\r\n\r\n", true)]
+        [InlineData("HTTP/1.0 100 Continue\r\n\r\n", true)]
+        [InlineData("HTTP/1.1 101 Continue\r\n", false)]
+        [InlineData("HTTP", false)]
+        [InlineData("", false)]
+        public void Is100Continue(string header, bool success)
+        {
+            var headerBytes = Encoding.UTF8.GetBytes(header);
+
+            var result = HttpHelper.Is100Continue(headerBytes);
+
+            Assert.Equal(success, result);
+        }
+    }
+}


### PR DESCRIPTION
Even if fluxzy is not sending `expect: 100-continue`,  we still need to handle it as some minor HTTP server will send it anyway.