### PR TITLE
Update package references for multiple target frameworks

### DIFF
--- a/src/Fluxzy.Core/Fluxzy.Core.csproj
+++ b/src/Fluxzy.Core/Fluxzy.Core.csproj
@@ -74,10 +74,31 @@
     <PackageReference Include="MessagePack" Version="2.5.198" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
-    <PackageReference Include="System.Text.Json" Version="9.0.8" />
-    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.11" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -102,6 +123,5 @@
   <ItemGroup>
     <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
Removed `System.IO.Pipelines` and `YamlDotNet` from the main item group.  Added `YamlDotNet` to the `net9.0` conditional group and reintroduced `System.IO.Pipelines` (version 9.0.8).  New item groups created for `net8.0`, `net6.0`, and `netstandard2.1`, each with specific versions of `System.Text.Json`, `System.IO.Pipelines`, and `System.Threading.Channels`.