### PR TITLE
Fix Windows proxy restore for legacy per-protocol ProxyServer formats

### DIFF
--- a/src/Fluxzy.Core/Core/Impl/SystemProxyRegistrationManager.cs
+++ b/src/Fluxzy.Core/Core/Impl/SystemProxyRegistrationManager.cs
@@ -79,7 +79,7 @@ namespace Fluxzy.Core
         }
 
         /// <summary>
-        /// Unregister any previous setting 
+        /// Unregister any previous setting
         /// </summary>
         /// <returns></returns>
         public async Task UnRegister()
@@ -100,12 +100,9 @@ namespace Fluxzy.Core
                 return;
             }
 
-            var existingSetting = await GetSystemProxySetting().ConfigureAwait(false);
-
-            if (existingSetting.Enabled) {
-                existingSetting.Enabled = false;
-                await _systemProxySetter.ApplySetting(existingSetting).ConfigureAwait(false);
-            }
+            // No pending state: UnRegister is a no-op. This matters for the ProcessExit
+            // handler that fires after an explicit UnRegister — touching the registry
+            // here would corrupt the already-restored user setting.
         }
         
         private IPAddress GetConnectableIpAddr(IPAddress address)

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Win/ProxyConstants.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Win/ProxyConstants.cs
@@ -5,5 +5,14 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Win
     internal static class ProxyConstants
     {
         public static readonly string NoProxyWord = "no_proxy_server";
+
+        /// <summary>
+        /// Key used in <see cref="Fluxzy.Core.Proxy.SystemProxySetting.PrivateValues"/>
+        /// to preserve the raw ProxyServer registry string when it cannot be parsed
+        /// as the standard "host:port" format (e.g. legacy per-protocol entries
+        /// like "http=proxy:80;https=proxy:443"). This allows UnRegister to
+        /// restore the original string verbatim instead of corrupting it.
+        /// </summary>
+        public const string WinProxyServerRawKey = "WinProxyServerRaw";
     }
 }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Win/WindowsProxyHelper.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Win/WindowsProxyHelper.cs
@@ -39,9 +39,18 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Win
             var proxyServerName = proxyServerTab.Length != 2 ? ProxyConstants.NoProxyWord : proxyServerTab[0];
             var proxyPort = proxyServerTab.Length != 2 ? -1 : int.Parse(proxyServerTab[1]);
 
-            return new SystemProxySetting(proxyServerName, proxyPort, proxyOverrideList) {
+            var setting = new SystemProxySetting(proxyServerName, proxyPort, proxyOverrideList) {
                 Enabled = proxyEnabled
             };
+
+            // Preserve the raw ProxyServer string when it does not match the standard
+            // "host:port" format (e.g. legacy per-protocol entries like
+            // "http=proxy:80;https=proxy:443"). Without this, the value would be lost
+            // on restore because BoundHost collapses to NoProxyWord.
+            if (proxyServerTab.Length != 2 && !string.IsNullOrEmpty(proxyServer))
+                setting.PrivateValues[ProxyConstants.WinProxyServerRawKey] = proxyServer;
+
+            return setting;
 
 #else
             throw new NotSupportedException("This method is only supported on .NET 6.0 or greater");
@@ -62,7 +71,15 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Win
 
             registry.SetValue("ProxyEnable", systemProxySetting.Enabled ? 1 : 0);
 
-            if (systemProxySetting.BoundHost == null
+            // If the setting carries a preserved raw ProxyServer string (round-trip from
+            // a previous GetSetting() call that could not parse it as "host:port"), write
+            // it back verbatim so corporate/legacy configurations are not corrupted.
+            if (systemProxySetting.PrivateValues.TryGetValue(ProxyConstants.WinProxyServerRawKey, out var rawObj)
+                && rawObj is string rawProxyServer
+                && !string.IsNullOrEmpty(rawProxyServer)) {
+                registry.SetValue("ProxyServer", rawProxyServer);
+            }
+            else if (systemProxySetting.BoundHost == null
                 || systemProxySetting.BoundHost == ProxyConstants.NoProxyWord) {
                 // Remove proxy setting
                 registry.DeleteValue("ProxyServer", false);

--- a/test/Fluxzy.Tests/UnitTests/Core/SystemProxyRegistrationManagerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SystemProxyRegistrationManagerTests.cs
@@ -121,7 +121,7 @@ namespace Fluxzy.Tests.UnitTests.Core
         }
 
         [Fact]
-        public async Task Unregister_Without_Register_Disables_Current_Proxy()
+        public async Task Unregister_Without_Register_Is_A_NoOp()
         {
             // Arrange: system has a proxy but Register was never called
             var currentSetting = CreateSetting("some-proxy.local", 3128, true);
@@ -135,9 +135,10 @@ namespace Fluxzy.Tests.UnitTests.Core
             // Act
             await manager.UnRegister();
 
-            // Assert: proxy is disabled
-            await setter.Received(1).ApplySetting(
-                Arg.Is<SystemProxySetting>(s => !s.Enabled));
+            // Assert: we must NOT touch the user's proxy when we never registered.
+            // The previous fallback path disabled the current proxy, which corrupted
+            // state when the ProcessExit handler ran after an explicit UnRegister.
+            await setter.DidNotReceive().ApplySetting(Arg.Any<SystemProxySetting>());
         }
 
         [Fact]
@@ -163,14 +164,43 @@ namespace Fluxzy.Tests.UnitTests.Core
 
             await manager.UnRegister();
 
-            // Assert: second unregister should NOT apply any setting (nothing to do)
-            // because both _oldSetting and _currentSetting are null.
-            // It falls to the third branch which reads current setting — the original
-            // is already enabled, so it would disable it. But the key point is it must
-            // NOT apply fluxzy's address with Enabled=false.
-            await setter.DidNotReceive().ApplySetting(
+            // Assert: second unregister must be a complete no-op. Both _oldSetting
+            // and _currentSetting are null after the first restore, so we must not
+            // touch the user's proxy again. The previous fallback branch would
+            // disable the just-restored original, which is wrong.
+            await setter.DidNotReceive().ApplySetting(Arg.Any<SystemProxySetting>());
+        }
+
+        [Fact]
+        public async Task Unregister_Should_Preserve_Raw_ProxyServer_For_Legacy_Formats()
+        {
+            // Arrange: Windows registry contains a legacy per-protocol ProxyServer
+            // (e.g. "http=proxy:80;https=proxy:443"). The Windows parser collapses
+            // the BoundHost to "no_proxy_server" because it is not a plain host:port.
+            // Without preserving the raw string, UnRegister would delete ProxyServer
+            // entirely, destroying the user's corporate configuration.
+            const string rawLegacyProxyServer = "http=corp-proxy.local:3128;https=corp-proxy.local:3128";
+
+            var originalSetting = new SystemProxySetting("no_proxy_server", -1) { Enabled = true };
+            originalSetting.PrivateValues["WinProxyServerRaw"] = rawLegacyProxyServer;
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(originalSetting));
+            setter.ApplySetting(Arg.Any<SystemProxySetting>()).Returns(Task.CompletedTask);
+
+            var manager = new SystemProxyRegistrationManager(setter);
+            await manager.Register(new IPEndPoint(IPAddress.Loopback, 8080), "localhost");
+
+            // Act
+            await manager.UnRegister();
+
+            // Assert: on restore the setting carries the raw legacy string so the
+            // Windows writer can round-trip it verbatim.
+            await setter.Received(1).ApplySetting(
                 Arg.Is<SystemProxySetting>(s =>
-                    s.BoundHost == "127.0.0.1"));
+                    s.Enabled
+                    && s.PrivateValues.ContainsKey("WinProxyServerRaw")
+                    && (string) s.PrivateValues["WinProxyServerRaw"] == rawLegacyProxyServer));
         }
     }
 }


### PR DESCRIPTION
## Summary

Two bugs were causing  Windows proxy configuration to be lost after Fluxzy's redirect was disabled, leaving `ProxyEnable=1` with an empty `ProxyServer` key in the registry.

### Bug 1: legacy ProxyServer formats are destroyed on restore

`WindowsProxyHelper.GetSetting()` only parses `ProxyServer` as strict `host:port`. Any other shape, such as the legacy per-protocol entry `http=proxy:80;https=proxy:443` emitted by corporate deployment tools, or a bare hostname, collapses to `BoundHost = NoProxyWord`. Combined with the `NoProxyWord` handling added in #599, `UnRegister` then deletes the `ProxyServer` registry key entirely.

Fix: preserve the raw `ProxyServer` string in `SystemProxySetting.PrivateValues["WinProxyServerRaw"]` when the standard parse fails, and write it back verbatim on restore. Normal `host:port` values are unaffected.

### Bug 2: UnRegister fallback corrupts state

`SystemProxyRegistrationManager.UnRegister()` had a fallback path that read the current registry and disabled it when both `_oldSetting` and `_currentSetting` were null. This fired in two situations:

- The `ProcessExit` handler running `UnRegister` after an explicit `UnRegister` had already restored the original, which then disabled the just-restored proxy.
- `UnRegister` being called without a prior `Register`, which disabled the user's untouched proxy.

Fix: remove the fallback. `UnRegister` is now a no-op when there is nothing to restore.

## Test changes

- `Unregister_Without_Register_Disables_Current_Proxy` renamed to `Unregister_Without_Register_Is_A_NoOp` and now asserts `DidNotReceive().ApplySetting(...)`.
- `Double_Unregister_Should_Not_Overwrite_Restored_Setting` strengthened to `DidNotReceive().ApplySetting(Any)`.
- New `Unregister_Should_Preserve_Raw_ProxyServer_For_Legacy_Formats` locks in the round-trip contract via `PrivateValues["WinProxyServerRaw"]`.