### PR TITLE
Perf: reduce per-exchange allocations on HTTP/1.1 hot path

### DIFF
--- a/src/Fluxzy.Core/Core/Exchange.cs
+++ b/src/Fluxzy.Core/Core/Exchange.cs
@@ -79,9 +79,11 @@ namespace Fluxzy.Core
 
             Metrics.ReceivedFromProxy = receivedFromProxy;
 
-            RunInLiveEdit = requestHeader.HeaderFields
-                                         .Any(h => h.Name.Span.Equals("x-fluxzy-live-edit",
-                                             StringComparison.OrdinalIgnoreCase));
+            if (FluxzySharedSetting.LiveEditEnabled) {
+                RunInLiveEdit = requestHeader.HeaderFields
+                                             .Any(h => h.Name.Span.Equals("x-fluxzy-live-edit",
+                                                 StringComparison.OrdinalIgnoreCase));
+            }
         }
 
         /// <summary>

--- a/src/Fluxzy.Core/Core/ExchangeScope.cs
+++ b/src/Fluxzy.Core/Core/ExchangeScope.cs
@@ -8,20 +8,31 @@ namespace Fluxzy.Core
 {
     public class ExchangeScope : IDisposable
     {
-        private readonly List<IDisposable> _memoryPools = new();
+        private char[]? _first;
+        private char[]? _second;
+        private List<char[]>? _overflow;
 
         private bool _disposed;
 
         public Memory<char> RegisterForReturn(int length)
         {
-            var memoryOwner = MemoryPool<char>.Shared.Rent(length);
+            var array = ArrayPool<char>.Shared.Rent(length);
 
-            lock (this)
-                _memoryPools.Add(memoryOwner);
+            lock (this) {
+                if (_first == null) {
+                    _first = array;
+                }
+                else if (_second == null) {
+                    _second = array;
+                }
+                else {
+                    (_overflow ??= new List<char[]>()).Add(array);
+                }
+            }
 
-            return memoryOwner.Memory.Slice(0, length);
+            return new Memory<char>(array, 0, length);
         }
-        
+
         public void Dispose()
         {
             if (_disposed)
@@ -31,9 +42,22 @@ namespace Fluxzy.Core
 
             _disposed = true;
 
-            foreach (var memoryOwner in _memoryPools)
-            {
-                memoryOwner.Dispose();
+            if (_first != null) {
+                ArrayPool<char>.Shared.Return(_first);
+                _first = null;
+            }
+
+            if (_second != null) {
+                ArrayPool<char>.Shared.Return(_second);
+                _second = null;
+            }
+
+            if (_overflow != null) {
+                foreach (var array in _overflow) {
+                    ArrayPool<char>.Shared.Return(array);
+                }
+
+                _overflow = null;
             }
         }
     }

--- a/src/Fluxzy.Core/Core/Header.cs
+++ b/src/Fluxzy.Core/Core/Header.cs
@@ -60,6 +60,67 @@ namespace Fluxzy.Core
 
         public IEnumerable<HeaderField> this[string headerName] => this[headerName.AsMemory()];
 
+        protected bool TryGetFirstHeader(ReadOnlyMemory<char> name, out HeaderField field)
+        {
+            foreach (var f in _rawHeaderFields) {
+                if (f.Name.Span.Equals(name.Span, StringComparison.OrdinalIgnoreCase)) {
+                    field = f;
+                    return true;
+                }
+            }
+
+            field = default;
+            return false;
+        }
+
+        protected bool TryGetLastHeader(ReadOnlyMemory<char> name, out HeaderField field)
+        {
+            field = default;
+            var found = false;
+
+            foreach (var f in _rawHeaderFields) {
+                if (f.Name.Span.Equals(name.Span, StringComparison.OrdinalIgnoreCase)) {
+                    field = f;
+                    found = true;
+                }
+            }
+
+            return found;
+        }
+
+        protected bool HasHeaderValueEqualsAny(ReadOnlyMemory<char> name, string value1, string? value2 = null)
+        {
+            foreach (var f in _rawHeaderFields) {
+                if (!f.Name.Span.Equals(name.Span, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                var valSpan = f.Value.Span;
+
+                if (valSpan.Equals(value1, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+
+                if (value2 != null && valSpan.Equals(value2, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected bool HasHeaderValueContains(ReadOnlyMemory<char> name, string value)
+        {
+            foreach (var f in _rawHeaderFields) {
+                if (f.Name.Span.Equals(name.Span, StringComparison.OrdinalIgnoreCase) &&
+                    f.Value.Span.Contains(value, StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         ///     If transfer-encoding chunked is defined
         /// </summary>

--- a/src/Fluxzy.Core/Core/RequestHeader.cs
+++ b/src/Fluxzy.Core/Core/RequestHeader.cs
@@ -37,28 +37,25 @@ namespace Fluxzy.Core
 
         private void InitSettings()
         {
-            Authority = this[Http11Constants.AuthorityVerb].First().Value;
-            Path = this[Http11Constants.PathVerb].First().Value;
-            Method = this[Http11Constants.MethodVerb].First().Value;
-            Scheme = this[Http11Constants.SchemeVerb].First().Value;
+            Authority = RequireFirstHeader(Http11Constants.AuthorityVerb).Value;
+            Path = RequireFirstHeader(Http11Constants.PathVerb).Value;
+            Method = RequireFirstHeader(Http11Constants.MethodVerb).Value;
+            Scheme = RequireFirstHeader(Http11Constants.SchemeVerb).Value;
 
-            IsWebSocketRequest = DoesHeadersIndicateWebsocketRequest();
-            HasExpectContinue = DoesHeadersIndicateExpectContinue();
+            IsWebSocketRequest = HasHeaderValueContains(Http11Constants.ConnectionVerb, "upgrade")
+                                 && HasHeaderValueEqualsAny(Http11Constants.Upgrade, "websocket");
+
+            HasExpectContinue = HasHeaderValueEqualsAny(Http11Constants.Expect, "100-continue");
         }
 
-        private bool DoesHeadersIndicateExpectContinue()
+        private HeaderField RequireFirstHeader(ReadOnlyMemory<char> name)
         {
-            return this[Http11Constants.Expect]
-                       .Any(c => c.Value.Span.Equals("100-continue", StringComparison.OrdinalIgnoreCase));
-        }
-        
-        private bool DoesHeadersIndicateWebsocketRequest()
-        {
-            return this[Http11Constants.ConnectionVerb]
-                       .Any(c => c.Value.Span.Contains("upgrade", StringComparison.OrdinalIgnoreCase))
-                   &&
-                   this[Http11Constants.Upgrade]
-                       .Any(c => c.Value.Span.Equals("websocket", StringComparison.OrdinalIgnoreCase));
+            if (!TryGetFirstHeader(name, out var field)) {
+                throw new InvalidOperationException(
+                    $"Missing required pseudo-header '{name}' in request.");
+            }
+
+            return field;
         }
 
         /// <summary>

--- a/src/Fluxzy.Core/Core/ResponseHeader.cs
+++ b/src/Fluxzy.Core/Core/ResponseHeader.cs
@@ -24,15 +24,11 @@ namespace Fluxzy.Core
             bool isSecure, bool parseConnectionInfo)
             : base(headerContent, isSecure)
         {
-            StatusCode = int.Parse(this[Http11Constants.StatusVerb].First().Value.Span);
+            StatusCode = ParseStatusCode();
 
             if (parseConnectionInfo) {
-                ConnectionCloseRequest = HeaderFields.Any(
-                    r => r.Name.Span.Equals(Http11Constants.ConnectionVerb.Span, StringComparison.OrdinalIgnoreCase)
-                         && (
-                             r.Value.Span.Equals("close", StringComparison.OrdinalIgnoreCase) ||
-                             r.Value.Span.Equals("upgrade", StringComparison.OrdinalIgnoreCase)
-                         ));
+                ConnectionCloseRequest =
+                    HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "close", "upgrade");
 
                 if (!ConnectionCloseRequest) {
                     ConnectionCloseRequest = ReadKeepAliveSettings() || ConnectionCloseRequest;
@@ -47,18 +43,23 @@ namespace Fluxzy.Core
         public ResponseHeader(IEnumerable<HeaderField> headers)
             : base(headers)
         {
-            StatusCode = int.Parse(this[Http11Constants.StatusVerb].First().Value.Span);
+            StatusCode = ParseStatusCode();
 
-            ConnectionCloseRequest = HeaderFields.Any(
-                r => r.Name.Span.Equals(Http11Constants.ConnectionVerb.Span, StringComparison.OrdinalIgnoreCase)
-                     && (
-                         r.Value.Span.Equals("close", StringComparison.OrdinalIgnoreCase) ||
-                         r.Value.Span.Equals("upgrade", StringComparison.OrdinalIgnoreCase)
-                     ));
+            ConnectionCloseRequest =
+                HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "close", "upgrade");
 
             if (!ConnectionCloseRequest) {
                 ConnectionCloseRequest = ReadKeepAliveSettings() || ConnectionCloseRequest;
             }
+        }
+
+        private int ParseStatusCode()
+        {
+            if (!TryGetFirstHeader(Http11Constants.StatusVerb, out var field)) {
+                throw new InvalidOperationException("Missing ':status' pseudo-header in response.");
+            }
+
+            return int.Parse(field.Value.Span);
         }
 
         public int TimeoutIdleSeconds { get; set; } = 1;
@@ -73,14 +74,9 @@ namespace Fluxzy.Core
         {
             var immediateClose = false;
 
-            if (HeaderFields.Any(
-                    r => r.Name.Span.Equals(Http11Constants.ConnectionVerb.Span, StringComparison.OrdinalIgnoreCase)
-                         && r.Value.Span.Equals("keep-alive", StringComparison.OrdinalIgnoreCase))) {
-                var keepHeaderValue = HeaderFields.LastOrDefault(
-                    h => h.Name.Span.Equals(Http11Constants.KeepAliveVerb.Span, StringComparison.OrdinalIgnoreCase)
-                );
-
-                if (!keepHeaderValue.Value.IsEmpty) {
+            if (HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "keep-alive")) {
+                if (TryGetLastHeader(Http11Constants.KeepAliveVerb, out var keepHeaderValue)
+                    && !keepHeaderValue.Value.IsEmpty) {
                     if (HeaderUtility.TryParseKeepAlive(keepHeaderValue.Value.Span, out var max, out var timeout)) {
                         if (max >= 0) {
                             MaxConnection = max;

--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -108,5 +108,12 @@ namespace Fluxzy
         /// </summary>
         public static int ProcessTrackerCacheSeconds { get; set; } =
             EnvironmentUtility.GetInt32("FLUXZY_PROCESS_TRACKER_CACHE_SECONDS", 30);
+
+        /// <summary>
+        ///     True when Fluxzy runs under Fluxzy Desktop (detected via the FluxzyDesktopVersion
+        ///     environment variable). Gates desktop-only hot-path checks like live-edit header scanning.
+        /// </summary>
+        public static bool LiveEditEnabled { get; } =
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FluxzyDesktopVersion"));
     }
 }


### PR DESCRIPTION
## Summary

Three small allocation cuts on the HTTP/1.1 MITM path:

- Gate the per-exchange `x-fluxzy-live-edit` header scan behind the `FluxzyDesktopVersion` env var (exposed as `FluxzySharedSetting.LiveEditEnabled`). Standalone fluxzy no longer walks every request's headers looking for a desktop-only debug flag.
- `ExchangeScope` now uses two inline `char[]?` slots plus a lazy overflow list, renting directly from `ArrayPool<char>.Shared`. Drops the unconditional `List<IDisposable>` allocation and the `IMemoryOwner` wrapper that `MemoryPool<char>.Shared.Rent` returns per header buffer.
- Added `TryGetFirstHeader`, `TryGetLastHeader`, `HasHeaderValueEqualsAny`, and `HasHeaderValueContains` helpers on `Header` that iterate the backing `List<HeaderField>` via its struct enumerator. Rewrote `RequestHeader.InitSettings`, the `ResponseHeader` constructors, and `ReadKeepAliveSettings` to use them, removing the yield-return iterator allocations from each `First`/`Any`/`LastOrDefault` call.

Targeting the `UseProxy=True, ServeH2=False, ResponseBodyLength=0` row in `ProxyThroughputBenchmark` (~7.7 µs, ~12.6 KB/op).