### PR TITLE
Fix stray DATA frame after HEADERS[END_STREAM] on zero-length POST

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -28,6 +28,7 @@ namespace Fluxzy.Clients.H2
 
         private Memory<byte> _headerBuffer;
 
+        private bool _headerEndedStream;
         private bool _noBodyStream;
         private bool _responseHeadersComplete;
 
@@ -177,6 +178,8 @@ namespace Fluxzy.Clients.H2
                             exchange.Request.Body == null ||
                             (exchange.Request.Body.CanSeek && exchange.Request.Body.Length == 0);
 
+            _headerEndedStream = endStream;
+
             var readyToBeSent = Parent.Context.HeaderEncoder.Encode(
                 new HeaderEncodingJob(exchange.Request.Header.GetHttp11Header(), StreamIdentifier, StreamDependency),
                 buffer, endStream);
@@ -198,6 +201,17 @@ namespace Fluxzy.Clients.H2
 
         public async ValueTask ProcessRequestBody(Exchange exchange, RsBuffer buffer, CancellationToken token)
         {
+            // HEADERS already carried END_STREAM (e.g. Content-Length: 0). The stream is
+            // half-closed (local) — sending any DATA frame now would be a PROTOCOL_ERROR
+            // on a closed stream, so we must not enter the body loop. This matters for
+            // clients like Firefox that send HEADERS + DATA[END_STREAM, 0] for zero-length
+            // POSTs: Fluxzy exposes the empty request body as a non-seekable pipe stream,
+            // which would otherwise trip the loop's "!CanSeek" entry condition.
+            if (_headerEndedStream) {
+                exchange.Metrics.RequestBodySent = ITimingProvider.Default.Instant();
+                return;
+            }
+
             var totalSent = 0;
             var requestBodyStream = exchange.Request.Body;
             var bodyLength = exchange.Request.Header.ContentLength;

--- a/test/Fluxzy.Tests/Cases/ReverseProxyH2Tests.cs
+++ b/test/Fluxzy.Tests/Cases/ReverseProxyH2Tests.cs
@@ -1,16 +1,26 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Clients.H2.Frames;
 using Fluxzy.Rules.Actions;
 using Fluxzy.Rules.Filters;
 using Fluxzy.Tests._Fixtures;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Xunit;
 
 namespace Fluxzy.Tests.Cases;
@@ -81,6 +91,165 @@ public class ReverseProxyH2Tests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(HttpVersion.Version11, response.Version);
+    }
+
+    /// <summary>
+    ///     Regression for the Firefox-style zero-length POST that used to corrupt the
+    ///     upstream H2 stream. Firefox sends a POST with Content-Length: 0 as
+    ///     HEADERS (no END_STREAM) followed by DATA[END_STREAM, 0 bytes]. Chrome collapses
+    ///     both into a single HEADERS[END_STREAM], which is why the bug only reproduces
+    ///     with Firefox-shaped clients.
+    ///
+    ///     The bug: StreamWorker.EnqueueRequestHeader saw Content-Length: 0 and set
+    ///     END_STREAM on the upstream HEADERS frame, half-closing the stream. But
+    ///     StreamWorker.ProcessRequestBody still entered its body loop (because the
+    ///     request body is a non-seekable pipe stream) and enqueued an extra
+    ///     DATA[END_STREAM, 0 bytes] on the already half-closed (local) stream. The
+    ///     remote answered with a connection reset (PROTOCOL_ERROR / STREAM_CLOSED).
+    ///
+    ///     This test pipes the Firefox pattern through a raw H2 downstream client into
+    ///     Fluxzy, while a strict raw-H2 server on the upstream side records every
+    ///     frame it receives. The assertion is simple: the upstream must never see a
+    ///     DATA frame after the HEADERS frame already carried END_STREAM.
+    /// </summary>
+    [Fact]
+    public async Task ReverseMode_WithServeH2_FirefoxStyleEmptyPost_UpstreamHasNoStrayDataFrame()
+    {
+        using var serverCert = InProcessHost.CreateSelfSignedCertificateForTesting();
+        await using var strictServer = await StrictH2Recorder.StartAsync(serverCert);
+
+        var setting = FluxzySetting.CreateLocalRandomPort();
+        setting.SetReverseMode(true);
+        setting.SetReverseModeForcedPort(strictServer.Port);
+        setting.SetServeH2(true);
+        setting.AddAlterationRules(
+            new SkipRemoteCertificateValidationAction(), AnyFilter.Default);
+
+        await using var proxy = new Proxy(setting);
+        var proxyPort = proxy.Run().First().Port;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        using var tcp = new TcpClient();
+        await tcp.ConnectAsync(IPAddress.Loopback, proxyPort, cts.Token);
+
+        await using var sslStream = new SslStream(tcp.GetStream(), leaveInnerStreamOpen: false);
+        await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+        {
+            TargetHost = "localhost",
+            RemoteCertificateValidationCallback = (_, _, _, _) => true,
+            ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
+        }, cts.Token);
+
+        Assert.Equal(SslApplicationProtocol.Http2, sslStream.NegotiatedApplicationProtocol);
+
+        // Client H2 preface + empty SETTINGS.
+        await sslStream.WriteAsync(H2Constants.Preface.AsMemory(), cts.Token);
+        await sslStream.WriteAsync(H2FrameHelper.BuildSettingsFrame(), cts.Token);
+        await sslStream.FlushAsync(cts.Token);
+
+        // Drain frames from Fluxzy until we see its server SETTINGS — then send an ACK.
+        await DrainUntilServerSettings(sslStream, cts.Token);
+        await sslStream.WriteAsync(H2FrameHelper.BuildSettingsAck(), cts.Token);
+        await sslStream.FlushAsync(cts.Token);
+
+        // Firefox pattern for POST /Feeds/Pop with Content-Length: 0:
+        //   HEADERS (END_HEADERS, NOT END_STREAM) then DATA[END_STREAM, 0 bytes].
+        var encoder = new HPackEncoder(new EncodingContext(ArrayPoolMemoryProvider<char>.Default));
+        var plainHeaders = (
+            "POST /Feeds/Pop HTTP/2\r\n" +
+            "Host: localhost\r\n" +
+            "Content-Length: 0\r\n" +
+            "TE: trailers\r\n\r\n"
+        ).AsMemory();
+
+        await sslStream.WriteAsync(
+            H2FrameHelper.BuildHeadersFrame(encoder, 1, plainHeaders, endStream: false, endHeaders: true),
+            cts.Token);
+        await sslStream.WriteAsync(
+            H2FrameHelper.BuildDataFrame(1, Array.Empty<byte>(), endStream: true),
+            cts.Token);
+        await sslStream.FlushAsync(cts.Token);
+
+        // Expect a HEADERS frame on stream 1 from the downstream side. This only
+        // confirms the round-trip finished; the real assertion is on the upstream.
+        await WaitForHeadersOnStream(sslStream, targetStreamId: 1, cts.Token);
+
+        // The upstream mock fails the test if it ever saw a DATA frame on a stream
+        // that already had END_STREAM set. Tear down the mock and surface any error.
+        await strictServer.StopAndVerifyAsync();
+    }
+
+    private static async Task DrainUntilServerSettings(Stream stream, CancellationToken token)
+    {
+        var deadline = Environment.TickCount64 + 5000;
+
+        while (Environment.TickCount64 < deadline) {
+            var (bodyType, _, _, _) = await ReadFrameHeaderAsync(stream, token);
+
+            if (bodyType == H2FrameType.Settings)
+                return;
+
+            if (bodyType == H2FrameType.Goaway)
+                throw new InvalidOperationException("Fluxzy sent GOAWAY during handshake");
+        }
+
+        throw new TimeoutException("Did not receive server SETTINGS in time");
+    }
+
+    private static async Task WaitForHeadersOnStream(
+        Stream stream, int targetStreamId, CancellationToken token)
+    {
+        while (true) {
+            var (bodyType, streamId, _, bodyBytes) = await ReadFrameHeaderAsync(stream, token);
+
+            if (bodyType == H2FrameType.RstStream && streamId == targetStreamId) {
+                var errorCode = (H2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(bodyBytes);
+                throw new InvalidOperationException(
+                    $"RST_STREAM on stream {targetStreamId}: {errorCode}");
+            }
+
+            if (bodyType == H2FrameType.Goaway) {
+                var errorCode = (H2ErrorCode)BinaryPrimitives.ReadUInt32BigEndian(bodyBytes.AsSpan(4, 4));
+                throw new InvalidOperationException($"GOAWAY: {errorCode}");
+            }
+
+            if (bodyType == H2FrameType.Headers && streamId == targetStreamId) {
+                // We reached a response HEADERS frame on our stream without any protocol
+                // error — that's enough to prove Fluxzy accepted and forwarded the
+                // Firefox-shaped empty POST round-trip.
+                return;
+            }
+        }
+    }
+
+    private static async Task<(H2FrameType bodyType, int streamId, HeaderFlags flags, byte[] body)>
+        ReadFrameHeaderAsync(Stream stream, CancellationToken token)
+    {
+        var header = new byte[9];
+        await ReadExactAsync(stream, header, token);
+
+        var bodyLength = (header[0] << 16) | (header[1] << 8) | header[2];
+        var bodyType = (H2FrameType)header[3];
+        var flags = (HeaderFlags)header[4];
+        var streamId = BinaryPrimitives.ReadInt32BigEndian(header.AsSpan(5, 4)) & 0x7FFFFFFF;
+
+        var body = bodyLength == 0 ? Array.Empty<byte>() : new byte[bodyLength];
+        if (bodyLength > 0)
+            await ReadExactAsync(stream, body, token);
+
+        return (bodyType, streamId, flags, body);
+    }
+
+    private static async Task ReadExactAsync(Stream stream, byte[] buffer, CancellationToken token)
+    {
+        var offset = 0;
+        while (offset < buffer.Length) {
+            var n = await stream.ReadAsync(buffer.AsMemory(offset), token);
+            if (n == 0)
+                throw new EndOfStreamException("Upstream closed the TLS connection unexpectedly");
+            offset += n;
+        }
     }
 
     /// <summary>

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
@@ -99,6 +99,50 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
         }
 
         /// <summary>
+        /// Firefox-style zero-length POST: HEADERS (no END_STREAM) + empty DATA[END_STREAM].
+        /// Verifies the exchange exposes an empty, non-seekable request body with
+        /// Content-Length: 0. This combination is precisely what tripped the upstream
+        /// StreamWorker into sending a stray DATA[END_STREAM] frame on top of a
+        /// HEADERS[END_STREAM] frame, causing the remote to reset the connection.
+        /// </summary>
+        [Fact]
+        public async Task PostContentLengthZero_WithTrailingEmptyDataFrame_ProducesEmptyBody()
+        {
+            await using var ctx = await H2TestContext.Create();
+
+            await ctx.ReadNextFrame(); // SETTINGS
+            await ctx.SendSettingsAck();
+
+            // Firefox sends HEADERS without END_STREAM...
+            var headers =
+                "POST /Feeds/Pop HTTP/2\r\nHost: localhost\r\nContent-Length: 0\r\nTE: trailers\r\n\r\n"
+                    .AsMemory();
+            await ctx.SendHeadersFrame(1, headers, endStream: false, endHeaders: true);
+
+            // ...then a DATA frame with zero bytes and END_STREAM to close the stream.
+            await ctx.SendDataFrame(1, Array.Empty<byte>(), endStream: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+
+            Assert.NotNull(exchange);
+            Assert.Equal(1, exchange!.StreamIdentifier);
+            Assert.Equal(0, exchange.Request.Header.ContentLength);
+
+            // The body must be a real (non-seekable) pipe stream — NOT Stream.Null — because
+            // HEADERS did not carry END_STREAM. This is the scenario that used to cause
+            // StreamWorker.ProcessRequestBody to enqueue an extra DATA[END_STREAM, 0] frame.
+            Assert.NotNull(exchange.Request.Body);
+            Assert.False(exchange.Request.Body!.CanSeek);
+
+            using var bodyStream = new MemoryStream();
+            await exchange.Request.Body.CopyToAsync(bodyStream, ctx.Token);
+            Assert.Empty(bodyStream.ToArray());
+        }
+
+        /// <summary>
         /// Send HEADERS (no END_STREAM) then DATA with END_STREAM.
         /// Verify the exchange body reads correctly.
         /// </summary>

--- a/test/Fluxzy.Tests/_Fixtures/InProcessHost.cs
+++ b/test/Fluxzy.Tests/_Fixtures/InProcessHost.cs
@@ -90,6 +90,12 @@ public class InProcessHost : IAsyncDisposable
         });
     }
 
+    /// <summary>
+    ///     Exposes the self-signed certificate factory for tests that spin up their
+    ///     own raw TLS listener instead of a full Kestrel host.
+    /// </summary>
+    public static X509Certificate2 CreateSelfSignedCertificateForTesting() => CreateSelfSignedCertificate();
+
     private static X509Certificate2 CreateSelfSignedCertificate()
     {
         using var rsa = RSA.Create(2048);

--- a/test/Fluxzy.Tests/_Fixtures/StrictH2Recorder.cs
+++ b/test/Fluxzy.Tests/_Fixtures/StrictH2Recorder.cs
@@ -1,0 +1,221 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Frames;
+
+namespace Fluxzy.Tests._Fixtures
+{
+    /// <summary>
+    ///     Minimal HTTP/2 server mock that records every incoming frame and fails the
+    ///     calling test if the client (Fluxzy, in these tests) ever violates the RFC
+    ///     9113 stream state machine by sending more frames on a stream that already
+    ///     received END_STREAM from its peer.
+    ///
+    ///     It is NOT a full H2 server: it only handshakes, answers requests on a
+    ///     single stream with an empty 200 response, and quietly drains everything
+    ///     else until the test is torn down.
+    /// </summary>
+    internal sealed class StrictH2Recorder : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly X509Certificate2 _serverCert;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly TaskCompletionSource<object?> _done =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Task? _acceptTask;
+        private Exception? _recordedError;
+
+        private StrictH2Recorder(TcpListener listener, X509Certificate2 serverCert)
+        {
+            _listener = listener;
+            _serverCert = serverCert;
+        }
+
+        public int Port => ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+        public static Task<StrictH2Recorder> StartAsync(X509Certificate2 serverCert)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var recorder = new StrictH2Recorder(listener, serverCert);
+            recorder._acceptTask = recorder.RunAsync();
+            return Task.FromResult(recorder);
+        }
+
+        private async Task RunAsync()
+        {
+            try {
+                using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                await using var sslStream = new SslStream(client.GetStream(), leaveInnerStreamOpen: false);
+
+                await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions {
+                    ServerCertificate = _serverCert,
+                    ClientCertificateRequired = false,
+                    EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12
+                                          | System.Security.Authentication.SslProtocols.Tls13,
+                    ApplicationProtocols = new List<SslApplicationProtocol> {
+                        SslApplicationProtocol.Http2
+                    },
+                }, _cts.Token);
+
+                await HandleConnectionAsync(sslStream, _cts.Token);
+            }
+            catch (OperationCanceledException) {
+                // expected on dispose
+            }
+            catch (Exception ex) {
+                _recordedError ??= ex;
+            }
+            finally {
+                _done.TrySetResult(null);
+            }
+        }
+
+        private async Task HandleConnectionAsync(SslStream stream, CancellationToken token)
+        {
+            // Read the H2 preface.
+            var prefaceBuffer = new byte[H2Constants.Preface.Length];
+            await ReadExactAsync(stream, prefaceBuffer, token);
+
+            // Send empty server SETTINGS.
+            var emptySettings = new byte[9];
+            emptySettings[3] = (byte)H2FrameType.Settings;
+            await stream.WriteAsync(emptySettings.AsMemory(), token);
+            await stream.FlushAsync(token);
+
+            var streamsWithEndStream = new HashSet<int>();
+            var streamsAnswered = new HashSet<int>();
+
+            while (!token.IsCancellationRequested) {
+                var header = new byte[9];
+                var read = await ReadAtMostAsync(stream, header, token);
+                if (read == 0)
+                    return; // peer closed
+
+                if (read < 9)
+                    throw new InvalidDataException("Incomplete frame header from Fluxzy upstream");
+
+                var bodyLength = (header[0] << 16) | (header[1] << 8) | header[2];
+                var frameType = (H2FrameType)header[3];
+                var flags = (HeaderFlags)header[4];
+                var streamId = BinaryPrimitives.ReadInt32BigEndian(header.AsSpan(5, 4)) & 0x7FFFFFFF;
+                var body = bodyLength == 0 ? Array.Empty<byte>() : new byte[bodyLength];
+                if (bodyLength > 0)
+                    await ReadExactAsync(stream, body, token);
+
+                // The actual regression check: once a stream has had END_STREAM set,
+                // no more HEADERS/DATA/CONTINUATION frames are allowed on it.
+                if (streamId != 0 && streamsWithEndStream.Contains(streamId)
+                    && (frameType == H2FrameType.Data
+                        || frameType == H2FrameType.Headers
+                        || frameType == H2FrameType.Continuation)) {
+                    _recordedError = new InvalidOperationException(
+                        $"Fluxzy sent a {frameType} frame on stream {streamId} after END_STREAM. " +
+                        "This is the regression the fix is meant to prevent.");
+                    return;
+                }
+
+                if (flags.HasFlag(HeaderFlags.EndStream))
+                    streamsWithEndStream.Add(streamId);
+
+                // On the first HEADERS[END_STREAM] from the client, answer with an
+                // empty 200 so Fluxzy's downstream client sees a response and the
+                // test's foreground side can move forward.
+                if (frameType == H2FrameType.Headers
+                    && streamId != 0
+                    && flags.HasFlag(HeaderFlags.EndStream)
+                    && streamsAnswered.Add(streamId)) {
+                    await WriteStatus200EndStreamAsync(stream, streamId, token);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Sends a HEADERS frame containing only ":status: 200", with END_HEADERS
+        ///     and END_STREAM set. The payload is hand-coded: it uses HPACK index 8
+        ///     (":status: 200" from the static table) which is a single 0x88 byte.
+        /// </summary>
+        private static async Task WriteStatus200EndStreamAsync(
+            Stream stream, int streamId, CancellationToken token)
+        {
+            var frame = new byte[9 + 1];
+            // length = 1
+            frame[0] = 0x00;
+            frame[1] = 0x00;
+            frame[2] = 0x01;
+            frame[3] = (byte)H2FrameType.Headers;
+            frame[4] = (byte)(HeaderFlags.EndHeaders | HeaderFlags.EndStream);
+            BinaryPrimitives.WriteInt32BigEndian(frame.AsSpan(5, 4), streamId);
+            frame[9] = 0x88; // :status 200, indexed header, static table index 8
+
+            await stream.WriteAsync(frame.AsMemory(), token);
+            await stream.FlushAsync(token);
+        }
+
+        public async Task StopAndVerifyAsync()
+        {
+            _cts.Cancel();
+
+            try {
+                _listener.Stop();
+            }
+            catch { /* best-effort */ }
+
+            if (_acceptTask != null) {
+                try {
+                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await _acceptTask.WaitAsync(timeoutCts.Token);
+                }
+                catch { /* already recorded via _recordedError or OperationCanceledException */ }
+            }
+
+            if (_recordedError != null)
+                throw _recordedError;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try {
+                await StopAndVerifyAsync();
+            }
+            catch {
+                // Dispose swallows errors; tests must call StopAndVerifyAsync explicitly.
+            }
+
+            _cts.Dispose();
+        }
+
+        private static async Task ReadExactAsync(Stream stream, byte[] buffer, CancellationToken token)
+        {
+            var offset = 0;
+            while (offset < buffer.Length) {
+                var n = await stream.ReadAsync(buffer.AsMemory(offset), token);
+                if (n == 0)
+                    throw new EndOfStreamException("Peer closed the connection unexpectedly");
+                offset += n;
+            }
+        }
+
+        private static async Task<int> ReadAtMostAsync(Stream stream, byte[] buffer, CancellationToken token)
+        {
+            var offset = 0;
+            while (offset < buffer.Length) {
+                var n = await stream.ReadAsync(buffer.AsMemory(offset), token);
+                if (n == 0)
+                    return offset;
+                offset += n;
+            }
+            return offset;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Firefox frames a `POST` with `Content-Length: 0` as `HEADERS` (no END_STREAM) + `DATA[END_STREAM, 0 bytes]`; Chrome collapses both into a single `HEADERS[END_STREAM]`. Under `--serve-h2`, `H2DownStreamPipe` exposes Firefox's empty body as a non-seekable pipe stream.

On the upstream leg, `StreamWorker.EnqueueRequestHeader` already set END_STREAM on HEADERS (because `ContentLength == 0`), half-closing the stream, but `ProcessRequestBody` still entered its body loop (`!CanSeek` is true), read 0 bytes, and enqueued a `DATA[END_STREAM, 0 bytes]` frame on the half-closed stream. Per RFC 9113 section 5.1 that is a STREAM_CLOSED error, and strict origins reset the connection.

## Fix

Remember the end-stream flag set on HEADERS and short-circuit `ProcessRequestBody` when it is set, so no body-loop DATA frame can follow `HEADERS[END_STREAM]`.

## Tests

- `H2DownStreamPipeTests.PostContentLengthZero_WithTrailingEmptyDataFrame_ProducesEmptyBody` locks in the non-seekable empty pipe body shape.
- `StrictH2Recorder` is a minimal RFC 9113 raw H2 server mock that fails on any HEADERS/DATA/CONTINUATION after END_STREAM.
- `ReverseProxyH2Tests.ReverseMode_WithServeH2_FirefoxStyleEmptyPost_UpstreamHasNoStrayDataFrame` drives the Firefox pattern through Fluxzy into the recorder. Verified to fail with the fix reverted.