### PR TITLE
Fix timeout in DuplicateTransferEncoding test

### DIFF
--- a/test/Fluxzy.Tests/Cases/DuplicateTransferEncodingTests.cs
+++ b/test/Fluxzy.Tests/Cases/DuplicateTransferEncodingTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Fluxzy.Core;
 using Fluxzy.Rules.Actions;
@@ -62,7 +63,12 @@ namespace Fluxzy.Tests.Cases
                     (_, _, _, _) => true);
             client.Timeout = TimeSpan.FromSeconds(30);
 
-            var response = await client.GetAsync("https://noaa-goes16.s3.amazonaws.com/");
+            // ResponseHeadersRead avoids buffering the full S3 listing body. The assertion
+            // only needs the response headers, and pulling megabytes across the proxy makes
+            // the test timeout-prone on CI.
+            var response = await client.GetAsync(
+                "https://noaa-goes16.s3.amazonaws.com/",
+                HttpCompletionOption.ResponseHeadersRead);
 
             Assert.True(response.IsSuccessStatusCode,
                 $"Expected 2xx from noaa-goes16.s3.amazonaws.com, got {(int)response.StatusCode}");


### PR DESCRIPTION
## Summary
The test only asserts on response headers, but `client.GetAsync` defaults to buffering the full response body. Against `noaa-goes16.s3.amazonaws.com` that is a large XML bucket listing, which exhausts the 30s `HttpClient.Timeout` on CI and fails inside `ChunkedEncodingReadStream.CopyToAsyncCore`.

Switching to `HttpCompletionOption.ResponseHeadersRead` keeps the same coverage (the upstream `Transfer-Encoding: chunked` header and the downstream header set are still verified) and brings test duration from 30s (timeout) down to ~4s locally.