### PR TITLE
Fix H2 connection pool disposal race (#614)

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -49,6 +49,15 @@ namespace Fluxzy.Clients.H2
 
         private DateTime _lastActivity = ITimingProvider.Default.Instant();
 
+        /// <summary>
+        ///     Test seam: allows tests to force the idle path of <see cref="CheckAlive"/>
+        ///     deterministically without resorting to reflection or wall-clock waits.
+        /// </summary>
+        internal DateTime LastActivity {
+            get => _lastActivity;
+            set => _lastActivity = value;
+        }
+
         // Window size of the remote 
         private readonly WindowSizeHolder _overallWindowSizeHolder;
 
@@ -114,6 +123,30 @@ namespace Fluxzy.Clients.H2
 
             _innerReadTask = InternalReadLoop(_connectionToken);
             _innerWriteRun = InternalWriteLoop(_connectionToken);
+        }
+
+        /// <summary>
+        ///     Test seam: captures internal state at a single point in time so tests can
+        ///     assert ordering invariants (e.g. "the writer channel must be drained before
+        ///     the fault callback runs"). Not used by production code paths.
+        /// </summary>
+        internal H2ConnectionPoolStateSnapshot SnapshotForTests()
+        {
+            var pendingCount = 0;
+            var channelDrainedAndClosed = true;
+
+            if (_writerChannel != null) {
+                channelDrainedAndClosed = _writerChannel.Reader.Completion.IsCompleted;
+
+                if (_writerChannel.Reader.CanCount)
+                    pendingCount = _writerChannel.Reader.Count;
+            }
+
+            return new H2ConnectionPoolStateSnapshot(
+                Complete: _complete,
+                CtsCancelled: _connectionCancellationTokenSource.IsCancellationRequested,
+                WriterChannelDrainedAndClosed: channelDrainedAndClosed,
+                WriterChannelPendingCount: pendingCount);
         }
 
         public ValueTask<bool> CheckAlive()
@@ -191,8 +224,10 @@ namespace Fluxzy.Clients.H2
             _connectionCancellationTokenSource?.Cancel();
             _connectionCancellationTokenSource?.Dispose();
 
+            // Note: do NOT null out _writeSemaphore. Nulling a mutable field that
+            // other code may concurrently observe is a latent NRE hazard. CTS
+            // cancellation is the canonical "writers must stop" signal.
             _writeSemaphore?.Dispose();
-            _writeSemaphore = null;
 
             if (_innerReadTask != null)
                 await _innerReadTask.ConfigureAwait(false);
@@ -254,18 +289,28 @@ namespace Fluxzy.Clients.H2
 
             _complete = true;
 
-            // End the connection. This operation is idempotent. 
+            // End the connection. This operation is idempotent.
 
             _logger.Trace(0, "Cleanup start " + ex);
 
-            if (_onConnectionFaulted != null)
-                _onConnectionFaulted(this);
+            // IMPORTANT: drive ALL of our own internal cleanup BEFORE notifying the
+            // fault callback. The callback (in PoolBuilder.OnConnectionFaulted) may
+            // synchronously start tearing the pool down via DisposeAsync, and the
+            // synchronous prefix of DisposeAsync runs inline up to its first await.
+            // If we notified first, the rest of OnLoopEnd would then be running on
+            // top of partially-disposed state — the reentrance race that produced
+            // the NRE in haga-rak/fluxzy.core#614.
+            //
+            // The new ordering guarantees: by the time the fault callback runs,
+            // _complete is set, the CTS is cancelled, the writer channel is
+            // completed and drained, and all pending write tasks have been
+            // signalled. Disposal can then run safely without racing OnLoopEnd.
 
             if (ex != null)
                 _streamPool.OnGoAway(ex);
 
             if (!_connectionCancellationTokenSource.IsCancellationRequested)
-                _connectionCancellationTokenSource?.Cancel();
+                _connectionCancellationTokenSource.Cancel();
 
             if (releaseChannelItems && _writerChannel != null) {
                 _writerChannel.Writer.TryComplete();
@@ -279,6 +324,9 @@ namespace Fluxzy.Clients.H2
                     }
                 }
             }
+
+            // Notify last so the callback observes a fully-quiesced pool.
+            _onConnectionFaulted?.Invoke(this);
 
             _logger.Trace(0, "Cleanup end");
         }
@@ -602,6 +650,12 @@ namespace Fluxzy.Clients.H2
 
             return false;
         }
+
+        internal readonly record struct H2ConnectionPoolStateSnapshot(
+            bool Complete,
+            bool CtsCancelled,
+            bool WriterChannelDrainedAndClosed,
+            int WriterChannelPendingCount);
 
         private async ValueTask InternalSend(
             Exchange exchange, RsBuffer buffer,

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -76,17 +76,46 @@ namespace Fluxzy.Clients
 
                     await Task.Delay(5000, token).ConfigureAwait(false);
 
-                    List<IHttpConnectionPool> activePools;
-
-                    lock (_connectionPools) {
-                        activePools = _connectionPools.Values.ToList();
-                    }
-
-                    await ValueTaskUtil.WhenAll(activePools.Select(s => s.CheckAlive()).ToArray()).ConfigureAwait(false);
+                    await CheckAllPoolsOnceAsync().ConfigureAwait(false);
                 }
             }
             catch (TaskCanceledException) {
-                // Disposed was called 
+                // Disposed was called
+            }
+        }
+
+        /// <summary>
+        ///     Performs one health-check pass over the currently registered pools.
+        ///     Extracted from <see cref="CheckPoolStatus"/> so tests can drive a single
+        ///     tick deterministically.
+        ///
+        ///     A failure in one pool's <c>CheckAlive</c> must NEVER propagate out of
+        ///     this method: the caller is the async-void <see cref="CheckPoolStatus"/>
+        ///     loop, and an unhandled exception there terminates the process
+        ///     (haga-rak/fluxzy.core#614). Each pool is checked in a try/catch and the
+        ///     sweep continues regardless of individual failures.
+        /// </summary>
+        internal async Task CheckAllPoolsOnceAsync()
+        {
+            List<IHttpConnectionPool> activePools;
+
+            lock (_connectionPools) {
+                activePools = _connectionPools.Values.ToList();
+            }
+
+            // Sequential: CheckAlive does no network I/O on either the alive or the
+            // idle-teardown branch, so concurrency would only add coordination cost.
+            // Per-pool try/catch ensures one bad pool can't poison the sweep.
+            for (var i = 0; i < activePools.Count; i++) {
+                try {
+                    await activePools[i].CheckAlive().ConfigureAwait(false);
+                }
+                catch (Exception) {
+                    // Swallow: if a pool's health check throws, the next sweep will
+                    // observe Complete==true (assuming the failure put it in that
+                    // state) and reap it via the GetPool fast path. Logging hook
+                    // can be added once the project has a structured logger here.
+                }
             }
         }
 
@@ -277,18 +306,45 @@ namespace Fluxzy.Clients
                         proxyRuntimeSetting.GetInternalProxyAuthentication() : null));
         }
 
-        private void OnConnectionFaulted(IHttpConnectionPool h2ConnectionPool)
+        /// <summary>
+        ///     Test seam: directly inserts a pool into the active pool dictionary so
+        ///     <see cref="CheckAllPoolsOnceAsync"/> picks it up. Avoids constructing
+        ///     the full <see cref="GetPool"/> collaborator stack.
+        /// </summary>
+        internal void TryAddPoolForTests(Authority authority, IHttpConnectionPool pool)
         {
             lock (_connectionPools) {
-                if (_connectionPools.Remove(h2ConnectionPool.Authority))
-                    h2ConnectionPool.DisposeAsync();
+                _connectionPools[authority] = pool;
+            }
+        }
+
+        private void OnConnectionFaulted(IHttpConnectionPool h2ConnectionPool)
+        {
+            bool removed;
+
+            lock (_connectionPools) {
+                removed = _connectionPools.Remove(h2ConnectionPool.Authority);
             }
 
+            if (!removed)
+                return;
+
+            // Disposal runs asynchronously after the H2ConnectionPool's own
+            // OnLoopEnd cleanup has completed (see the reordering in
+            // H2ConnectionPool.OnLoopEnd). We do not block the caller here, but we
+            // also do not discard the ValueTask: ObserveDisposal awaits it and
+            // swallows any error so it doesn't surface as UnobservedTaskException.
+            _ = ObserveDisposal(h2ConnectionPool);
+        }
+
+        private static async Task ObserveDisposal(IHttpConnectionPool pool)
+        {
             try {
-                // h2ConnectionPool.Dispose();
+                await pool.DisposeAsync().ConfigureAwait(false);
             }
-            catch {
-                // Dispose and suppress errors
+            catch (Exception) {
+                // Swallow: a faulted disposal is not actionable from this context.
+                // A structured logger hook can be added here once available.
             }
         }
     }

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolDisposalTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolDisposalTests.cs
@@ -1,0 +1,206 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    /// <summary>
+    ///     Reproducers for the H2 connection-pool disposal race documented in
+    ///     haga-rak/fluxzy.core#614.
+    ///
+    ///     These tests are RED on the current code and document the structural
+    ///     defects that need to be fixed:
+    ///
+    ///     1) <see cref="CheckAlive_IdleTeardown_DrainsWriterChannelAndCancelsCtsBeforeFaultCallback"/>
+    ///        — <c>H2ConnectionPool.OnLoopEnd</c> calls the fault callback BEFORE it
+    ///        cancels its CTS and drains its writer channel, so the callback (which in
+    ///        production fire-and-forgets <c>DisposeAsync</c>) races with the rest of
+    ///        OnLoopEnd's cleanup.
+    ///
+    ///     2) <see cref="CheckAllPoolsOnceAsync_WhenPoolThrows_DoesNotPropagate"/>
+    ///        — <c>PoolBuilder.CheckPoolStatus</c> only catches
+    ///        <see cref="TaskCanceledException"/>, so any other exception from a pool's
+    ///        <c>CheckAlive</c> escapes the async-void method and crashes the process.
+    /// </summary>
+    public class H2ConnectionPoolDisposalTests
+    {
+        // ------------------------------------------------------------------
+        // Test 1: structural ordering invariant
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task CheckAlive_IdleTeardown_DrainsWriterChannelAndCancelsCtsBeforeFaultCallback()
+        {
+            // Arrange ----------------------------------------------------------
+            using var pipe = new DuplexPipe();
+
+            // The pool's base stream is a single bidirectional stream, recomposed
+            // from the two unidirectional pipe halves on the client side.
+            var baseStream = new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream);
+
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting {
+                // 0 means "any positive elapsed time qualifies as idle"; combined with
+                // setting LastActivity to MinValue below, the very first CheckAlive
+                // call deterministically takes the idle-teardown branch.
+                MaxIdleSeconds = 0
+            };
+            var connection = new Connection(authority, new TestIdProvider());
+
+            // Snapshot of the pool's internal state at the moment the fault callback
+            // fires. Captured non-destructively via SnapshotForTests so the assertions
+            // can run after the pool has been quiesced.
+            H2ConnectionPool.H2ConnectionPoolStateSnapshot? snapshotAtCallback = null;
+            var faultCallbackInvocations = 0;
+
+            var pool = new H2ConnectionPool(
+                baseStream,
+                setting,
+                authority,
+                connection,
+                onConnectionFaulted: p => {
+                    Interlocked.Increment(ref faultCallbackInvocations);
+                    snapshotAtCallback = p.SnapshotForTests();
+                });
+
+            pool.Init();
+
+            // Force the idle branch deterministically (no wall-clock dependency).
+            pool.LastActivity = DateTime.MinValue;
+
+            // Act --------------------------------------------------------------
+            // CheckAlive observes idle, calls EmitGoAway (queues a GoAway WriteTask
+            // on the writer channel), then calls OnLoopEnd(null, true). OnLoopEnd
+            // is the unit under test for the ordering invariant.
+            await pool.CheckAlive();
+
+            // Quiesce: dispose the pool so the read/write loops exit cleanly before
+            // we tear down the duplex pipe in the using-block.
+            await pool.DisposeAsync();
+
+            // Assert -----------------------------------------------------------
+            Assert.Equal(1, faultCallbackInvocations);
+            Assert.NotNull(snapshotAtCallback);
+
+            var snap = snapshotAtCallback!.Value;
+
+            // The fault callback should observe a pool that has already finished its
+            // own internal cleanup. Today this is NOT the case — OnLoopEnd notifies
+            // the callback first and only then cancels the CTS / drains the channel.
+
+            Assert.True(
+                snap.Complete,
+                "_complete must be set before the fault callback runs (currently true)");
+
+            Assert.True(
+                snap.CtsCancelled,
+                "the connection CTS must be cancelled before the fault callback runs " +
+                "(currently NOT — OnLoopEnd cancels after returning from the callback)");
+
+            Assert.True(
+                snap.WriterChannelDrainedAndClosed,
+                "the writer channel must be completed and drained before the fault " +
+                "callback runs (currently NOT — OnLoopEnd drains after the callback)");
+
+            Assert.Equal(0, snap.WriterChannelPendingCount);
+        }
+
+        // ------------------------------------------------------------------
+        // Test 4: async-void crash vector
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task CheckAllPoolsOnceAsync_WhenPoolThrows_DoesNotPropagate()
+        {
+            // Arrange ----------------------------------------------------------
+            // We only exercise the per-tick check pass via the internal seam; the
+            // GetPool collaborator stack is never touched, so we can pass null! for
+            // the four constructor dependencies.
+            var poolBuilder = new PoolBuilder(
+                remoteConnectionBuilder: null!,
+                timingProvider: null!,
+                archiveWriter: null!,
+                dnsSolver: null!);
+
+            // Cancel the background CheckPoolStatus loop immediately so it can't
+            // race with our test by hitting the throwing pool on its own 5s tick.
+            poolBuilder.Dispose();
+
+            var authority = new Authority("throwing.local", 443, true);
+            var throwingPool = new ThrowingHttpConnectionPool(authority);
+            poolBuilder.TryAddPoolForTests(authority, throwingPool);
+
+            // Act --------------------------------------------------------------
+            Exception? caught = null;
+            try {
+                await poolBuilder.CheckAllPoolsOnceAsync();
+            }
+            catch (Exception ex) {
+                caught = ex;
+            }
+
+            // Assert -----------------------------------------------------------
+            // In production, this exception would escape the async-void
+            // CheckPoolStatus and terminate the process. The fix must catch and log
+            // it inside the check loop instead of propagating.
+            Assert.Null(caught);
+            Assert.Equal(1, throwingPool.CheckAliveInvocations);
+        }
+
+        // ------------------------------------------------------------------
+        // Test doubles
+        // ------------------------------------------------------------------
+
+        /// <summary>
+        ///     Stub <see cref="IHttpConnectionPool"/> whose <see cref="CheckAlive"/>
+        ///     throws a <see cref="NullReferenceException"/> — mirroring the prod
+        ///     symptom in haga-rak/fluxzy.core#614. Other members are unused by the
+        ///     test and throw if invoked.
+        /// </summary>
+        private sealed class ThrowingHttpConnectionPool : IHttpConnectionPool
+        {
+            public ThrowingHttpConnectionPool(Authority authority)
+            {
+                Authority = authority;
+            }
+
+            public Authority Authority { get; }
+
+            public bool Complete => false;
+
+            public int CheckAliveInvocations { get; private set; }
+
+            public void Init()
+            {
+            }
+
+            public ValueTask<bool> CheckAlive()
+            {
+                CheckAliveInvocations++;
+                throw new NullReferenceException(
+                    "Simulated NRE from H2ConnectionPool.OnLoopEnd (haga-rak/fluxzy.core#614)");
+            }
+
+            public ValueTask Send(
+                Exchange exchange,
+                IDownStreamPipe downstreamPipe,
+                Fluxzy.Misc.ResizableBuffers.RsBuffer buffer,
+                ExchangeScope exchangeScope,
+                CancellationToken cancellationToken = default)
+            {
+                throw new NotSupportedException("Send is not exercised by this test.");
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                return default;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ref #614.

Under load, the H2 pool sometimes crashed the host with an NRE out of OnLoopEnd. Two interlocking issues:

1. OnLoopEnd called the fault callback before cancelling its CTS or draining its writer channel. The callback fire-and-forgets DisposeAsync, so the sync prefix of disposal ran on top of state OnLoopEnd was still about to touch. Reordered so the callback runs last, after internal cleanup is done.

2. PoolBuilder.CheckPoolStatus is async void and only caught TaskCanceledException, so any other exception from a pool's CheckAlive escaped and killed the process. Extracted the per-tick body into CheckAllPoolsOnceAsync and gave each pool its own try/catch.

Smaller cleanups: stopped nulling _writeSemaphore in DisposeAsync (just dispose it) and made OnConnectionFaulted observe the disposal ValueTask instead of discarding it.

Two new tests in H2ConnectionPoolDisposalTests reproduce both defects deterministically. Red before the fix, green after. No network, no certs, no elevation needed.
