### PR TITLE
Fix session action not propagating on subdomain

### DIFF
--- a/src/Fluxzy.Core/Rules/Session/SessionData.cs
+++ b/src/Fluxzy.Core/Rules/Session/SessionData.cs
@@ -44,12 +44,13 @@ namespace Fluxzy.Rules.Session
         /// <summary>
         /// Add or update a cookie
         /// </summary>
-        public void SetCookie(string name, string value, string? path = null, DateTime? expires = null)
+        public void SetCookie(string name, string value, string? path = null, DateTime? expires = null, string? domain = null)
         {
             var cookie = new SessionCookie(name, value)
             {
                 Path = path,
-                Expires = expires
+                Expires = expires,
+                Domain = domain
             };
 
             Cookies.AddOrUpdate(name, cookie, (_, _) => cookie);


### PR DESCRIPTION
 When a cookie was set with Domain=github.com, it wasn't being applied to requests for api.github.com because:
  - CaptureSessionAction stored cookies under the request's hostname, ignoring the cookie's Domain attribute
  - ApplySessionAction only did exact domain matching

Add unit tests
