### PR TITLE
Fix OOP pcap capture race with archive packaging

### DIFF
--- a/src/Fluxzy.Core.Pcap/OutOfProcessCaptureContext.cs
+++ b/src/Fluxzy.Core.Pcap/OutOfProcessCaptureContext.cs
@@ -124,6 +124,7 @@ namespace Fluxzy.Core.Pcap
 
             lock (this) {
                 _writer.Write((byte) MessageType.Flush);
+                _writer.Flush();
             }
         }
 

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -308,7 +308,11 @@ namespace Fluxzy.Cli.Commands
             var uaParserProvider = parseUserAgent ? new UaParserUserAgentInfoProvider() : null;
             var systemProxyManager = new SystemProxyRegistrationManager(new NativeProxySetterManager().Get());
 
-            await using var scope = new ProxyScope(() => new FluxzyNetOutOfProcessHost(), a => new OutOfProcessCaptureContext(a));
+            // Scope owns the out-of-proc capture subprocess lifetime. It must be disposed
+            // BEFORE PackDirectoryToFile runs so the subprocess closes its pcapng FileStreams
+            // and flushes all buffered packet data to disk; otherwise small captures can sit
+            // in the 4 KB FileStream buffer and the packager's Length==0 skip drops them.
+            await using (var scope = new ProxyScope(() => new FluxzyNetOutOfProcessHost(), a => new OutOfProcessCaptureContext(a))) {
 
             if (!ValidateSetting(invocationContext, proxyStartUpSetting)) {
                 invocationContext.ExitCode = 1;
@@ -389,6 +393,8 @@ namespace Fluxzy.Cli.Commands
                     }
                 }
             }
+
+            } // scope dispose: subprocess exits, pcapng FileStreams closed + flushed
 
             invocationContext.Console.Out.WriteLine("Proxy ended, gracefully");
 

--- a/test/Fluxzy.Tests/Cli/CliTestBase.cs
+++ b/test/Fluxzy.Tests/Cli/CliTestBase.cs
@@ -132,7 +132,8 @@ namespace Fluxzy.Tests.Cli
                 if (rawCap != CaptureType.None)
                 {
                     var rawCapStream = archiveReader.GetRawCaptureStream(connection.Id);
-                    Assert.True(await rawCapStream!.DrainAsync(disposeStream: true) > 0);
+                    Assert.NotNull(rawCapStream);
+                    Assert.True(await rawCapStream.DrainAsync(disposeStream: true) > 0);
                 }
 
                 if (rule)


### PR DESCRIPTION
## Summary

The out-of-proc capture subprocess held pcapng `FileStream`s with buffered data while `PackDirectoryToFile` zipped the capture directory. Small captures could sit in the 4KB `FileStream` buffer and get skipped by `ZipHelper`'s `Length == 0` check, leaving `captures/*.pcapng` missing from the fxzy archive. This caused intermittent NREs in `CliWithCapOutOfProc.Run` when the test drained the (null) raw capture stream.

## Changes

- `StartCommandBuilder`: wrap `scope` in an `await using` block so the capture subprocess exits (closing and flushing all pcapng `FileStream`s) before packaging runs.
- `OutOfProcessCaptureContext.Flush`: actually flush the `BinaryWriter` so the flush message reaches the subprocess.
- `CliTestBase`: assert `NotNull` on the raw capture stream before draining so future regressions surface with a clear message instead of an NRE through an extension method.