### PR TITLE
Add `--insecure` option to disable certificate validation globally

### DIFF
--- a/src/Fluxzy.Core/Core/ExchangeContext.cs
+++ b/src/Fluxzy.Core/Core/ExchangeContext.cs
@@ -41,6 +41,7 @@ namespace Fluxzy.Core
             VariableContext = variableContext;
             FluxzySetting = fluxzySetting;
             SetUserAgentActionMapping = setUserAgentActionMapping;
+            SkipRemoteCertificateValidation = fluxzySetting?.SkipRemoteCertificateValidation ?? false;
         }
 
         /// <summary>

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -60,6 +60,17 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///    Avoid certificate validation
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public FluxzySetting SetSkipRemoteCertificateValidation(bool value)
+        {
+            SkipRemoteCertificateValidation = value;
+            return this;
+        }
+
+        /// <summary>
         ///     Add hosts that fluxzy should not decrypt
         /// </summary>
         /// <param name="hosts"></param>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -212,7 +212,12 @@ namespace Fluxzy
         /// </summary>
         [JsonInclude]
         public string? UserAgentActionConfigurationFile { get; internal set; }
-        
+
+        /// <summary>
+        ///     Skip remote certificate validation, default false
+        /// </summary>
+        [JsonInclude]
+        public bool SkipRemoteCertificateValidation { get; internal set; }
 
         internal IEnumerable<Rule> FixedRules()
         {

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -74,6 +74,7 @@ namespace Fluxzy.Cli.Commands
             command.AddOption(StartCommandOptions.CreateEnableTracingOption());
 
             command.AddOption(StartCommandOptions.CreateSkipCertInstallOption());
+            command.AddOption(StartCommandOptions.CreateSkipRemoteCertificateValidation());
             command.AddOption(StartCommandOptions.CreateNoCertCacheOption());
             command.AddOption(StartCommandOptions.CreateCertificateFileOption());
             command.AddOption(StartCommandOptions.CreateCertificatePasswordOption());
@@ -104,6 +105,7 @@ namespace Fluxzy.Cli.Commands
             var registerAsSystemProxy = invocationContext.Value<bool>("system-proxy");
             var includeTcpDump = invocationContext.Value<bool>("include-dump");
             var skipDecryption = invocationContext.Value<bool>("skip-ssl-decryption");
+            var skipRemoteCertificateValidation = invocationContext.Value<bool>("insecure");
             var installCert = invocationContext.Value<bool>("install-cert");
             var noCertCache = invocationContext.Value<bool>("no-cert-cache");
             var certFile = invocationContext.Value<FileInfo?>("cert-file");
@@ -120,7 +122,7 @@ namespace Fluxzy.Cli.Commands
             var proxyMode = invocationContext.Value<ProxyMode>("mode");
             var modeReversePort = invocationContext.Value<int?>("mode-reverse-port");
             var proxyBasicAuthCredential = invocationContext.Value<NetworkCredential?>("proxy-auth-basic");
-
+            
             if (trace) {
                 D.EnableTracing = true;
             }
@@ -176,6 +178,10 @@ namespace Fluxzy.Cli.Commands
             if (proxyBasicAuthCredential != null) {
                 proxyStartUpSetting.SetProxyAuthentication(
                     ProxyAuthentication.Basic(proxyBasicAuthCredential.UserName, proxyBasicAuthCredential.Password));
+            }
+
+            if (skipRemoteCertificateValidation) {
+                proxyStartUpSetting.SetSkipRemoteCertificateValidation(true);
             }
 
             var finalListenInterfaces = listenInterfaces.ToList();

--- a/src/Fluxzy/Commands/StartCommandOptions.cs
+++ b/src/Fluxzy/Commands/StartCommandOptions.cs
@@ -160,6 +160,22 @@ namespace Fluxzy.Cli.Commands
 
             return option;
         }
+
+        public static Option CreateSkipRemoteCertificateValidation()
+        {
+            var option = new Option<bool>(
+                "--insecure",
+                "Skip remote certificate validation globally. Use `SkipRemoteCertificateValidationAction` for specific host only");
+
+            option.AddAlias("-k");
+            option.SetDefaultValue(false);
+            option.Arity = ArgumentArity.Zero;
+
+            return option;
+        }
+
+
+
         public static Option<ProxyMode> CreateReverseProxyMode()
         {
             var possibleValues = string.Join(", ",

--- a/src/Fluxzy/Properties/launchSettings.json
+++ b/src/Fluxzy/Properties/launchSettings.json
@@ -16,7 +16,7 @@
             "commandName": "Project",
             "environmentVariables": {
             },
-            "commandLineArgs": "start --no-cert-cache --trace"
+            "commandLineArgs": "start"
         },
         "launch (debug rule)": {
             "commandName": "Project",

--- a/test/Fluxzy.Tests/Cli/WithProvidedRules.cs
+++ b/test/Fluxzy.Tests/Cli/WithProvidedRules.cs
@@ -117,6 +117,26 @@ namespace Fluxzy.Tests.Cli
             Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
         }
 
+        [Fact]
+        public async Task Run_Cli_Skip_Certificate_Validation() 
+        {
+            // Arrange 
+            var commandLine = "start -l 127.0.0.1/0 -k";
+
+            var commandLineHost = new FluxzyCommandLineHost(commandLine);
+
+            await using var fluxzyInstance = await commandLineHost.Run();
+            using var proxiedHttpClient = new ProxiedHttpClient(fluxzyInstance.ListenPort);
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post,
+                $"https://{TestConstants.HttpBinHost}/status/304");
+
+            var response = await proxiedHttpClient.Client.SendAsync(requestMessage);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        }
+
         [Theory]
         [InlineData(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36",


### PR DESCRIPTION
Provides better usability than `skipRemoteCertificateValidationAction`