### PR TITLE
Fix H2 GOAWAY handling to track peer LastStreamId and drain reliably

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -40,7 +40,7 @@ namespace Fluxzy.Clients.H2
 
         private readonly CancellationTokenSource _connectionCancellationTokenSource = new();
 
-        private bool _goAwayInitByRemote;
+        private int _faultCallbackFired;
 
         private volatile bool _initDone;
 
@@ -109,7 +109,14 @@ namespace Fluxzy.Clients.H2
 
         public H2StreamSetting Setting { get; }
 
-        public bool Complete => _complete;
+        /// <summary>
+        ///     True once the pool is no longer accepting new exchanges — either because the
+        ///     connection has terminated (<see cref="_complete"/>) or the remote sent GOAWAY
+        ///     and the pool is draining in-flight streams (<see cref="StreamPool.IsDraining"/>).
+        ///     <see cref="PoolBuilder"/> uses this to route future exchanges to a fresh pool
+        ///     while existing in-flight streams continue to completion on this pool.
+        /// </summary>
+        public bool Complete => _complete || _streamPool.IsDraining;
 
         public void Init()
         {
@@ -146,27 +153,45 @@ namespace Fluxzy.Clients.H2
                 Complete: _complete,
                 CtsCancelled: _connectionCancellationTokenSource.IsCancellationRequested,
                 WriterChannelDrainedAndClosed: channelDrainedAndClosed,
-                WriterChannelPendingCount: pendingCount);
+                WriterChannelPendingCount: pendingCount,
+                Draining: _streamPool.IsDraining,
+                PeerLastStreamId: _streamPool.PeerLastStreamId,
+                GoAwayErrorCode: (_streamPool.GoAwayException as H2Exception)?.ErrorCode,
+                ActiveStreamCount: _streamPool.ActiveStreamCount);
         }
+
+        /// <summary>Test seam: direct access to the stream pool for unit-level assertions.</summary>
+        internal StreamPool StreamPoolForTests => _streamPool;
 
         public ValueTask<bool> CheckAlive()
         {
             var instant = ITimingProvider.Default.Instant();
 
+            // Fast path: a draining pool with no in-flight streams has nothing to do —
+            // tear down immediately without waiting for the idle timer. Prevents the pool
+            // from lingering in the dictionary after a graceful GOAWAY drained cleanly.
+            if (!_complete && _streamPool.IsDraining && _streamPool.ActiveStreamCount == 0) {
+                OnLoopEnd(null, true);
+                _logger.Trace(0, () => "Drain complete. Connection closed.");
+                return new ValueTask<bool>(false);
+            }
+
             if (!_complete && _streamPool.ActiveStreamCount == 0 &&
                 instant - _lastActivity > TimeSpan.FromSeconds(Setting.MaxIdleSeconds)) {
-                if (!_goAwayInitByRemote) {
+                // Only emit our own GOAWAY if the remote hasn't already sent us one.
+                // IsDraining is set exclusively by StreamPool.OnRemoteGoAway.
+                if (!_streamPool.IsDraining) {
                     try {
                         EmitGoAway(H2ErrorCode.NoError);
                     }
                     catch {
                         // Ignore go away error
                     }
-
-                    OnLoopEnd(null, true);
-
-                    _logger.Trace(0, () => "IDLE timeout. Connection closed.");
                 }
+
+                OnLoopEnd(null, true);
+
+                _logger.Trace(0, () => "IDLE timeout. Connection closed.");
 
                 return new ValueTask<bool>(false);
             }
@@ -195,11 +220,17 @@ namespace Fluxzy.Clients.H2
                 if (ex is OperationCanceledException opex
                     && cancellationToken != default
                     && opex.CancellationToken == cancellationToken) {
-                    // The caller cancels this exchange. 
-                    // Send a reset on stream to prevent the remote 
+                    // The caller cancels this exchange.
+                    // Send a reset on stream to prevent the remote
                 }
 
-                OnLoopEnd(ex, true);
+                // ConnectionCloseException here means either (a) the pool was already
+                // draining/complete when the exchange arrived, or (b) this stream was
+                // proactively abandoned because the server's GOAWAY LastStreamId ruled
+                // it out. Neither case is a pool-level transport failure — other
+                // in-flight streams on this pool may still complete. Skip OnLoopEnd.
+                if (ex is not ConnectionCloseException)
+                    OnLoopEnd(ex, true);
 
                 throw;
             }
@@ -262,24 +293,54 @@ namespace Fluxzy.Clients.H2
 
         private void EmitGoAway(H2ErrorCode errorCode)
         {
-            var goAwayFrame = new GoAwayFrame(_streamPool.LastStreamIdentifier, errorCode);
-            var buffer = new byte[9 + goAwayFrame.BodyLength];
-
-            goAwayFrame.Write(buffer);
-
+            var buffer = BuildGoAwayBytes(errorCode);
             var writeTask = new WriteTask(H2FrameType.Goaway, 0, 0, 0, buffer);
             UpStreamChannel(ref writeTask);
         }
 
+        /// <summary>
+        ///     Serialise a GOAWAY frame for emission from this pool.
+        ///     <para>
+        ///         RFC 9113 §6.8: LastStreamId carries the last *peer-initiated* stream
+        ///         id the sender processed. For a client with SETTINGS_ENABLE_PUSH=0 (our
+        ///         default, see <see cref="H2StreamSetting.Local"/>.EnablePush), the peer
+        ///         opens zero streams, so the correct value is 0. Writing
+        ///         <c>_streamPool.LastStreamIdentifier</c> (our own outgoing last id) would
+        ///         mis-signal which server-initiated streams were processed, and worse
+        ///         would emit the sentinel -1 on an early GOAWAY.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     Extracted from <see cref="EmitGoAway"/> as an <c>internal</c> test seam so
+        ///     the LastStreamId=0 invariant can be asserted deterministically without
+        ///     racing the writer loop (which may cancel the queued WriteTask if
+        ///     <c>OnLoopEnd</c> fires before it drains).
+        /// </remarks>
+        internal static byte[] BuildGoAwayBytes(H2ErrorCode errorCode)
+        {
+            const int lastProcessedPeerStreamId = 0;
+            var goAwayFrame = new GoAwayFrame(lastProcessedPeerStreamId, errorCode);
+            var buffer = new byte[9 + goAwayFrame.BodyLength];
+
+            goAwayFrame.Write(buffer);
+
+            return buffer;
+        }
+
         private void OnGoAway(ref GoAwayFrame frame)
         {
-            _goAwayInitByRemote = true;
+            // Build the cause synchronously so StreamPool.OnRemoteGoAway can surface it
+            // via GoAwayException. Non-NoError error codes must never be silently dropped
+            // — callers rely on the code to decide whether to retry on a fresh connection.
+            var cause = frame.ErrorCode == H2ErrorCode.NoError
+                ? null
+                : new H2Exception($"Remote GOAWAY {frame.ErrorCode}", frame.ErrorCode);
 
-            if (frame.ErrorCode == H2ErrorCode.CompressionError)
-                Console.WriteLine("Compression error");
-
-            if (frame.ErrorCode != H2ErrorCode.NoError)
-                throw new H2Exception($"Had to goaway {frame.ErrorCode}", frame.ErrorCode);
+            // Flip the pool into draining mode. The read loop keeps running so in-flight
+            // streams with id <= frame.LastStreamId can finish on this pool; new exchanges
+            // route to a fresh pool via Complete=true. Proactive abandonment of
+            // id > frame.LastStreamId streams happens inside OnRemoteGoAway.
+            _streamPool.OnRemoteGoAway(frame.LastStreamId, frame.ErrorCode, cause);
         }
 
         private void OnLoopEnd(Exception? ex, bool releaseChannelItems)
@@ -306,8 +367,11 @@ namespace Fluxzy.Clients.H2
             // completed and drained, and all pending write tasks have been
             // signalled. Disposal can then run safely without racing OnLoopEnd.
 
+            // Transport-level failure without a prior GOAWAY: surface the cause through
+            // the stream pool so any stream that's currently in Send() observes a
+            // meaningful GoAwayException. No-op if a GOAWAY already recorded a cause.
             if (ex != null)
-                _streamPool.OnGoAway(ex);
+                _streamPool.OnRemoteGoAway(_streamPool.PeerLastStreamId, H2ErrorCode.InternalError, ex);
 
             if (!_connectionCancellationTokenSource.IsCancellationRequested)
                 _connectionCancellationTokenSource.Cancel();
@@ -325,8 +389,13 @@ namespace Fluxzy.Clients.H2
                 }
             }
 
-            // Notify last so the callback observes a fully-quiesced pool.
-            _onConnectionFaulted?.Invoke(this);
+            // Notify last so the callback observes a fully-quiesced pool. Use a
+            // CAS-guarded fire so concurrent teardown paths (read-loop exit racing
+            // with idle CheckAlive, or Send-path error racing with transport close)
+            // cannot double-evict the pool from PoolBuilder or double-schedule
+            // disposal via ObserveDisposal.
+            if (Interlocked.CompareExchange(ref _faultCallbackFired, 1, 0) == 0)
+                _onConnectionFaulted?.Invoke(this);
 
             _logger.Trace(0, "Cleanup end");
         }
@@ -493,8 +562,11 @@ namespace Fluxzy.Clients.H2
                 _logger.TraceDeep(0, () => "OperationCanceledException death");
             }
             catch (Exception ex) {
-                if (!_goAwayInitByRemote)
-                    outException = ex;
+                // Surface the cause verbatim. Previously this was gated on a
+                // _goAwayInitByRemote flag to suppress the synthetic H2Exception that
+                // OnGoAway used to throw; with OnGoAway no longer throwing, the gate
+                // is dead and any exception reaching here is a genuine transport fault.
+                outException = ex;
             }
             finally {
                 OnLoopEnd(outException, false);
@@ -646,7 +718,11 @@ namespace Fluxzy.Clients.H2
 
                 OnGoAway(ref goAwayFrame);
 
-                return goAwayFrame.ErrorCode != H2ErrorCode.NoError;
+                // Do NOT break the read loop here. In-flight streams with id <= LastStreamId
+                // are still expected to receive HEADERS/DATA/RST/trailers from the server.
+                // The loop exits naturally when the server half-closes the transport or the
+                // idle CheckAlive fast path fires once draining completes.
+                return false;
             }
 
             return false;
@@ -656,7 +732,11 @@ namespace Fluxzy.Clients.H2
             bool Complete,
             bool CtsCancelled,
             bool WriterChannelDrainedAndClosed,
-            int WriterChannelPendingCount);
+            int WriterChannelPendingCount,
+            bool Draining = false,
+            int PeerLastStreamId = int.MaxValue,
+            H2ErrorCode? GoAwayErrorCode = null,
+            int ActiveStreamCount = 0);
 
         private async ValueTask InternalSend(
             Exchange exchange, RsBuffer buffer,
@@ -763,6 +843,16 @@ namespace Fluxzy.Clients.H2
                 // and set to RequestHeaderSent for no-body requests (above).
             }
             catch (OperationCanceledException opex) {
+                // Abandonment-by-GOAWAY surfaces here as OCE because AbandonAsRetryable
+                // cancels the stream CTS. Rewrap as ConnectionCloseException so the
+                // orchestrator (ProxyOrchestrator.cs:524) treats it as retryable and
+                // Send() skips the pool-level OnLoopEnd teardown.
+                if (activeStream != null && activeStream.AbandonedByGoAway) {
+                    throw new ConnectionCloseException(
+                        "Stream abandoned after remote GOAWAY; request was not processed",
+                        activeStream.AbandonInnerCause);
+                }
+
                 if (activeStream != null &&
                     opex.CancellationToken == callerCancellationToken)
 

--- a/src/Fluxzy.Core/Clients/H2/StreamPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamPool.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Fluxzy.Clients.H2.Frames;
 using Fluxzy.Core;
 using Org.BouncyCastle.Utilities.IO;
 
@@ -16,7 +17,7 @@ namespace Fluxzy.Clients.H2
         private readonly ConcurrentDictionary<int, StreamWorker> _runningStreams = new();
 
         private int _lastStreamIdentifier = -1;
-        private bool _onError;
+        private volatile bool _draining;
 
         private int _overallWindowSize;
 
@@ -30,12 +31,22 @@ namespace Fluxzy.Clients.H2
 
         public StreamContext Context { get; }
 
-        // WARNING : to be improved, may be extreme volatile 
+        // WARNING : to be improved, may be extreme volatile
         public int ActiveStreamCount => _runningStreams.Count;
 
         internal Exception? GoAwayException { get; private set; }
 
         internal int LastStreamIdentifier => _lastStreamIdentifier;
+
+        /// <summary>
+        ///     Last stream id the peer reported as processed in a received GOAWAY.
+        ///     <c>int.MaxValue</c> until a GOAWAY arrives (meaning "all current streams are
+        ///     in range"). After GOAWAY, streams with <c>id &gt; PeerLastStreamId</c> are
+        ///     guaranteed by RFC 9113 §6.8 to not have been processed and are safe to retry.
+        /// </summary>
+        internal int PeerLastStreamId { get; private set; } = int.MaxValue;
+
+        internal bool IsDraining => _draining;
 
         public ValueTask DisposeAsync()
         {
@@ -57,8 +68,9 @@ namespace Fluxzy.Clients.H2
             CancellationToken callerCancellationToken,
             SemaphoreSlim ongoingStreamInit, CancellationTokenSource resetTokenSource)
         {
-            if (_onError)
-                throw new InvalidOperationException("This connection is on error");
+            if (_draining)
+                throw new ConnectionCloseException(
+                    "This connection is draining after receiving GOAWAY", GoAwayException);
 
             await ongoingStreamInit.WaitAsync(callerCancellationToken).ConfigureAwait(false);
 
@@ -82,8 +94,9 @@ namespace Fluxzy.Clients.H2
             CancellationToken callerCancellationToken, SemaphoreSlim ongoingStreamInit,
             CancellationTokenSource resetTokenSource)
         {
-            if (_onError)
-                throw new ConnectionCloseException("This connection is on error");
+            if (_draining)
+                throw new ConnectionCloseException(
+                    "This connection is draining after receiving GOAWAY", GoAwayException);
 
             if (!_maxConcurrentStreamBarrier.Wait(TimeSpan.Zero))
                 await _maxConcurrentStreamBarrier.WaitAsync(callerCancellationToken).ConfigureAwait(false);
@@ -96,7 +109,7 @@ namespace Fluxzy.Clients.H2
 
         public void NotifyDispose(StreamWorker streamWorker)
         {
-            // reset can happens here 
+            // reset can happens here
 
             if (_runningStreams.TryRemove(streamWorker.StreamIdentifier, out _)) {
                 _maxConcurrentStreamBarrier.Release();
@@ -106,17 +119,37 @@ namespace Fluxzy.Clients.H2
 
         public void NotifyInitialWindowChange(int newInitialWindow)
         {
-            foreach (var kvp in _runningStreams)         
+            foreach (var kvp in _runningStreams)
             {
                 StreamWorker worker = kvp.Value;
                 worker.RemoteWindowSize.UpdateInitialWindowSize(newInitialWindow);
             }
         }
 
-        public void OnGoAway(Exception? ex)
+        /// <summary>
+        ///     Record a received GOAWAY from the remote peer. Always flips the pool to
+        ///     draining (no new streams), persists the peer-reported last-processed
+        ///     stream id, and proactively abandons any in-flight streams whose id
+        ///     exceeds it — per RFC 9113 §6.8 those streams were not processed by the
+        ///     server and are safe to retry on a fresh connection.
+        /// </summary>
+        /// <param name="peerLastStreamId">The <c>LastStreamId</c> field of the GOAWAY.</param>
+        /// <param name="errorCode">The error code carried by the GOAWAY.</param>
+        /// <param name="cause">
+        ///     Non-null for error-coded GOAWAYs. Becomes the inner exception of the
+        ///     retryable <see cref="ConnectionCloseException"/> surfaced to callers.
+        /// </param>
+        public void OnRemoteGoAway(int peerLastStreamId, H2ErrorCode errorCode, Exception? cause)
         {
-            _onError = ex != null;
-            GoAwayException = ex;
+            PeerLastStreamId = peerLastStreamId;
+            GoAwayException = cause;
+            _draining = true;
+
+            foreach (var kvp in _runningStreams) {
+                if (kvp.Key > peerLastStreamId) {
+                    kvp.Value.AbandonAsRetryable(cause);
+                }
+            }
         }
 
         public int ShouldWindowUpdate(int dataLength)

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -32,6 +32,9 @@ namespace Fluxzy.Clients.H2
         private bool _noBodyStream;
         private bool _responseHeadersComplete;
 
+        private volatile bool _abandonedByGoAway;
+        private Exception? _abandonInnerCause;
+
         private int _totalBodyReceived;
 
         private int _totalHeaderReceived;
@@ -128,6 +131,43 @@ namespace Fluxzy.Clients.H2
         public void NotifyStreamWindowUpdate(int windowSizeUpdateValue)
         {
             RemoteWindowSize.UpdateWindowSize(windowSizeUpdateValue);
+        }
+
+        /// <summary>
+        ///     True once <see cref="AbandonAsRetryable"/> has been called — the server's
+        ///     GOAWAY indicated this stream was not processed.
+        /// </summary>
+        internal bool AbandonedByGoAway => _abandonedByGoAway;
+
+        internal Exception? AbandonInnerCause => _abandonInnerCause;
+
+        /// <summary>
+        ///     Proactively fail this stream as retryable because the remote sent GOAWAY
+        ///     with a <c>LastStreamId</c> below this stream's id. RFC 9113 §6.8 guarantees
+        ///     the server did not process it, so the orchestrator may safely reissue the
+        ///     exchange on a new connection.
+        ///     <para>
+        ///         Sets the abandon marker and cancels the stream's CTS so any in-flight
+        ///         awaits (header-received semaphore, window booking, body read) unblock
+        ///         with <see cref="OperationCanceledException"/>. The OCE catch paths
+        ///         upstream check <see cref="AbandonedByGoAway"/> and rewrap as
+        ///         <see cref="ConnectionCloseException"/> before returning to
+        ///         <see cref="H2ConnectionPool.Send"/>.
+        ///     </para>
+        /// </summary>
+        internal void AbandonAsRetryable(Exception? goAwayCause)
+        {
+            _abandonInnerCause = goAwayCause;
+            _abandonedByGoAway = true;
+
+            if (!_resetTokenSource.IsCancellationRequested) {
+                try {
+                    _resetTokenSource.Cancel();
+                }
+                catch (ObjectDisposedException) {
+                    // CTS already disposed — stream is tearing down on another path.
+                }
+            }
         }
 
         public void ResetByCaller(H2ErrorCode reason = H2ErrorCode.StreamClosed)
@@ -434,6 +474,13 @@ namespace Fluxzy.Clients.H2
             }
             catch (OperationCanceledException) {
                 _logger.Trace(StreamIdentifier, $"Received no header, cancelled by caller {StreamIdentifier}");
+
+                if (_abandonedByGoAway) {
+                    Parent.NotifyDispose(this);
+                    throw new ConnectionCloseException(
+                        "Stream abandoned after remote GOAWAY; request was not processed",
+                        _abandonInnerCause);
+                }
 
                 throw new ClientErrorException(1,
                     "The connection was interrupted before receiving response header");

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolGoAwayTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolGoAwayTests.cs
@@ -1,0 +1,299 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Clients.H2.Frames;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    /// <summary>
+    ///     Reliability tests for HTTP/2 GOAWAY handling in <see cref="H2ConnectionPool"/>,
+    ///     covering the four structural defects that produced the escalating
+    ///     <c>OperationCanceledException</c> pattern documented in
+    ///     haga-rak/fluxzy.core#634:
+    ///
+    ///     <list type="number">
+    ///         <item>The peer-reported <c>LastStreamId</c> was ignored.</item>
+    ///         <item>Graceful GOAWAY never set the pool into draining mode, so new
+    ///               exchanges kept allocating doomed stream ids on the pool.</item>
+    ///         <item>Non-NoError GOAWAY error codes were silently dropped by
+    ///               <c>_goAwayInitByRemote</c>-gated exception suppression.</item>
+    ///         <item>Client-emitted GOAWAY frames carried our own outgoing
+    ///               <c>LastStreamIdentifier</c> instead of the 0 required by RFC 9113
+    ///               §6.8 for a client with push disabled.</item>
+    ///     </list>
+    /// </summary>
+    public class H2ConnectionPoolGoAwayTests
+    {
+        // ------------------------------------------------------------------
+        // Test: graceful GOAWAY flips the pool into draining mode
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task RemoteGracefulGoAway_PutsPoolInDrainingMode_AndMarksComplete()
+        {
+            using var pipe = new DuplexPipe();
+            var (pool, _) = CreatePool(pipe);
+            pool.Init();
+
+            // Server sends GOAWAY(NoError, lastStreamId=7)
+            await SendServerGoAway(pipe, lastStreamId: 7, H2ErrorCode.NoError);
+
+            // Wait for the read loop to observe the frame and call OnGoAway.
+            await WaitForDrainingAsync(pool);
+
+            var snap = pool.SnapshotForTests();
+
+            Assert.True(snap.Draining, "pool must be draining after graceful GOAWAY");
+            Assert.True(pool.Complete, "pool.Complete must be true once draining so PoolBuilder evicts");
+            Assert.Equal(7, snap.PeerLastStreamId);
+            Assert.Null(snap.GoAwayErrorCode);
+
+            await pool.DisposeAsync();
+        }
+
+        // ------------------------------------------------------------------
+        // Test: error GOAWAY preserves the error code through the read loop
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task RemoteErrorGoAway_PreservesErrorCode()
+        {
+            using var pipe = new DuplexPipe();
+            var (pool, _) = CreatePool(pipe);
+            pool.Init();
+
+            await SendServerGoAway(pipe, lastStreamId: 0, H2ErrorCode.EnhanceYourCalm);
+
+            await WaitForDrainingAsync(pool);
+
+            var snap = pool.SnapshotForTests();
+
+            Assert.True(snap.Draining);
+            Assert.Equal(H2ErrorCode.EnhanceYourCalm, snap.GoAwayErrorCode);
+            Assert.NotNull(pool.StreamPoolForTests.GoAwayException);
+            Assert.IsType<H2Exception>(pool.StreamPoolForTests.GoAwayException);
+
+            await pool.DisposeAsync();
+        }
+
+        // ------------------------------------------------------------------
+        // Test: persisted peer LastStreamId
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task RemoteGoAway_PersistsPeerLastStreamId()
+        {
+            using var pipe = new DuplexPipe();
+            var (pool, _) = CreatePool(pipe);
+            pool.Init();
+
+            await SendServerGoAway(pipe, lastStreamId: 42, H2ErrorCode.NoError);
+
+            await WaitForDrainingAsync(pool);
+
+            Assert.Equal(42, pool.SnapshotForTests().PeerLastStreamId);
+            Assert.Equal(42, pool.StreamPoolForTests.PeerLastStreamId);
+
+            await pool.DisposeAsync();
+        }
+
+        // ------------------------------------------------------------------
+        // Test: StreamPool after draining rejects new stream creation
+        // ------------------------------------------------------------------
+        [Fact]
+        public void StreamPool_AfterDraining_RejectsNewStreamCreation()
+        {
+            var pool = CreateBareStreamPool();
+
+            pool.OnRemoteGoAway(peerLastStreamId: 1, H2ErrorCode.NoError, cause: null);
+
+            var ex = Assert.Throws<ConnectionCloseException>(() =>
+                pool.CreateNewStreamProcessing(
+                    exchange: MakeExchange(),
+                    callerCancellationToken: CancellationToken.None,
+                    ongoingStreamInit: new SemaphoreSlim(1, 1),
+                    resetTokenSource: new CancellationTokenSource())
+                    .AsTask().GetAwaiter().GetResult());
+
+            Assert.Contains("draining", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // ------------------------------------------------------------------
+        // Test: StreamPool proactively abandons streams above peer LastStreamId
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task StreamPool_OnRemoteGoAway_AbandonsStreamsAboveLastStreamId()
+        {
+            var pool = CreateBareStreamPool();
+            var creationLock = new SemaphoreSlim(1, 1);
+
+            var resetCts1 = new CancellationTokenSource();
+            var resetCts3 = new CancellationTokenSource();
+
+            var stream1 = await pool.CreateNewStreamProcessing(
+                MakeExchange(), CancellationToken.None, creationLock, resetCts1);
+
+            // In production H2ConnectionPool.InternalSend releases the per-pool creation
+            // lock in its finally block; the bare pool fixture has no such caller, so
+            // release here to let the second stream's init proceed.
+            creationLock.Release();
+
+            var stream3 = await pool.CreateNewStreamProcessing(
+                MakeExchange(), CancellationToken.None, creationLock, resetCts3);
+
+            creationLock.Release();
+
+            // Sanity: client-initiated stream ids are odd and increase by 2
+            Assert.Equal(1, stream1.StreamIdentifier);
+            Assert.Equal(3, stream3.StreamIdentifier);
+
+            pool.OnRemoteGoAway(peerLastStreamId: 1, H2ErrorCode.NoError, cause: null);
+
+            Assert.False(stream1.AbandonedByGoAway, "stream 1 is in range (id <= 1), must NOT be abandoned");
+            Assert.True(stream3.AbandonedByGoAway, "stream 3 exceeds lastStreamId, must be proactively abandoned");
+            Assert.True(resetCts3.IsCancellationRequested, "abandonment must cancel the stream's reset CTS");
+            Assert.False(resetCts1.IsCancellationRequested, "in-range streams must not be cancelled");
+        }
+
+        // ------------------------------------------------------------------
+        // Test: emitted GOAWAY carries LastStreamId=0 (RFC 9113 §6.8 compliance)
+        //
+        // Asserts the invariant directly at the frame-build seam rather than through
+        // an end-to-end write, because CheckAlive's idle path queues the GOAWAY on
+        // the writer channel and then immediately calls OnLoopEnd, which cancels the
+        // task before the writer loop drains it — a pre-existing best-effort
+        // behaviour. The seam guarantees the LastStreamId never leaks our own outgoing
+        // _lastStreamIdentifier (which is -1 before any stream is opened, causing a
+        // protocol-invalid negative value on the wire).
+        // ------------------------------------------------------------------
+        [Theory]
+        [InlineData(H2ErrorCode.NoError)]
+        [InlineData(H2ErrorCode.EnhanceYourCalm)]
+        [InlineData(H2ErrorCode.InternalError)]
+        public void EmittedGoAway_CarriesZeroLastStreamId(H2ErrorCode errorCode)
+        {
+            var bytes = H2ConnectionPool.BuildGoAwayBytes(errorCode);
+
+            // Skip the 9-byte frame header; GoAwayFrame's span constructor reads the body.
+            var frame = new GoAwayFrame(bytes.AsSpan(9));
+
+            Assert.Equal(0, frame.LastStreamId);
+            Assert.Equal(errorCode, frame.ErrorCode);
+        }
+
+        // ------------------------------------------------------------------
+        // Test: GOAWAY followed by transport EOF fires fault callback exactly once
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task OnGoAwayThenEof_DoesNotDoubleInvokeFaultCallback()
+        {
+            using var pipe = new DuplexPipe();
+            var callbackInvocations = 0;
+
+            var (pool, _) = CreatePool(pipe,
+                onFault: _ => Interlocked.Increment(ref callbackInvocations));
+
+            pool.Init();
+
+            await SendServerGoAway(pipe, lastStreamId: 0, H2ErrorCode.NoError);
+            await WaitForDrainingAsync(pool);
+
+            // Now simulate transport close — the read loop exits and OnLoopEnd fires.
+            pipe.ServerWriteStream.Close();
+
+            await pool.DisposeAsync();
+
+            Assert.Equal(1, callbackInvocations);
+        }
+
+        // ==================================================================
+        // Helpers
+        // ==================================================================
+
+        private static (H2ConnectionPool pool, Connection conn) CreatePool(
+            DuplexPipe pipe, Action<H2ConnectionPool>? onFault = null)
+        {
+            var baseStream = new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream);
+
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting();
+            var connection = new Connection(authority, new TestIdProvider());
+
+            var pool = new H2ConnectionPool(
+                baseStream,
+                setting,
+                authority,
+                connection,
+                onConnectionFaulted: onFault ?? (_ => { }));
+
+            return (pool, connection);
+        }
+
+        private static async Task SendServerGoAway(
+            DuplexPipe pipe, int lastStreamId, H2ErrorCode errorCode)
+        {
+            var bytes = H2FrameHelper.BuildGoAway(lastStreamId, errorCode);
+            await pipe.ServerWriteStream.WriteAsync(bytes);
+            await pipe.ServerWriteStream.FlushAsync();
+        }
+
+        private static async Task WaitForDrainingAsync(H2ConnectionPool pool)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            while (!pool.SnapshotForTests().Draining) {
+                if (sw.Elapsed > TimeSpan.FromSeconds(5))
+                    throw new TimeoutException("Pool did not enter draining mode within 5s.");
+
+                await Task.Delay(5);
+            }
+        }
+
+        // -- Bare StreamPool fixture (no H2ConnectionPool wrapper) ---------
+
+        private static StreamPool CreateBareStreamPool()
+        {
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting();
+            var logger = new H2Logger(authority, -1);
+
+            var hpackEncoder = new HPackEncoder(
+                new EncodingContext(ArrayPoolMemoryProvider<char>.Default));
+            var hpackDecoder = new HPackDecoder(
+                new DecodingContext(authority, ArrayPoolMemoryProvider<char>.Default));
+            var headerEncoder = new HeaderEncoder(hpackEncoder, hpackDecoder, setting);
+
+            var overallWindow = new WindowSizeHolder(logger, setting.OverallWindowSize, 0);
+
+            UpStreamChannel noopChannel = (ref WriteTask _) => { };
+
+            var context = new StreamContext(
+                connectionId: 1,
+                authority: authority,
+                setting: setting,
+                logger: logger,
+                headerEncoder: headerEncoder,
+                upStreamChannel: noopChannel,
+                overallWindowSizeHolder: overallWindow);
+
+            return new StreamPool(context);
+        }
+
+        private static Exchange MakeExchange()
+        {
+            var authority = new Authority("test.local", 443, true);
+            var header = "GET / HTTP/2.0\r\nhost: test.local\r\n\r\n".AsMemory();
+
+            return new Exchange(new TestIdProvider(), authority, header,
+                httpVersion: "HTTP/2", DateTime.UtcNow);
+        }
+    }
+}


### PR DESCRIPTION
Reworks the client-side GOAWAY state machine in `H2ConnectionPool`, suspected root cause of #634.

Fixes four structural defects:

1. `OnGoAway` ignored `frame.LastStreamId`.
2. Graceful GOAWAY (`NoError`) never flipped the pool out of accepting new streams. Strongest candidate for #634.
3. Non-`NoError` GOAWAYs lost their error code via `_goAwayInitByRemote` suppression.
4. Emitted GOAWAY carried our own outgoing `_lastStreamIdentifier` instead of the zero required by RFC 9113 section 6.8 for a client with push disabled.

`StreamPool` now exposes `PeerLastStreamId` and a single `OnRemoteGoAway` entry point that sets draining mode regardless of error code and proactively abandons streams with `id > PeerLastStreamId` as retryable `ConnectionCloseException`. `H2ConnectionPool.Complete` returns true while draining so `PoolBuilder` evicts the pool. The fault callback is CAS-guarded to prevent double-eviction.