### PR TITLE
Enable non-interactive pcap tests on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,6 @@ thirdParty/
 # docfx build output
 _site/
 docs/docfx/api/
+
+# Local sudo password for Linux test setcap (see test/Fluxzy.Tests/Utility.cs)
+.password

--- a/src/Fluxzy.Core/Misc/ProcessUtils.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtils.cs
@@ -227,7 +227,16 @@ namespace Fluxzy.Misc
                 return osXProcess;
             }
 
-            // For other OS we use pkexec
+            // For other OS we use pkexec, unless FLUXZY_SUDO_PASSWORD_FILE points to a
+            // readable file — in that case we shell out to `sudo -S` and feed the password
+            // from the file. Used primarily by tests to bypass the interactive pkexec prompt.
+
+            var passwordFile = Environment.GetEnvironmentVariable("FLUXZY_SUDO_PASSWORD_FILE");
+
+            if (!string.IsNullOrEmpty(passwordFile) && File.Exists(passwordFile)) {
+                return await StartWithSudoPasswordFile(commandName, args, passwordFile,
+                    redirectStdOut, redirectStandardError);
+            }
 
             var canElevated = await ProcessUtilX.HasCaptureCapabilities() || await ProcessUtilX.CanElevated();
             var execCommandName = canElevated ? commandName : "pkexec";
@@ -240,6 +249,42 @@ namespace Fluxzy.Misc
                 RedirectStandardInput = redirectStdOut,
                 RedirectStandardError = redirectStandardError
             });
+
+            return process;
+        }
+
+        private static async Task<Process?> StartWithSudoPasswordFile(
+            string commandName, string[] args, string passwordFile,
+            bool redirectStdOut, bool redirectStandardError)
+        {
+            var password = (await File.ReadAllTextAsync(passwordFile).ConfigureAwait(false))
+                .TrimEnd('\r', '\n');
+
+            var startInfo = new ProcessStartInfo("sudo") {
+                UseShellExecute = false,
+                RedirectStandardInput = true,
+                RedirectStandardOutput = redirectStdOut,
+                RedirectStandardError = redirectStandardError,
+            };
+
+            startInfo.ArgumentList.Add("-S");
+            startInfo.ArgumentList.Add("-p");
+            startInfo.ArgumentList.Add(string.Empty);
+            startInfo.ArgumentList.Add("-E");
+            startInfo.ArgumentList.Add(commandName);
+
+            foreach (var arg in args)
+                startInfo.ArgumentList.Add(arg);
+
+            var process = Process.Start(startInfo);
+
+            if (process == null)
+                return null;
+
+            // sudo -S reads the password (up to the first newline) from stdin, then execs
+            // the target. Remaining stdin flows to the child, so the caller can keep writing.
+            await process.StandardInput.WriteLineAsync(password).ConfigureAwait(false);
+            await process.StandardInput.FlushAsync().ConfigureAwait(false);
 
             return process;
         }

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -287,7 +287,11 @@ namespace Fluxzy.Cli.Commands
             proxyStartUpSetting.SetAutoInstallCertificate(installCert);
             proxyStartUpSetting.SetSkipGlobalSslDecryption(skipDecryption);
             proxyStartUpSetting.SetDisableCertificateCache(noCertCache);
-            proxyStartUpSetting.OutOfProcCapture = outOfProcCapture;
+            // When FLUXZY_SUDO_PASSWORD_FILE is set we can't capture in-process (the current
+            // process has no caps — the whole point of the file is to sudo the child). Force
+            // out-of-proc so the fluxzynetcap helper gets spawned under sudo.
+            proxyStartUpSetting.OutOfProcCapture = outOfProcCapture
+                || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FLUXZY_SUDO_PASSWORD_FILE"));
             proxyStartUpSetting.UseBouncyCastle = bouncyCastle;
             proxyStartUpSetting.SetEnableProcessTracking(enableProcessTracking);
             proxyStartUpSetting.SetIncludeAndroidEmulatorHost(!noAndroidEmulator);

--- a/test/Fluxzy.Tests/Startup.cs
+++ b/test/Fluxzy.Tests/Startup.cs
@@ -51,10 +51,28 @@ namespace Fluxzy.Tests
             CertificateContext.InstallDefaultCertificate();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                Task.Run(async () => { await Utility.AcquireCapabilitiesLinux(new FileInfo("fluxzynetcap").FullName);
-                        })
-                        .GetAwaiter().GetResult();
+                var passwordFile = FindRepoPasswordFile();
+
+                if (passwordFile != null) {
+                    Environment.SetEnvironmentVariable("FLUXZY_SUDO_PASSWORD_FILE", passwordFile);
+                }
             }
+        }
+
+        private static string? FindRepoPasswordFile()
+        {
+            var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+            while (dir != null) {
+                var candidate = Path.Combine(dir.FullName, ".password");
+
+                if (File.Exists(candidate))
+                    return candidate;
+
+                dir = dir.Parent;
+            }
+
+            return null;
         }
 
         public static string DirectoryName { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- When `FLUXZY_SUDO_PASSWORD_FILE` points to a readable file, `RunElevatedAsync` pipes the password to `sudo -S` instead of falling back to the interactive pkexec prompt.
- The CLI forces out-of-proc capture when the env var is set, so the privileged work happens in the `fluxzynetcap` child rather than the unprivileged host.
- Test `Startup` auto-populates the env var from a `.password` file walked up from the test working directory, letting pcap integration tests run without setcap on the dotnet host. `.password` is gitignored.