### PR TITLE
Set the default named groups match OpenSsl 3.2.2 when using BC

### DIFF
--- a/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/FluxzyTlsClient.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/FluxzyTlsClient.cs
@@ -22,6 +22,19 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
         private static readonly int[] DefaultKeyShares = new int[] {
             NamedGroup.x25519
         };
+        
+        private static readonly int[] DefaultSupportGroups = new int[] {
+            NamedGroup.x25519,
+            NamedGroup.secp256r1,
+            NamedGroup.x448,
+            NamedGroup.secp521r1,
+            NamedGroup.secp384r1,
+            NamedGroup.ffdhe2048,
+            NamedGroup.ffdhe3072,
+            NamedGroup.ffdhe4096,
+            NamedGroup.ffdhe6144,
+            NamedGroup.ffdhe8192,
+        };
 
         private readonly IReadOnlyCollection<SslApplicationProtocol>_applicationProtocols;
         private readonly FluxzyCrypto _crypto;
@@ -91,7 +104,7 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
                 return _fingerPrint.EffectiveSupportGroups;
             }
 
-            return base.GetSupportedGroups(namedGroupRoles);
+            return DefaultSupportGroups;
         }
 
         protected override IList<ServerName> GetSniServerNames()

--- a/test/Fluxzy.Tests/Utility.cs
+++ b/test/Fluxzy.Tests/Utility.cs
@@ -24,7 +24,11 @@ namespace Fluxzy.Tests
                 return true; // Already root  - no need to set capabilities
             
             if (!ProcessUtils.IsCommandAvailable("setcap"))
-                return false; 
+                return false;
+
+            if (await ProcessUtilX.HasCaptureCapabilities()) {
+                return true;
+            }
             
             var process = await ProcessUtilX.RunElevatedSudoALinux("setcap", 
                 new []{ "cap_net_raw,cap_net_admin=eip", executablePath},


### PR DESCRIPTION
Previous default configuration suggests (4588) which is often accepted by significant servers (google, cloudflare) and leads to an extra round time trip