### PR TITLE
Fix certificate creation with password ignored with Fluxzy CLI

### DIFF
--- a/src/Fluxzy.Core/Certificates/CertificateBuilder.cs
+++ b/src/Fluxzy.Core/Certificates/CertificateBuilder.cs
@@ -69,7 +69,7 @@ namespace Fluxzy.Certificates
                     _options.DaysBeforeExpiration));
 
             if (_options.P12Password != null)
-                cert.Export(X509ContentType.Pkcs12, _options.P12Password);
+                return cert.Export(X509ContentType.Pkcs12, _options.P12Password);
 
             return cert.Export(X509ContentType.Pkcs12);
         }

--- a/test/Fluxzy.Tests/Cli/Certificates/CreateCertificate.cs
+++ b/test/Fluxzy.Tests/Cli/Certificates/CreateCertificate.cs
@@ -29,6 +29,22 @@ namespace Fluxzy.Tests.Cli.Certificates
         }
 
         [Fact]
+        public async Task Check_With_Password()
+        {
+            var password = "youshallnotpass";
+
+            var getTempPath = GetTempFile();
+            await InternalRun("create", getTempPath.FullName, "TestCN", "-p", password);
+
+            var certificate = new X509Certificate2(getTempPath.FullName, password);
+
+            Assert.True(getTempPath.Exists);
+            Assert.Equal(2048, certificate.PublicKey.GetRSAPublicKey()!.KeySize);
+            Assert.Equal(10 * 365D, (certificate.NotAfter - DateTime.Now).TotalDays, 1);
+            Assert.Equal("CN=TestCN", certificate.Subject);
+        }
+
+        [Fact]
         public async Task Check_With_Option()
         {
             var getTempPath = GetTempFile();


### PR DESCRIPTION
Addressing #398 

Previously, the `-p option is completely ignored`. Add unit test to cover this issue. 