### PR TITLE
Fix Expect: 100-continue deadlock on H1 upstream (#624)

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -122,7 +122,7 @@ namespace Fluxzy.Clients.H11
                     _logger.Trace(exchange.Id, () => $"New connection obtained: {exchange.Connection.Id}");
                 }
 
-                var poolProcessing = new Http11PoolProcessing(_logger);
+                var poolProcessing = new Http11PoolProcessing(_logger, _proxyRuntimeSetting.ExpectContinueTimeout);
 
                 try {
                     await poolProcessing.Process(exchange, buffer, exchangeScope, cancellationToken)

--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Fluxzy.Clients.H2.Encoder.Utils;
 using Fluxzy.Core;
 using Fluxzy.Formatters.Producers.Requests;
 using Fluxzy.Misc.ResizableBuffers;
@@ -16,10 +17,12 @@ namespace Fluxzy.Clients.H11
     internal class Http11PoolProcessing
     {
         private readonly H1Logger _logger;
+        private readonly TimeSpan _expectContinueTimeout;
 
-        public Http11PoolProcessing(H1Logger logger)
+        public Http11PoolProcessing(H1Logger logger, TimeSpan expectContinueTimeout)
         {
             _logger = logger;
+            _expectContinueTimeout = expectContinueTimeout;
         }
 
         /// <summary>
@@ -46,7 +49,7 @@ namespace Fluxzy.Clients.H11
                 !exchange.Authority.Secure,
                 buffer, skipNonForwardableHeader: true, writeExtraHeaderField: true, requestClose: false);
 
-            // Sending request header 
+            // Sending request header
 
             await exchange.Connection.WriteStream!
                           .WriteAsync(buffer.Memory.Slice(0, headerLength), cancellationToken)
@@ -58,9 +61,54 @@ namespace Fluxzy.Clients.H11
             exchange.Metrics.RequestHeaderSent = ITimingProvider.Default.Instant();
             exchange.Metrics.RequestHeaderLength = headerLength;
 
-            // Sending request body 
+            // Expect: 100-continue path — read any interim/final response from
+            // upstream before streaming the body, otherwise the body-copy below
+            // would block on a client that is itself waiting for our 100 Continue
+            // (deadlock — issue #624).
 
-            if (exchange.Request.Body != null) {
+            HeaderBlockReadResult headerBlockDetectResult = default;
+            var hasEarlyResponseHeader = false;
+
+            if (exchange.Request.Header.HasExpectContinue && _expectContinueTimeout > TimeSpan.Zero) {
+                headerBlockDetectResult = await ReadExpectContinueInterim(
+                    exchange, buffer, cancellationToken).ConfigureAwait(false);
+
+                if (headerBlockDetectResult.HeaderLength > 0) {
+                    var earlyStatus = HttpHelper.ReadStatusCode(
+                        buffer.Buffer.AsSpan(0, headerBlockDetectResult.HeaderLength));
+
+                    if (earlyStatus >= 100 && earlyStatus < 200) {
+                        // 1xx interim — forward verbatim to client, then keep
+                        // pumping the body as usual. Upstream will send the
+                        // final response later; the regular response-read loop
+                        // will pick it up.
+                        await ForwardInterimToClient(exchange, earlyStatus, cancellationToken)
+                              .ConfigureAwait(false);
+                    }
+                    else {
+                        // Final response before body — the origin rejected
+                        // (413, 417, 401…) or produced a response without
+                        // needing the body. Skip body send entirely and hand
+                        // the already-buffered header off to the normal
+                        // response-processing tail.
+                        hasEarlyResponseHeader = true;
+                    }
+                }
+                else {
+                    // Origin stayed silent — either it doesn't honour Expect
+                    // (HTTP/1.0, naive origins) or the timeout beat the
+                    // network. Synthesise a 100 Continue to the client so it
+                    // releases the body (nginx/Apache do the same). Without
+                    // this, the body pump below would block forever on a
+                    // client that's still waiting for the interim response.
+                    await ForwardInterimToClient(exchange, 100, cancellationToken)
+                          .ConfigureAwait(false);
+                }
+            }
+
+            // Sending request body (unless the origin already answered)
+
+            if (!hasEarlyResponseHeader && exchange.Request.Body != null) {
                 var writeStream = exchange.Connection.WriteStream;
                 ChunkedTransferWriteStream? chunkedStream = null;
 
@@ -86,42 +134,45 @@ namespace Fluxzy.Clients.H11
 
             _logger.Trace(exchange.Id, () => "Body sent");
 
-            // Waiting for header block 
+            // Waiting for header block — unless the Expect pre-read already
+            // produced the final response header.
 
-            HeaderBlockReadResult headerBlockDetectResult = default;
+            if (!hasEarlyResponseHeader) {
+                try {
+                    while (true) {
+                        headerBlockDetectResult = await Http11HeaderBlockReader.GetNext(exchange.Connection.ReadStream!,
+                            buffer,
+                            () => exchange.Metrics.ResponseHeaderStart = ITimingProvider.Default.Instant(),
+                            () => exchange.Metrics.ResponseHeaderEnd = ITimingProvider.Default.Instant(),
+                            true,
+                            cancellationToken,
+                            true).ConfigureAwait(false);
 
-            try {
-                while (true) {
-                    headerBlockDetectResult = await Http11HeaderBlockReader.GetNext(exchange.Connection.ReadStream!,
-                        buffer,
-                        () => exchange.Metrics.ResponseHeaderStart = ITimingProvider.Default.Instant(),
-                        () => exchange.Metrics.ResponseHeaderEnd = ITimingProvider.Default.Instant(),
-                        true,
-                        cancellationToken,
-                        true).ConfigureAwait(false);
+                        var earlyStatus = HttpHelper.ReadStatusCode(
+                            buffer.Buffer.AsSpan(0, headerBlockDetectResult.HeaderLength));
 
-                    var is100Continue = HttpHelper.Is100Continue(
-                        buffer.Buffer);
+                        if (earlyStatus >= 100 && earlyStatus < 200) {
+                            // Forward any interim response to the client (previously
+                            // only 100 Continue was silently dropped). Apache-style
+                            // origins can send a 100 here even without Expect:
+                            // that still needs to reach the client per RFC 9110.
+                            await ForwardInterimToClient(exchange, earlyStatus, cancellationToken)
+                                  .ConfigureAwait(false);
+                            continue;
+                        }
 
-                    if (is100Continue) {
-                        // Even if fluxzy is not sending expect 100-continue,
-                        // we still need to handle it as many apache based server
-                        // will send it anyway
-
-                        continue;
+                        break;
+                    }
+                }
+                catch (Exception ex) {
+                    if (ex is TlsFatalAlert || (exchange.Context.EventNotifierStream?.Faulted ?? false)) {
+                        throw new ConnectionCloseException("Relaunch");
                     }
 
-                    break;
+                    throw new ClientErrorException(0,
+                        "The connection was closed while trying to read the response header",
+                        ex.Message, ex);
                 }
-            }
-            catch (Exception ex) {
-                if (ex is TlsFatalAlert || (exchange.Context.EventNotifierStream?.Faulted ?? false)) {
-                    throw new ConnectionCloseException("Relaunch");
-                }
-                
-                throw new ClientErrorException(0,
-                    "The connection was closed while trying to read the response header",
-                    ex.Message, ex);
             }
 
             if (headerBlockDetectResult.CloseNotify) {
@@ -139,10 +190,10 @@ namespace Fluxzy.Clients.H11
             _logger.TraceResponse(exchange);
 
             var shouldCloseConnection = exchange.Response.Header.ConnectionCloseRequest;
-            
+
             if (!exchange.Response.Header.HasResponseBody(exchange.Request.Header.Method.Span, out var shouldClose)) {
                 // We close the connection because
-                // many web server still sends a content-body with a 304 response 
+                // many web server still sends a content-body with a 304 response
                 // https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html 10.3.5
 
                 exchange.Metrics.ResponseBodyStart =
@@ -222,6 +273,56 @@ namespace Fluxzy.Clients.H11
                 );
 
             return shouldCloseConnection;
+        }
+
+        /// <summary>
+        ///     Tries to read a response-header block from upstream within
+        ///     <see cref="_expectContinueTimeout"/>. Returns default
+        ///     (HeaderLength == 0) if the timeout fires before any bytes
+        ///     arrive, so the caller can fall back to the legacy "send body,
+        ///     then read response" flow.
+        /// </summary>
+        private async ValueTask<HeaderBlockReadResult> ReadExpectContinueInterim(
+            Exchange exchange, RsBuffer buffer, CancellationToken cancellationToken)
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(_expectContinueTimeout);
+
+            try {
+                return await Http11HeaderBlockReader.GetNext(
+                    exchange.Connection!.ReadStream!,
+                    buffer,
+                    () => exchange.Metrics.ResponseHeaderStart = ITimingProvider.Default.Instant(),
+                    null,
+                    throwOnError: false,
+                    timeoutCts.Token,
+                    dontThrowIfEarlyClosed: true).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                // Timeout — origin didn't produce 100 Continue in time, or
+                // doesn't honour Expect at all. Fall back to legacy flow.
+                return default;
+            }
+            catch (IOException) {
+                // Socket-level read error — let the regular response loop
+                // surface it with its richer error mapping.
+                return default;
+            }
+        }
+
+        private static async ValueTask ForwardInterimToClient(
+            Exchange exchange, int statusCode, CancellationToken cancellationToken)
+        {
+            var writer = exchange.InterimResponseWriter;
+
+            if (writer == null) {
+                return; // no downstream bridge (H2, tunnel, legacy call site)
+            }
+
+            var reasonPhrase = Http11Constants
+                .GetStatusLine(statusCode.ToString().AsMemory());
+
+            await writer(statusCode, reasonPhrase, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Fluxzy.Core/Clients/H2/Encoder/Utils/Http11Constants.cs
+++ b/src/Fluxzy.Core/Clients/H2/Encoder/Utils/Http11Constants.cs
@@ -148,6 +148,16 @@ namespace Fluxzy.Clients.H2.Encoder.Utils
                 ConnectionVerb, KeepAliveVerb, ProxyAuthenticate, Trailer, Upgrade, AltSvc, Expect, FluxzyLiveEdit
             }, new SpanCharactersIgnoreCaseComparer());
 
+        // RFC 9110 §7.6.1 hop-by-hop headers plus fluxzy-internal markers.
+        // Deliberately excludes Expect: the proxy must forward Expect: 100-continue
+        // to an HTTP/1.1 upstream so the origin keeps authority over whether to
+        // accept the body (issue #624). Expect is still stripped on H2 upstreams
+        // via NonH2Header, because HPACK forbids it.
+        public static readonly HashSet<ReadOnlyMemory<char>> H1HopByHopHeader =
+            new(new[] {
+                ConnectionVerb, KeepAliveVerb, ProxyAuthenticate, Trailer, Upgrade, AltSvc, FluxzyLiveEdit
+            }, new SpanCharactersIgnoreCaseComparer());
+
         public static ReadOnlyMemory<char> GetStatusLine(ReadOnlyMemory<char> statusCode)
         {
             if (StatusLineMapping.TryGetValue(statusCode, out var res))
@@ -179,6 +189,11 @@ namespace Fluxzy.Clients.H2.Encoder.Utils
         public static bool IsNonForwardableHeader(string headerName)
         {
             return NonH2Header.Contains(headerName.AsMemory());
+        }
+
+        public static bool IsH1HopByHopHeader(ReadOnlyMemory<char> headerName)
+        {
+            return H1HopByHopHeader.Contains(headerName);
         }
     }
 }

--- a/src/Fluxzy.Core/Core/Exchange.cs
+++ b/src/Fluxzy.Core/Core/Exchange.cs
@@ -185,6 +185,15 @@ namespace Fluxzy.Core
 
         public int StreamIdentifier { get; set; }
 
+        /// <summary>
+        ///     Bridges the upstream connection pool to the downstream pipe for interim
+        ///     (1xx) responses — specifically `100 Continue` when the client sent
+        ///     `Expect: 100-continue`. Set by <see cref="ProxyOrchestrator"/> once the
+        ///     exchange is bound to a downstream pipe. Null when unsupported (e.g. H2
+        ///     downstream, tunnel mode).
+        /// </summary>
+        internal Func<int, ReadOnlyMemory<char>, System.Threading.CancellationToken, ValueTask>? InterimResponseWriter { get; set; }
+
         public IEnumerable<HeaderFieldInfo> GetRequestHeaders()
         {
             return Request.Header.Headers.Select(t => (HeaderFieldInfo) t);

--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -610,6 +610,16 @@ namespace Fluxzy.Core
             }
         }
 
+        public ValueTask WriteInterimResponse(int statusCode, ReadOnlyMemory<char> reasonPhrase, int streamIdentifier, CancellationToken token)
+        {
+            // HTTP/2 clients do not rely on Expect: 100-continue in practice
+            // (§8.1.2.2 forbids the Expect header in H2 requests), so the
+            // Expect-100 bridge from issue #624 is only relevant for H1
+            // downstream. If this ever needs to be implemented, it should queue
+            // a separate HEADERS frame with `:status: 1xx` and no END_STREAM.
+            return default;
+        }
+
         public ValueTask WriteResponseHeader(
             ResponseHeader responseHeader, RsBuffer buffer, bool shouldClose, int streamIdentifier, ReadOnlyMemory<char> requestMethod, CancellationToken token)
         {

--- a/src/Fluxzy.Core/Core/Header.cs
+++ b/src/Fluxzy.Core/Core/Header.cs
@@ -194,7 +194,10 @@ namespace Fluxzy.Core
                     continue;
                 }
 
-                if (skipNonForwardableHeader && Http11Constants.IsNonForwardableHeader(header.Name)) {
+                // HTTP/1.1 forwarding only strips true hop-by-hop headers.
+                // Expect: 100-continue is end-to-end on H1 and must be preserved
+                // so the origin can answer the client (issue #624).
+                if (skipNonForwardableHeader && Http11Constants.IsH1HopByHopHeader(header.Name)) {
                     continue;
                 }
 
@@ -234,7 +237,7 @@ namespace Fluxzy.Core
                     continue;
                 }
 
-                if (skipNonForwardableHeader && Http11Constants.IsNonForwardableHeader(header.Name)) {
+                if (skipNonForwardableHeader && Http11Constants.IsH1HopByHopHeader(header.Name)) {
                     continue;
                 }
 
@@ -273,7 +276,7 @@ namespace Fluxzy.Core
                     continue;
                 }
 
-                if (skipNonForwardableHeader && Http11Constants.IsNonForwardableHeader(header.Name)) {
+                if (skipNonForwardableHeader && Http11Constants.IsH1HopByHopHeader(header.Name)) {
                     continue;
                 }
 

--- a/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
@@ -91,6 +91,19 @@ namespace Fluxzy.Core
             return new Exchange(_idProvider, exchangeContext, RequestedAuthority, secureHeader, bodyStream, null!, receivedFromProxy);
         }
 
+        public async ValueTask WriteInterimResponse(int statusCode, ReadOnlyMemory<char> reasonPhrase, int _, CancellationToken token)
+        {
+            if (_writeStream == null)
+                throw new FluxzyException("Down stream has already been closed");
+
+            // "HTTP/1.1 NNN <reason>\r\n\r\n" — max ~64 bytes for typical reason phrases.
+            var line = $"HTTP/1.1 {statusCode} {reasonPhrase}\r\n\r\n";
+            var bytes = Encoding.ASCII.GetBytes(line);
+
+            await _writeStream.WriteAsync(bytes, 0, bytes.Length, token).ConfigureAwait(false);
+            await _writeStream.FlushAsync(token).ConfigureAwait(false);
+        }
+
         public async ValueTask WriteResponseHeader(ResponseHeader responseHeader, RsBuffer buffer, bool shouldClose, int _, ReadOnlyMemory<char> requestMethod, CancellationToken token)
         {
             if (_writeStream == null)

--- a/src/Fluxzy.Core/Core/IDownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/IDownStreamPipe.cs
@@ -20,6 +20,13 @@ namespace Fluxzy.Core
 
         ValueTask WriteResponseBody(Stream responseBodyStream, RsBuffer rsBuffer, bool chunked, int streamIdentifier, Response? responseForTrailers, CancellationToken token);
 
+        /// <summary>
+        ///     Write an interim (1xx) response to the downstream client. Used to
+        ///     forward an upstream `100 Continue` back to a client that sent
+        ///     `Expect: 100-continue` (issue #624).
+        /// </summary>
+        ValueTask WriteInterimResponse(int statusCode, ReadOnlyMemory<char> reasonPhrase, int streamIdentifier, CancellationToken token);
+
         (Stream ReadStream, Stream WriteStream) AbandonPipe();
 
         bool CanWrite { get; }

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -200,6 +200,14 @@ namespace Fluxzy.Core
                     return;
                 }
 
+                // Bridge the upstream pool to the downstream pipe so it can
+                // forward interim (1xx) responses — notably `100 Continue`
+                // for `Expect: 100-continue` (issue #624).
+                var capturedPipe = downStreamPipe;
+                var capturedStreamId = exchange.StreamIdentifier;
+                exchange.InterimResponseWriter = (statusCode, reason, ct) =>
+                    capturedPipe.WriteInterimResponse(statusCode, reason, capturedStreamId, ct);
+
                 var shouldCloseDownStreamConnection = await EnterProcessExchange(
                     buffer, closeImmediately, token, exchange,
                     remoteEndPoint, downStreamClientAddress,
@@ -260,6 +268,14 @@ namespace Fluxzy.Core
                 {
                     continue;
                 }
+
+                // Same interim-response bridge as the sequential path. The H2
+                // downstream implementation is a no-op, so this is defensive
+                // coverage for mixed-version scenarios (H2 client, H1 upstream).
+                var capturedPipe = downStreamPipe;
+                var capturedStreamId = exchange.StreamIdentifier;
+                exchange.InterimResponseWriter = (statusCode, reason, ct) =>
+                    capturedPipe.WriteInterimResponse(statusCode, reason, capturedStreamId, ct);
 
                 tracker.Increment();
 

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -46,6 +46,7 @@ namespace Fluxzy.Core
             IdProvider = idProvider;
             UserAgentProvider = userAgentProvider;
             ConcurrentConnection = startupSetting.ConnectionPerHost;
+            ExpectContinueTimeout = startupSetting.ExpectContinueTimeout;
             ActionMapping = new SetUserAgentActionMapping(startupSetting.UserAgentActionConfigurationFile);
         }
 
@@ -73,6 +74,13 @@ namespace Fluxzy.Core
         public int ConcurrentConnection { get; set; } = 16;
 
         public int TimeOutSecondsUnusedConnection { get; set; } = 4;
+
+        /// <summary>
+        ///     Maximum time fluxzy waits for an upstream `100 Continue` (or a
+        ///     final response) before falling back to sending the request body.
+        ///     Matches .NET's default `Expect100ContinueTimeout` of 1 second.
+        /// </summary>
+        public TimeSpan ExpectContinueTimeout { get; set; } = TimeSpan.FromSeconds(1);
 
         public IIdProvider IdProvider { get; set; } = new FromIndexIdProvider(0, 0);
 

--- a/src/Fluxzy.Core/Core/RequestHeader.cs
+++ b/src/Fluxzy.Core/Core/RequestHeader.cs
@@ -43,6 +43,13 @@ namespace Fluxzy.Core
             Scheme = this[Http11Constants.SchemeVerb].First().Value;
 
             IsWebSocketRequest = DoesHeadersIndicateWebsocketRequest();
+            HasExpectContinue = DoesHeadersIndicateExpectContinue();
+        }
+
+        private bool DoesHeadersIndicateExpectContinue()
+        {
+            return this[Http11Constants.Expect]
+                       .Any(c => c.Value.Span.Equals("100-continue", StringComparison.OrdinalIgnoreCase));
         }
         
         private bool DoesHeadersIndicateWebsocketRequest()
@@ -78,6 +85,11 @@ namespace Fluxzy.Core
         /// true if it's a websocket request
         /// </summary>
         public bool IsWebSocketRequest { get; set; }
+
+        /// <summary>
+        /// true if the request carries an Expect: 100-continue header.
+        /// </summary>
+        public bool HasExpectContinue { get; set; }
 
         /// <summary>
         /// Full URL building with Authority, path and scheme

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -228,6 +228,19 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Configure how long the proxy waits for an upstream `100 Continue`
+        ///     before forwarding the request body anyway when the client used
+        ///     `Expect: 100-continue`. A value of <see cref="TimeSpan.Zero"/> or
+        ///     negative disables the interim-relay wait and makes the proxy send
+        ///     the body immediately after the request headers.
+        /// </summary>
+        public FluxzySetting SetExpectContinueTimeout(TimeSpan timeout)
+        {
+            ExpectContinueTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
         ///     Set the default protocols used by fluxzy
         /// </summary>
         /// <param name="protocols"></param>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -59,6 +59,15 @@ namespace Fluxzy
         public int ConnectionPerHost { get; internal set; } = FluxzySharedSetting.MaxConnectionPerHost;
 
         /// <summary>
+        ///     Maximum time fluxzy waits for an upstream `100 Continue` (or a final
+        ///     response) after forwarding a request carrying `Expect: 100-continue`
+        ///     before falling back to sending the request body. Default: 1 second
+        ///     (matches .NET's `HttpClient.Expect100ContinueTimeout`).
+        /// </summary>
+        [JsonInclude]
+        public TimeSpan ExpectContinueTimeout { get; internal set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
         ///     Ssl protocols for remote host connection
         /// </summary>
         [JsonInclude]

--- a/src/Fluxzy.Core/Formatters/Producers/Requests/HttpHelper.cs
+++ b/src/Fluxzy.Core/Formatters/Producers/Requests/HttpHelper.cs
@@ -118,5 +118,32 @@ namespace Fluxzy.Formatters.Producers.Requests
 
             return statusLine.SequenceEqual(_100ContinueBytes);
         }
+
+        /// <summary>
+        ///     Reads the three-digit status code from an HTTP/1.1 header block
+        ///     that starts with the response status line (e.g. <c>HTTP/1.1 100 Continue\r\n...</c>).
+        ///     Returns 0 if the line cannot be parsed.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadStatusCode(ReadOnlySpan<byte> httpLine)
+        {
+            if (httpLine.Length < 12)
+                return 0;
+
+            var statusLine = httpLine.Slice(9, 3);
+
+            int code = 0;
+
+            for (int i = 0; i < 3; i++) {
+                var b = statusLine[i];
+
+                if (b < (byte)'0' || b > (byte)'9')
+                    return 0;
+
+                code = code * 10 + (b - (byte)'0');
+            }
+
+            return code;
+        }
     }
 }

--- a/test/Fluxzy.Tests/Cases/Issue624ExpectContinueHangTests.cs
+++ b/test/Fluxzy.Tests/Cases/Issue624ExpectContinueHangTests.cs
@@ -1,0 +1,251 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    /// <summary>
+    ///     Regression coverage for https://github.com/haga-rak/fluxzy.core/issues/624:
+    ///     AWS CLI S3 uploads hang because the request uses
+    ///     <c>Expect: 100-continue</c> with <c>Transfer-Encoding: chunked</c>.
+    ///
+    ///     Before the fix, Fluxzy (a) stripped <c>Expect</c> on the upstream leg
+    ///     and (b) pumped the client body sequentially before reading any
+    ///     response header — so the proxy ended up blocked in CopyDetailed()
+    ///     on a client that was itself waiting for the interim response.
+    ///
+    ///     After the fix, the HTTP/1.1 pool:
+    ///       - forwards <c>Expect: 100-continue</c> to HTTP/1.1 upstreams;
+    ///       - waits up to <c>ExpectContinueTimeout</c> for a 1xx/final
+    ///         response before pumping the body;
+    ///       - forwards any interim the origin sends back to the client;
+    ///       - synthesises a 100 Continue if the origin stays silent so
+    ///         naive clients don't stall indefinitely (nginx/Apache parity).
+    ///
+    ///     Tests stay on plain HTTP (no ReverseSecure/TLS) and drive the proxy
+    ///     with a raw TCP socket so the wire behaviour is observable.
+    ///     HttpClient would mask the bug because .NET silently sends the body
+    ///     after <c>Expect100ContinueTimeout</c> (default 1 s) expires.
+    /// </summary>
+    public class Issue624ExpectContinueHangTests
+    {
+        [Fact]
+        public async Task Expect100Continue_WithSilentOrigin_ProxySynthesisesInterimResponse()
+        {
+            using var upstreamCts = new CancellationTokenSource();
+
+            // Silent upstream — accepts the TCP connection and drains bytes
+            // but never answers. Reproduces an HTTP/1.0 or Expect-ignorant
+            // origin: the proxy must synthesise its own 100 Continue,
+            // otherwise the client deadlocks.
+            var upstream = new TcpListener(IPAddress.Loopback, 0);
+            upstream.Start();
+            var upstreamPort = ((IPEndPoint) upstream.LocalEndpoint).Port;
+
+            var upstreamTask = Task.Run(async () => {
+                try {
+                    using var upstreamClient =
+                        await upstream.AcceptTcpClientAsync(upstreamCts.Token);
+                    using var upstreamStream = upstreamClient.GetStream();
+
+                    var buffer = new byte[4096];
+                    while (!upstreamCts.IsCancellationRequested) {
+                        var read = await upstreamStream.ReadAsync(buffer, upstreamCts.Token);
+
+                        if (read == 0)
+                            break;
+                    }
+                }
+                catch {
+                    // Cancellation or socket abort is expected on teardown.
+                }
+            });
+
+            var setting = FluxzySetting.CreateLocalRandomPort()
+                                       .SetExpectContinueTimeout(TimeSpan.FromMilliseconds(300));
+
+            await using var proxy = new Proxy(setting);
+
+            var (clientStream, _) = await ConnectRawClient(proxy);
+
+            await SendExpectContinueRequest(clientStream, upstreamPort);
+
+            var received = await ReadInterimResponse(clientStream, TimeSpan.FromSeconds(8));
+
+            upstreamCts.Cancel();
+            upstream.Stop();
+            try { await upstreamTask; } catch { /* teardown */ }
+
+            Assert.Contains("HTTP/1.1 100", received);
+            Assert.Contains("Continue", received, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Expect100Continue_OriginSends100_ProxyForwardsItThenFinalResponse()
+        {
+            using var upstreamCts = new CancellationTokenSource();
+
+            // Cooperative upstream: on seeing `Expect: 100-continue`, it
+            // replies `HTTP/1.1 100 Continue`, consumes the chunked body and
+            // answers `200 OK`. This exercises the RFC-correct path where
+            // the proxy forwards the origin's interim to the client.
+            var upstream = new TcpListener(IPAddress.Loopback, 0);
+            upstream.Start();
+            var upstreamPort = ((IPEndPoint) upstream.LocalEndpoint).Port;
+
+            var upstreamTask = Task.Run(async () => {
+                try {
+                    using var upstreamClient =
+                        await upstream.AcceptTcpClientAsync(upstreamCts.Token);
+                    using var upstreamStream = upstreamClient.GetStream();
+
+                    await ReadHeadersAsync(upstreamStream);
+
+                    var interim = Encoding.ASCII.GetBytes("HTTP/1.1 100 Continue\r\n\r\n");
+                    await upstreamStream.WriteAsync(interim, upstreamCts.Token);
+                    await upstreamStream.FlushAsync(upstreamCts.Token);
+
+                    await DrainChunkedBodyAsync(upstreamStream);
+
+                    var response = Encoding.ASCII.GetBytes(
+                        "HTTP/1.1 200 OK\r\n" +
+                        "Content-Length: 2\r\n" +
+                        "Connection: close\r\n" +
+                        "\r\n" +
+                        "OK");
+                    await upstreamStream.WriteAsync(response, upstreamCts.Token);
+                    await upstreamStream.FlushAsync(upstreamCts.Token);
+                }
+                catch {
+                    // teardown
+                }
+            });
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            await using var proxy = new Proxy(setting);
+
+            var (clientStream, tcpClient) = await ConnectRawClient(proxy);
+
+            await SendExpectContinueRequest(clientStream, upstreamPort);
+
+            var interimReceived = await ReadInterimResponse(clientStream, TimeSpan.FromSeconds(8));
+            Assert.Contains("HTTP/1.1 100", interimReceived);
+
+            var body = Encoding.ASCII.GetBytes("5\r\nhello\r\n0\r\n\r\n");
+            await clientStream.WriteAsync(body);
+            await clientStream.FlushAsync();
+
+            var finalReceived = await ReadAllAsync(clientStream, TimeSpan.FromSeconds(8));
+
+            upstreamCts.Cancel();
+            upstream.Stop();
+            try { await upstreamTask; } catch { /* teardown */ }
+            tcpClient.Dispose();
+
+            Assert.Contains("HTTP/1.1 200", finalReceived);
+            Assert.Contains("OK", finalReceived);
+        }
+
+        private static async Task<(NetworkStream stream, TcpClient client)> ConnectRawClient(Proxy proxy)
+        {
+            var proxyEndpoint = proxy.Run().First();
+            var proxyAddress = proxyEndpoint.Address.Equals(IPAddress.Any)
+                ? IPAddress.Loopback
+                : proxyEndpoint.Address;
+
+            var tcpClient = new TcpClient();
+            await tcpClient.ConnectAsync(proxyAddress, proxyEndpoint.Port);
+            return (tcpClient.GetStream(), tcpClient);
+        }
+
+        private static async Task SendExpectContinueRequest(NetworkStream clientStream, int upstreamPort)
+        {
+            var request =
+                $"POST http://127.0.0.1:{upstreamPort}/upload HTTP/1.1\r\n" +
+                $"Host: 127.0.0.1:{upstreamPort}\r\n" +
+                "Expect: 100-continue\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "Content-Type: application/octet-stream\r\n" +
+                "\r\n";
+
+            var requestBytes = Encoding.ASCII.GetBytes(request);
+            await clientStream.WriteAsync(requestBytes);
+            await clientStream.FlushAsync();
+        }
+
+        private static async Task<string> ReadInterimResponse(NetworkStream clientStream, TimeSpan timeout)
+        {
+            using var readCts = new CancellationTokenSource(timeout);
+            var buffer = new byte[1024];
+
+            try {
+                var read = await clientStream.ReadAsync(buffer, readCts.Token);
+                return Encoding.ASCII.GetString(buffer, 0, read);
+            }
+            catch (OperationCanceledException) {
+                Assert.Fail(
+                    "Issue #624: the proxy did not forward or synthesise an " +
+                    "interim response within the read timeout — the client " +
+                    "would hang waiting for 100 Continue.");
+                return string.Empty;
+            }
+        }
+
+        private static async Task<string> ReadAllAsync(NetworkStream clientStream, TimeSpan timeout)
+        {
+            using var readCts = new CancellationTokenSource(timeout);
+            var sb = new StringBuilder();
+            var buffer = new byte[1024];
+
+            try {
+                while (true) {
+                    var read = await clientStream.ReadAsync(buffer, readCts.Token);
+                    if (read == 0) break;
+                    sb.Append(Encoding.ASCII.GetString(buffer, 0, read));
+                    if (sb.ToString().Contains("\r\n\r\nOK", StringComparison.Ordinal)) break;
+                }
+            }
+            catch (OperationCanceledException) {
+                // acceptable — caller asserts on what was collected so far
+            }
+
+            return sb.ToString();
+        }
+
+        private static async Task ReadHeadersAsync(NetworkStream stream)
+        {
+            var buffer = new byte[1];
+            var matches = 0;
+            while (matches < 4) {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0) return;
+                matches = buffer[0] switch {
+                    (byte)'\r' when matches % 2 == 0 => matches + 1,
+                    (byte)'\n' when matches % 2 == 1 => matches + 1,
+                    _ => 0
+                };
+            }
+        }
+
+        private static async Task DrainChunkedBodyAsync(NetworkStream stream)
+        {
+            var sb = new StringBuilder();
+            var buffer = new byte[1];
+            while (true) {
+                var read = await stream.ReadAsync(buffer);
+                if (read == 0) return;
+                sb.Append((char) buffer[0]);
+                if (sb.ToString().EndsWith("0\r\n\r\n", StringComparison.Ordinal))
+                    return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #624. Clients that wait for `100 Continue` before sending the
request body (AWS CLI S3 uploads, curl with `--expect100-timeout`, etc.)
hang through Fluxzy.

Two coupled defects:
- `Expect` was stripped on the H1 upstream leg (classified as
  non-forwardable together with H2-forbidden headers), so the origin
  never saw it and never produced an interim.
- `Http11PoolProcessing` pumped the client body before reading any
  upstream response, so the proxy blocked in `CopyDetailed` on a client
  that was itself waiting for the interim. Deadlock.

## Changes

- Split header classification: new `H1HopByHopHeader` set (RFC 9110 hop
  by hop only, no `Expect`). H1 writes use it; H2 writes still strip
  `Expect` per HPACK rules.
- Pre-read one upstream response header with a configurable
  `ExpectContinueTimeout` (default 1s) before the body pump.
- Forward any 1xx to the client through a new
  `IDownStreamPipe.WriteInterimResponse`.
- Short-circuit the body pump when the origin returns a final response
  early (413, 417, 401...).
- Synthesize `100 Continue` to the client when the origin stays silent,
  so naive clients don't stall (nginx/Apache parity).
- Fast path for non-Expect requests is unchanged.