### PR TITLE
Update ReverseProxyExchangeSourceProvider.cs

### DIFF
--- a/src/Fluxzy.Core/Core/ReverseProxyExchangeSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/ReverseProxyExchangeSourceProvider.cs
@@ -50,7 +50,7 @@ namespace Fluxzy.Core
                 CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
                 EncryptionPolicy = EncryptionPolicy.RequireEncryption,
                 ServerCertificateSelectionCallback = (sender, name) => {
-                    var certificate = _certificateProvider.GetCertificate(name ?? "fluxzy.io");
+                    var certificate = _certificateProvider.GetCertificate(string.IsNullOrWhiteSpace(name) ? "fluxzy.io" : name);
                     authorityName = name;
                     return certificate;
                 }


### PR DESCRIPTION
 ServerCertificateCallback checks on empty name instead of name being null.
#300 