### PR TITLE
Fix flaky WS req/res test and 64-bit frame length parsing

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/WebSocketStream.cs
+++ b/src/Fluxzy.Core/Clients/H11/WebSocketStream.cs
@@ -138,8 +138,8 @@ namespace Fluxzy.Clients.H11
                     byteIndex += 2;
                 }
                 else {
-                    if (startBuffer.Length < 4)
-                        return -1; // Not enough data 
+                    if (startBuffer.Length < 8)
+                        return -1; // Not enough data
 
                     wsFrame.PayloadLength = BinaryPrimitives.ReadInt64BigEndian(startBuffer);
                     byteIndex += 8;

--- a/test/Fluxzy.Tests/Cli/CliWebSockets.cs
+++ b/test/Fluxzy.Tests/Cli/CliWebSockets.cs
@@ -130,7 +130,16 @@ namespace Fluxzy.Tests.Cli
 
                 Assert.Equal(expectedHash, resultHash);
 
-                await Task.Delay(200);
+                // Clean close so the proxy finishes writing the sent message to the
+                // archive before fluxzyInstance disposal — abrupt Dispose races with
+                // InitRead on slow CI and can leave the archive without the Sent entry.
+                try {
+                    using var closeCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", closeCts.Token);
+                }
+                catch {
+                    // best effort; fall through to dispose
+                }
             }
 
             using (IArchiveReader archiveReader = new DirectoryArchiveReader(directoryName)) {


### PR DESCRIPTION
## Summary
- Replace abrupt `ws.Dispose` + `Task.Delay(200)` in `Run_Cli_For_Web_Socket_Req_Res` with a clean `CloseAsync`, closing a long-standing race where `InitRead` could miss committing the Sent entry to the archive before `fluxzyInstance` disposal on slow CI.
- Fix `TryReadWsFrameHeader`: the 127 (8-byte extended length) branch checked `startBuffer.Length < 4` but then called `ReadInt64BigEndian`, which needs 8 bytes.