### PR TITLE
Add Android emulator host (`10.0.2.2`) support for IsSelfFilter

### DIFF
--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -528,5 +528,19 @@ namespace Fluxzy
             EnableProcessTracking = value;
             return this;
         }
+
+        /// <summary>
+        ///     Enable or disable inclusion of Android emulator host (10.0.2.2) in IsSelfFilter.
+        ///     When enabled, the IsSelfFilter will also consider 10.0.2.2 as a local address.
+        ///     This is useful when Fluxzy is used with Android emulators where 10.0.2.2
+        ///     represents the host machine from within the emulator. Default is true.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public FluxzySetting SetIncludeAndroidEmulatorHost(bool value)
+        {
+            IncludeAndroidEmulatorHost = value;
+            return this;
+        }
     }
 }

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -229,6 +229,14 @@ namespace Fluxzy
         [JsonInclude]
         public bool EnableProcessTracking { get; internal set; }
 
+        /// <summary>
+        ///     When enabled, the IsSelfFilter will also consider 10.0.2.2 as a local address.
+        ///     This is useful when Fluxzy is used with Android emulators where 10.0.2.2
+        ///     represents the host machine from within the emulator. Default is true.
+        /// </summary>
+        [JsonInclude]
+        public bool IncludeAndroidEmulatorHost { get; internal set; } = true;
+
         internal IEnumerable<Rule> FixedRules()
         {
             if (GlobalSkipSslDecryption) {

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -88,6 +88,7 @@ namespace Fluxzy.Cli.Commands
             command.AddOption(StartCommandOptions.CreateMaxConnectionPerHost());
             command.AddOption(StartCommandOptions.CreateCounterOption());
             command.AddOption(StartCommandOptions.CreateEnableProcessTrackingOption());
+            command.AddOption(StartCommandOptions.CreateNoAndroidEmulatorOption());
 
             command.SetHandler(context => Run(context, cancellationToken));
 
@@ -125,6 +126,7 @@ namespace Fluxzy.Cli.Commands
             var modeReversePort = invocationContext.Value<int?>("mode-reverse-port");
             var proxyBasicAuthCredential = invocationContext.Value<NetworkCredential?>("proxy-auth-basic");
             var enableProcessTracking = invocationContext.Value<bool>("enable-process-tracking");
+            var noAndroidEmulator = invocationContext.Value<bool>("no-android-emulator");
 
             if (trace) {
                 D.EnableTracing = true;
@@ -277,6 +279,7 @@ namespace Fluxzy.Cli.Commands
             proxyStartUpSetting.OutOfProcCapture = outOfProcCapture;
             proxyStartUpSetting.UseBouncyCastle = bouncyCastle;
             proxyStartUpSetting.SetEnableProcessTracking(enableProcessTracking);
+            proxyStartUpSetting.SetIncludeAndroidEmulatorHost(!noAndroidEmulator);
 
             var certificateProvider = new CertificateProvider(proxyStartUpSetting.CaCertificate,
                 noCertCache ? new InMemoryCertificateCache() : new FileSystemCertificateCache(proxyStartUpSetting));

--- a/src/Fluxzy/Commands/StartCommandOptions.cs
+++ b/src/Fluxzy/Commands/StartCommandOptions.cs
@@ -425,5 +425,18 @@ namespace Fluxzy.Cli.Commands
 
             return option;
         }
+
+        public static Option CreateNoAndroidEmulatorOption()
+        {
+            var option = new Option<bool>(
+                "--no-android-emulator",
+                "Disable inclusion of Android emulator host (10.0.2.2) in self detection. " +
+                "By default, Fluxzy considers 10.0.2.2 as a local address for Android emulator compatibility.");
+
+            option.SetDefaultValue(false);
+            option.Arity = ArgumentArity.Zero;
+
+            return option;
+        }
     }
 }

--- a/src/Fluxzy/Properties/launchSettings.json
+++ b/src/Fluxzy/Properties/launchSettings.json
@@ -16,7 +16,7 @@
             "commandName": "Project",
             "environmentVariables": {
             },
-            "commandLineArgs": "start -k"
+            "commandLineArgs": "start -k --lany -t"
         },
         "launch (debug rule)": {
             "commandName": "Project",

--- a/test/Fluxzy.Tests/Cases/SelfCallTests.cs
+++ b/test/Fluxzy.Tests/Cases/SelfCallTests.cs
@@ -1,5 +1,6 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -8,6 +9,9 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Fluxzy.Certificates;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Rules;
 using Fluxzy.Rules.Actions.HighLevelActions;
 using Fluxzy.Rules.Filters;
 using Fluxzy.Rules.Filters.RequestFilters;
@@ -17,6 +21,90 @@ namespace Fluxzy.Tests.Cases
 {
     public class SelfCallTests
     {
+        [Fact]
+        public void IncludeAndroidEmulatorHost_DefaultValue_IsTrue()
+        {
+            // The default value for IncludeAndroidEmulatorHost should be true
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            Assert.True(setting.IncludeAndroidEmulatorHost);
+        }
+
+        [Fact]
+        public void IncludeAndroidEmulatorHost_CanBeDisabled()
+        {
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            setting.SetIncludeAndroidEmulatorHost(false);
+            Assert.False(setting.IncludeAndroidEmulatorHost);
+        }
+
+        [Fact]
+        public void AndroidEmulatorHostAddress_IsCorrect()
+        {
+            // Verify the Android emulator host address is 10.0.2.2
+            Assert.Equal(IPAddress.Parse("10.0.2.2"), IsSelfFilter.AndroidEmulatorHostAddress);
+        }
+
+        [Fact]
+        public void IsSelfFilter_WithAndroidEmulatorEnabled_MatchesEmulatorAddress()
+        {
+            // Arrange
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            setting.SetIncludeAndroidEmulatorHost(true);
+
+            var authority = new Authority("10.0.2.2", 8080, false);
+            var variableContext = new VariableContext();
+            var exchangeContext = new ExchangeContext(authority, variableContext, setting, null!) {
+                RemoteHostIp = IPAddress.Parse("10.0.2.2"),
+                RemoteHostPort = 8080
+            };
+
+            // Create a minimal exchange for testing
+            var exchange = CreateTestExchange(8080);
+
+            var filter = new IsSelfFilter();
+
+            // Act
+            var result = filter.Apply(exchangeContext, authority, exchange, null);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsSelfFilter_WithAndroidEmulatorDisabled_DoesNotMatchEmulatorAddress()
+        {
+            // Arrange
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            setting.SetIncludeAndroidEmulatorHost(false);
+
+            var authority = new Authority("10.0.2.2", 8080, false);
+            var variableContext = new VariableContext();
+            var exchangeContext = new ExchangeContext(authority, variableContext, setting, null!) {
+                RemoteHostIp = IPAddress.Parse("10.0.2.2"),
+                RemoteHostPort = 8080
+            };
+
+            // Create a minimal exchange for testing
+            var exchange = CreateTestExchange(8080);
+
+            var filter = new IsSelfFilter();
+
+            // Act
+            var result = filter.Apply(exchangeContext, authority, exchange, null);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        private static Exchange CreateTestExchange(int port)
+        {
+            var authority = new Authority("10.0.2.2", port, false);
+            var requestHeader = "GET / HTTP/1.1\r\nHost: 10.0.2.2\r\n\r\n".AsMemory();
+            var exchange = new Exchange(IIdProvider.FromZero, authority, requestHeader, "HTTP/1.1", System.DateTime.UtcNow);
+            exchange.Metrics.DownStreamLocalPort = port;
+            return exchange;
+        }
+
         [Theory]
         [MemberData(nameof(AllValidHosts))]
         public async Task MakeMultipleSelfCall(string host)


### PR DESCRIPTION
 When Fluxzy is used with Android emulators, the emulator accesses the   host machine via 10.0.2.2. This change adds a new etting
  `IncludeAndroidEmulatorHost` (default: true) that makes IsSelfFilter   recognize 10.0.2.2 as a local address.

- Add --no-android-emulator CLI option to disable the feature
- Add unit tests for the new functionality
