### PR TITLE
Fix certificate generation for IP addresses

### DIFF
--- a/src/Fluxzy.Core/Certificates/CertificateProvider.cs
+++ b/src/Fluxzy.Core/Certificates/CertificateProvider.cs
@@ -147,9 +147,10 @@ namespace Fluxzy.Certificates
             RSA privateKey, string cnName)
         {
             var randomGenerator = new Random();
+            var isIpAddress = IPAddress.TryParse(cnName, out var ipAddress);
 
             var certificateRequest = new CertificateRequest(
-                $"CN=*.{cnName}",
+                isIpAddress ? $"CN={cnName}" : $"CN=*.{cnName}",
                 privateKey,
                 HashAlgorithmName.SHA256,
                 RSASignaturePadding.Pkcs1);
@@ -159,8 +160,14 @@ namespace Fluxzy.Certificates
             }
 
             var alternativeName = new SubjectAlternativeNameBuilder();
-            alternativeName.AddDnsName(cnName);
-            alternativeName.AddDnsName($"*.{cnName}");
+
+            if (isIpAddress) {
+                alternativeName.AddIpAddress(ipAddress!);
+            }
+            else {
+                alternativeName.AddDnsName(cnName);
+                alternativeName.AddDnsName($"*.{cnName}");
+            }
 
             certificateRequest.CertificateExtensions.Add(alternativeName.Build());
 
@@ -208,9 +215,10 @@ namespace Fluxzy.Certificates
             ECDsa privateKey, string cnName)
         {
             var randomGenerator = new Random();
+            var isIpAddress = IPAddress.TryParse(cnName, out var ipAddress);
 
             var certificateRequest = new CertificateRequest(
-                $"CN=*.{cnName}",
+                isIpAddress ? $"CN={cnName}" : $"CN=*.{cnName}",
                 privateKey,
                 HashAlgorithmName.SHA256);
 
@@ -220,8 +228,13 @@ namespace Fluxzy.Certificates
 
             var alternativeName = new SubjectAlternativeNameBuilder();
 
-            alternativeName.AddDnsName(cnName);
-            alternativeName.AddDnsName($"*.{cnName}");
+            if (isIpAddress) {
+                alternativeName.AddIpAddress(ipAddress!);
+            }
+            else {
+                alternativeName.AddDnsName(cnName);
+                alternativeName.AddDnsName($"*.{cnName}");
+            }
 
             certificateRequest.CertificateExtensions.Add(alternativeName.Build());
 

--- a/test/Fluxzy.Tests/UnitTests/Certificates/CertificateProviderTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Certificates/CertificateProviderTests.cs
@@ -1,0 +1,147 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using Fluxzy.Certificates;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Certificates
+{
+    public class CertificateProviderTests
+    {
+        [Theory]
+        [InlineData("192.168.1.1")]
+        [InlineData("10.0.0.1")]
+        [InlineData("127.0.0.1")]
+        [InlineData("::1")]
+        [InlineData("2001:db8::1")]
+        public void GetCertificate_ForIpAddress_HasCorrectCN(string ipAddress)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(ipAddress);
+
+            // Assert
+            Assert.NotNull(cert);
+            Assert.Equal($"CN={ipAddress}", cert.Subject);
+        }
+
+        [Theory]
+        [InlineData("192.168.1.1")]
+        [InlineData("10.0.0.1")]
+        [InlineData("127.0.0.1")]
+        public void GetCertificate_ForIpAddress_HasIpAddressInSAN(string ipAddress)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(ipAddress);
+
+            // Assert
+            var sanExtension = cert.Extensions
+                .OfType<X509SubjectAlternativeNameExtension>()
+                .FirstOrDefault();
+
+            Assert.NotNull(sanExtension);
+
+            var ipAddresses = sanExtension.EnumerateIPAddresses().ToList();
+            Assert.Single(ipAddresses);
+            Assert.Equal(IPAddress.Parse(ipAddress), ipAddresses[0]);
+        }
+
+        [Theory]
+        [InlineData("192.168.1.1")]
+        [InlineData("10.0.0.1")]
+        public void GetCertificate_ForIpAddress_HasNoDnsNamesInSAN(string ipAddress)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(ipAddress);
+
+            // Assert
+            var sanExtension = cert.Extensions
+                .OfType<X509SubjectAlternativeNameExtension>()
+                .FirstOrDefault();
+
+            Assert.NotNull(sanExtension);
+
+            var dnsNames = sanExtension.EnumerateDnsNames().ToList();
+            Assert.Empty(dnsNames);
+        }
+
+        [Theory]
+        [InlineData("example.com")]
+        [InlineData("www.example.com")]
+        [InlineData("fluxzy.io")]
+        public void GetCertificate_ForDomain_HasWildcardCN(string domain)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(domain);
+
+            // Assert
+            Assert.NotNull(cert);
+            Assert.StartsWith("CN=*.", cert.Subject);
+        }
+
+        [Theory]
+        [InlineData("example.com")]
+        [InlineData("fluxzy.io")]
+        public void GetCertificate_ForDomain_HasDnsNamesInSAN(string domain)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(domain);
+
+            // Assert
+            var sanExtension = cert.Extensions
+                .OfType<X509SubjectAlternativeNameExtension>()
+                .FirstOrDefault();
+
+            Assert.NotNull(sanExtension);
+
+            var dnsNames = sanExtension.EnumerateDnsNames().ToList();
+            Assert.Contains(domain, dnsNames);
+            Assert.Contains($"*.{domain}", dnsNames);
+        }
+
+        [Theory]
+        [InlineData("example.com")]
+        [InlineData("fluxzy.io")]
+        public void GetCertificate_ForDomain_HasNoIpAddressesInSAN(string domain)
+        {
+            // Arrange
+            var rootCertificate = Certificate.UseDefault();
+            using var provider = new CertificateProvider(rootCertificate, new InMemoryCertificateCache());
+
+            // Act
+            var cert = provider.GetCertificate(domain);
+
+            // Assert
+            var sanExtension = cert.Extensions
+                .OfType<X509SubjectAlternativeNameExtension>()
+                .FirstOrDefault();
+
+            Assert.NotNull(sanExtension);
+
+            var ipAddresses = sanExtension.EnumerateIPAddresses().ToList();
+            Assert.Empty(ipAddresses);
+        }
+    }
+}


### PR DESCRIPTION
Content:

  - Fix invalid certificate generation when the target host is an IP address
  - Add unit tests for certificate generation with IP addresses and domains


  When generating certificates for IP addresses, `CertificateProvider.InternalBuildCertificateForRootDomain`
   produced invalid certificates:

  1. **Invalid CN**: The CN was set to `CN=*.{ip}` (e.g., `CN=*.192.168.1.1`) - wildcards are not valid for
  IP addresses
  2. **Wrong SAN type**: IP addresses were added as DNS names via `AddDnsName()` instead of using
  `AddIpAddress()`
