### PR TITLE
Fix missing new line leading invalid `SSLKEYLOGFILE` output

### DIFF
--- a/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/NssLogWriter.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/NssLogWriter.cs
@@ -48,7 +48,7 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
 
         public void Write(string key, byte[] clientRandom, byte[] secret)
         {
-            var stringKey = $"{key} {Hex.ToHexString(clientRandom)} {Hex.ToHexString(secret)}";
+            var stringKey = $"{key} {Hex.ToHexString(clientRandom)} {Hex.ToHexString(secret)}\n";
 
             KeyHandler?.Invoke(stringKey);
 


### PR DESCRIPTION
The missing new line makes Wireshark not be able to decode TLS v1.3 under Windows. 

