### PR TITLE
Add `Properties`, a custom data holder, to `ArchiveMetaInformation`

### DIFF
--- a/src/Fluxzy.Core/Archiving/ArchiveMetaInformation.cs
+++ b/src/Fluxzy.Core/Archiving/ArchiveMetaInformation.cs
@@ -41,5 +41,11 @@ namespace Fluxzy
         /// Fluxzy version used to create this archive
         /// </summary>
         public string FluxzyVersion { get; set; } = Assembly.GetExecutingAssembly().GetName().Version!.ToString();
+
+        /// <summary>
+        ///  Can be used to store additional information about the archive.
+        /// </summary>
+
+        public Dictionary<string, string> Properties { get; set; } = new();
     }
 }


### PR DESCRIPTION
Capture initiator needs in certain cases to store custom information about the archive that's been build. This PR added properties field on `ArchiveInformation` to hold that kind of data. 