### PR TITLE
Perf: skip redundant upfront per-stream WINDOW_UPDATE in H2

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,10 +345,10 @@ Reference numbers from a Ryzen 9 7950X3D on Linux, .NET 10, loopback. Use them t
 
 | Scenario               | Direct to Kestrel       | Through Fluxzy proxy   |
 |------------------------|------------------------:|-----------------------:|
-| HTTP/1.1, empty body   | 269k req/s, 49 MiB/s    | 129k req/s, 24 MiB/s   |
-| HTTP/1.1, 8 KB body    | 158k req/s, 1.24 GiB/s  | 56k req/s, 450 MiB/s   |
-| HTTP/2, empty body     | 268k req/s, 23 MiB/s    | 145k req/s, 15 MiB/s   |
-| HTTP/2, 8 KB body      | 75k req/s, 603 MiB/s    | 57k req/s, 457 MiB/s   |
+| HTTP/1.1, empty body   | 272k req/s, 49 MiB/s    | 138k req/s, 25 MiB/s   |
+| HTTP/1.1, 8 KB body    | 155k req/s, 1.22 GiB/s  | 61k req/s, 492 MiB/s   |
+| HTTP/2, empty body     | 270k req/s, 24 MiB/s    | 154k req/s, 16 MiB/s   |
+| HTTP/2, 8 KB body      | 75k req/s, 604 MiB/s    | 57k req/s, 457 MiB/s   |
 
 The "Direct to Kestrel" column is the upper bound of what the test client + Kestrel can achieve without a proxy in the path. The "Through Fluxzy proxy" column shows the same workload after the SOCKS5 + MITM hop, so the gap between the two columns is the cost the proxy adds.
 

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -424,8 +424,6 @@ namespace Fluxzy.Clients.H2
         
         public async ValueTask ProcessResponse(CancellationToken cancellationToken, H2ConnectionPool cp)
         {
-            SendWindowUpdate(Parent.Context.Setting.Local.WindowSize, StreamIdentifier);
-
             try {
                 _logger.Trace(StreamIdentifier, "Before semaphore ");
 


### PR DESCRIPTION
## Summary

`StreamWorker.ProcessResponse` emitted a `WINDOW_UPDATE(streamId, Local.WindowSize)` right after HEADERS on every new stream. Since `SETTINGS_INITIAL_WINDOW_SIZE` (6 MB) is already advertised in the connection preface, each new stream already has that full credit. The extra frame was wasted: one channel enqueue and 13 wire bytes per request, with no benefit for any body within the initial window.

Large-body streaming still gets credit via the consumption-driven path in `OnDataConsumedByCaller` (per-stream update above 16 KiB consumed, plus connection-level updates through `ShouldWindowUpdate`).

No impact on the Akamai / JA4 H2 fingerprint: those capture the connection-level `WINDOW_UPDATE` on stream 0 from the preface (`SettingHelper.WriteWelcomeSettings`), which is unchanged.

Refreshed `ProxyThroughputBenchmark` numbers in the README.