### PR TITLE
Fix concurrent HashSet modification when serializing archive meta

### DIFF
--- a/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
+++ b/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
@@ -17,6 +17,7 @@ namespace Fluxzy.Writers
     public class DirectoryArchiveWriter : RealtimeArchiveWriter
     {
         private readonly ArchiveMetaInformation _archiveMetaInformation = CreateNewCaptureArchiveMetaInformation();
+        private readonly object _metaLock = new object();
 
         private static ArchiveMetaInformation CreateNewCaptureArchiveMetaInformation()
         {
@@ -78,7 +79,7 @@ namespace Fluxzy.Writers
             if (!force && File.Exists(_archiveMetaInformationPath))
                 return;
 
-            lock (_archiveMetaInformationPath)
+            lock (_metaLock)
             {
                 using var fileStream = File.Create(_archiveMetaInformationPath);
                 JsonSerializer.Serialize(fileStream, _archiveMetaInformation, GlobalArchiveOption.DefaultSerializerOptions);
@@ -87,15 +88,15 @@ namespace Fluxzy.Writers
 
         public override void UpdateTags(IEnumerable<Tag> tags)
         {
-            lock (_archiveMetaInformationPath)
+            lock (_metaLock)
             {
                 foreach (var tag in tags)
                 {
                     _archiveMetaInformation.Tags.Add(tag);
                 }
-            }
 
-            UpdateMeta(true);
+                UpdateMeta(true);
+            }
         }
 
         protected override bool ExchangeUpdateRequired(Exchange exchange)
@@ -130,18 +131,18 @@ namespace Fluxzy.Writers
 
             if (exchangeInfo.Tags?.Any() ?? false)
             {
-                var modified = false;
-
-                lock (_archiveMetaInformation) {
+                lock (_metaLock)
+                {
+                    var modified = false;
 
                     foreach (var tag in exchangeInfo.Tags)
                     {
                         modified = _archiveMetaInformation.Tags.Add(tag) || modified;
                     }
-                }
 
-                if (modified)
-                    UpdateMeta(true);
+                    if (modified)
+                        UpdateMeta(true);
+                }
             }
 
             return true;


### PR DESCRIPTION
## Summary

`DirectoryArchiveWriter` guarded `_archiveMetaInformation.Tags` with two different locks: `UpdateMeta` and `UpdateTags` locked on the path string, while `Update(ExchangeInfo)` locked on the meta object itself. That meant two threads could be inside the tag code at the same time, one adding to the HashSet while the other was enumerating it through `JsonSerializer.Serialize`, which throws "Collection was modified; enumeration operation may not execute".

The issue shows up more often when `UseDnsOverHttpsAction` is enabled because every DoH query becomes its own captured exchange, roughly doubling the concurrent write traffic through the archive writer.

This PR routes every access through a single `_metaLock` and keeps the `UpdateMeta(true)` call inside the lock so the Add and the serialize never interleave. The lock on an interned string was also a latent issue and is gone.