### PR TITLE
Fix PcapngWriter 'Already registered' on ephemeral port reuse

### DIFF
--- a/src/Fluxzy.Core.Pcap/DirectCaptureContext.cs
+++ b/src/Fluxzy.Core.Pcap/DirectCaptureContext.cs
@@ -56,11 +56,14 @@ namespace Fluxzy.Core.Pcap
 
             var connectionKey = PacketKeyBuilder.GetConnectionKey(localPort, remotePort, remoteAddress);
 
-            var writer = _packetQueue.GetOrAdd(connectionKey);
+            // The OS can reuse an ephemeral local port while the previous writer is still in
+            // its linger window, which would collide on connectionKey. Always rotate so a
+            // fresh writer serves the new connection; the stale writer is disposed here.
+            var writer = _packetQueue.Rotate(connectionKey);
 
-            writer.Register(outFileName); // There is a change that the writer is already registered
+            writer.Register(outFileName);
 
-            return writer.Key;
+            return writer.SubscriptionId;
         }
 
         public void StoreKey(string nssKey, IPAddress remoteAddress, int remotePort, int localPort)
@@ -95,7 +98,7 @@ namespace Fluxzy.Core.Pcap
             if (_packetQueue == null)
                 throw new InvalidOperationException("Not started yet");
 
-            _packetQueue.TryRemove(subscription, out _);
+            _packetQueue.TryRemoveBySubId(subscription, out _);
 
             return default;
         }

--- a/src/Fluxzy.Core.Pcap/Pcapng/PcapngWriter.cs
+++ b/src/Fluxzy.Core.Pcap/Pcapng/PcapngWriter.cs
@@ -157,5 +157,7 @@ namespace Fluxzy.Core.Pcap.Pcapng
         }
 
         public long Key { get; }
+
+        public long SubscriptionId { get; set; }
     }
 }

--- a/src/Fluxzy.Core.Pcap/SyncWriterQueue.cs
+++ b/src/Fluxzy.Core.Pcap/SyncWriterQueue.cs
@@ -1,5 +1,5 @@
 // // Copyright 2022 - Haga Rakotoharivelo
-// 
+//
 
 using System.Collections.Concurrent;
 using Fluxzy.Core.Pcap.Pcapng;
@@ -9,35 +9,72 @@ namespace Fluxzy.Core.Pcap
 {
     internal class SyncWriterQueue : IDisposable
     {
-        private ConcurrentDictionary<long, IRawCaptureWriter> _writers = new();
+        private ConcurrentDictionary<long, IRawCaptureWriter> _writersByKey = new();
+        private ConcurrentDictionary<long, IRawCaptureWriter> _writersBySubId = new();
+
+        private static long _nextSubscriptionId;
 
         private static readonly string ApplicationName = $"fluxzy {FluxzySharedSetting.RunningVersion} - https://www.fluxzy.io";
 
         public IRawCaptureWriter GetOrAdd(long key)
         {
             lock (this) {
-                return _writers.GetOrAdd(key,
-                    (k) => new PcapngWriter(k, ApplicationName)); ;
+                if (_writersByKey.TryGetValue(key, out var existing))
+                    return existing;
+
+                var writer = CreateWriter(key);
+                _writersByKey[key] = writer;
+                _writersBySubId[writer.SubscriptionId] = writer;
+                return writer;
+            }
+        }
+
+        public IRawCaptureWriter Rotate(long key)
+        {
+            lock (this) {
+                if (_writersByKey.TryRemove(key, out var stale)) {
+                    _writersBySubId.TryRemove(stale.SubscriptionId, out _);
+
+                    try {
+                        stale.Dispose();
+                    }
+                    catch {
+                        // ignore stale writer disposal errors
+                    }
+                }
+
+                var writer = CreateWriter(key);
+                _writersByKey[key] = writer;
+                _writersBySubId[writer.SubscriptionId] = writer;
+                return writer;
             }
         }
 
         public bool TryGet(long key, out IRawCaptureWriter? writer)
         {
-            return _writers.TryGetValue(key, out writer);
+            return _writersByKey.TryGetValue(key, out writer);
         }
 
-        public bool TryRemove(long key, out IRawCaptureWriter? writer)
+        public bool TryRemoveBySubId(long subscriptionId, out IRawCaptureWriter? writer)
         {
-            var res = _writers.TryRemove(key, out writer);
-            writer?.Flush();
-            writer?.Dispose();
+            lock (this) {
+                if (!_writersBySubId.TryRemove(subscriptionId, out writer))
+                    return false;
 
-            return res;
+                if (_writersByKey.TryGetValue(writer!.Key, out var current)
+                    && ReferenceEquals(current, writer)) {
+                    _writersByKey.TryRemove(writer.Key, out _);
+                }
+
+                writer.Flush();
+                writer.Dispose();
+                return true;
+            }
         }
 
         public void FlushAll()
         {
-            foreach (var writer in _writers.Values)
+            foreach (var writer in _writersByKey.Values)
             {
                 writer.Flush();
             }
@@ -45,26 +82,35 @@ namespace Fluxzy.Core.Pcap
 
         public void ClearAll()
         {
-            var oldWriter = _writers;
-            _writers = new ConcurrentDictionary<long, IRawCaptureWriter>();
+            var oldWriters = _writersByKey;
+            _writersByKey = new ConcurrentDictionary<long, IRawCaptureWriter>();
+            _writersBySubId = new ConcurrentDictionary<long, IRawCaptureWriter>();
 
-            foreach (var writer in oldWriter) {
+            foreach (var writer in oldWriters) {
                 try {
                     writer.Value.Dispose();
                 }
                 catch {
-                    // We ignore file closing exception 
+                    // We ignore file closing exception
                 }
             }
 
-            oldWriter.Clear();
+            oldWriters.Clear();
         }
 
         public void Dispose()
         {
-            foreach (var writer in _writers.Values) {
+            foreach (var writer in _writersByKey.Values) {
                 writer.Dispose();
             }
+        }
+
+        private static IRawCaptureWriter CreateWriter(long key)
+        {
+            var writer = new PcapngWriter(key, ApplicationName) {
+                SubscriptionId = Interlocked.Increment(ref _nextSubscriptionId)
+            };
+            return writer;
         }
     }
 }

--- a/src/Fluxzy.Core.Pcap/Writing/IRawCaptureWriter.cs
+++ b/src/Fluxzy.Core.Pcap/Writing/IRawCaptureWriter.cs
@@ -9,6 +9,8 @@ namespace Fluxzy.Core.Pcap.Writing
     {
         long Key { get; }
 
+        long SubscriptionId { get; set; }
+
         bool Faulted { get; }
 
         void Flush();

--- a/test/Fluxzy.Tests/UnitTests/Pcap/SyncWriterQueueTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Pcap/SyncWriterQueueTests.cs
@@ -1,0 +1,111 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using Fluxzy.Core.Pcap;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Pcap
+{
+    public class SyncWriterQueueTests : ProduceDeletableItem
+    {
+        [Fact]
+        public void Rotate_Replaces_Stale_Writer_On_Same_Key()
+        {
+            using var queue = new SyncWriterQueue();
+
+            const long connectionKey = 12345;
+
+            var firstFile = GetRegisteredRandomFile();
+            var first = queue.Rotate(connectionKey);
+            first.Register(firstFile);
+
+            var firstSubId = first.SubscriptionId;
+
+            var secondFile = GetRegisteredRandomFile();
+            var second = queue.Rotate(connectionKey);
+            second.Register(secondFile);
+
+            Assert.NotSame(first, second);
+            Assert.NotEqual(firstSubId, second.SubscriptionId);
+            Assert.Equal(connectionKey, second.Key);
+        }
+
+        [Fact]
+        public void Stale_Unsubscribe_Is_NoOp_After_Rotate()
+        {
+            using var queue = new SyncWriterQueue();
+
+            const long connectionKey = 23456;
+
+            var firstFile = GetRegisteredRandomFile();
+            var first = queue.Rotate(connectionKey);
+            first.Register(firstFile);
+            var firstSubId = first.SubscriptionId;
+
+            var secondFile = GetRegisteredRandomFile();
+            var second = queue.Rotate(connectionKey);
+            second.Register(secondFile);
+
+            // Simulate the old connection's linger-delayed Unsubscribe firing after rotation.
+            var removed = queue.TryRemoveBySubId(firstSubId, out _);
+            Assert.False(removed);
+
+            Assert.True(queue.TryGet(connectionKey, out var current));
+            Assert.Same(second, current);
+        }
+
+        [Fact]
+        public void Unsubscribe_Removes_Current_Writer()
+        {
+            using var queue = new SyncWriterQueue();
+
+            const long connectionKey = 34567;
+
+            var file = GetRegisteredRandomFile();
+            var writer = queue.Rotate(connectionKey);
+            writer.Register(file);
+
+            Assert.True(queue.TryRemoveBySubId(writer.SubscriptionId, out _));
+            Assert.False(queue.TryGet(connectionKey, out _));
+        }
+
+        [Fact]
+        public void GetOrAdd_Then_Rotate_Disposes_PreSubscribe_Writer()
+        {
+            using var queue = new SyncWriterQueue();
+
+            const long connectionKey = 45678;
+
+            // Packet-arrival path creates a writer before Subscribe.
+            var early = queue.GetOrAdd(connectionKey);
+            var earlySubId = early.SubscriptionId;
+
+            // Subscribe rotates — must not throw "Already registered!".
+            var file = GetRegisteredRandomFile();
+            var registered = queue.Rotate(connectionKey);
+            registered.Register(file);
+
+            Assert.NotSame(early, registered);
+            Assert.NotEqual(earlySubId, registered.SubscriptionId);
+        }
+
+        [Fact]
+        public void Double_Register_On_Same_Connection_Key_Does_Not_Throw()
+        {
+            using var queue = new SyncWriterQueue();
+
+            const long connectionKey = 56789;
+
+            var firstFile = GetRegisteredRandomFile();
+            var first = queue.Rotate(connectionKey);
+            first.Register(firstFile);
+
+            var secondFile = GetRegisteredRandomFile();
+            var second = queue.Rotate(connectionKey);
+
+            // Regression for "InvalidOperationException: Already registered!"
+            var ex = Record.Exception(() => second.Register(secondFile));
+            Assert.Null(ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When the OS reuses an ephemeral local port during the linger tear-down of a previous outbound capture, `DirectCaptureContext.Subscribe` collided on the connection 5-tuple key and called `PcapngWriter.Register` a second time on an already-registered writer, throwing `InvalidOperationException: Already registered!`.

Fix rotates the stale writer in `Subscribe` and decouples the subscription id (lifecycle) from the 5-tuple key (packet routing). `SyncWriterQueue` now holds two dicts and `TryRemoveBySubId` only removes by key when instances still match, so the old connection's linger-delayed `Unsubscribe` is a safe no-op after rotation.

No change to `ICaptureContext` shape or the out-of-proc wire protocol.