### PR TITLE
Settle `appdata` env var for nix and macos to avoid unwanted folders

### DIFF
--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -19,6 +19,13 @@ namespace Fluxzy
                 OverallMaxConcurrentConnections = value;
 
             SkipCollectingEnvironmentInformation = Environment.GetEnvironmentVariable("SkipCollectingEnvironmentInformation") == "1";
+            
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("appdata"))) {
+                // for macOS and linux, this environment variable used in several temp file (certcache) is not 
+                // set leading unwanted folder creation
+
+                Environment.SetEnvironmentVariable("appdata", Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            }
         }
 
         /// <summary>

--- a/test/Fluxzy.Tests/Startup.cs
+++ b/test/Fluxzy.Tests/Startup.cs
@@ -31,6 +31,8 @@ namespace Fluxzy.Tests
         public Startup(IMessageSink messageSink)
             : base(messageSink)
         {
+            Environment.SetEnvironmentVariable("appdata", "test-appdata");
+
             foreach (var fileSystemInfo in new DirectoryInfo(".").EnumerateFileSystemInfos().ToList())
             {
                 if (fileSystemInfo is DirectoryInfo directory && Guid.TryParse(directory.Name, out _))


### PR DESCRIPTION
Previously, when using `Fluxzy.Core` only in a standalone app, the folder %appdata% was created for non-Windows OS