### PR TITLE
Move H2 idle teardown to per-connection timer

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -65,11 +65,6 @@ namespace Fluxzy.Clients.H11
         {
         }
 
-        public ValueTask<bool> CheckAlive()
-        {
-            return new ValueTask<bool>(true);
-        }
-
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe downstreamPipe, RsBuffer buffer, ExchangeScope exchangeScope,
             CancellationToken cancellationToken)

--- a/src/Fluxzy.Core/Clients/H11/TunnelOnlyConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/TunnelOnlyConnectionPool.cs
@@ -46,11 +46,6 @@ namespace Fluxzy.Clients.H11
         {
         }
 
-        public ValueTask<bool> CheckAlive()
-        {
-            return new ValueTask<bool>(!Complete);
-        }
-
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe downStreamPipe, RsBuffer buffer, ExchangeScope __,
             CancellationToken cancellationToken = default)

--- a/src/Fluxzy.Core/Clients/H11/WebsocketConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/WebsocketConnectionPool.cs
@@ -45,11 +45,6 @@ namespace Fluxzy.Clients.H11
         {
         }
 
-        public ValueTask<bool> CheckAlive()
-        {
-            return new ValueTask<bool>(!Complete);
-        }
-
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe downStreamPipe, RsBuffer buffer, ExchangeScope __,
             CancellationToken cancellationToken = default)

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -47,10 +47,13 @@ namespace Fluxzy.Clients.H2
         private Task? _innerReadTask;
         private Task? _innerWriteRun;
 
+        private PeriodicTimer? _idleTimer;
+        private Task? _idleMonitorTask;
+
         private DateTime _lastActivity = ITimingProvider.Default.Instant();
 
         /// <summary>
-        ///     Test seam: allows tests to force the idle path of <see cref="CheckAlive"/>
+        ///     Test seam: allows tests to force the idle path of <see cref="TryIdleTeardown"/>
         ///     deterministically without resorting to reflection or wall-clock waits.
         /// </summary>
         internal DateTime LastActivity {
@@ -130,6 +133,104 @@ namespace Fluxzy.Clients.H2
 
             _innerReadTask = InternalReadLoop(_connectionToken);
             _innerWriteRun = InternalWriteLoop(_connectionToken);
+
+            // Per-connection idle teardown. Replaces the centralized PoolBuilder
+            // sweeper (the old async-void CheckPoolStatus loop). Tick is bounded
+            // so that very large MaxIdleSeconds values still observe Cancel/Dispose
+            // promptly; the lower bound keeps the test-only MaxIdleSeconds=0 case
+            // ticking instead of busy-spinning.
+            var tickSeconds = Math.Clamp(Setting.MaxIdleSeconds, 1, 30);
+            _idleTimer = new PeriodicTimer(TimeSpan.FromSeconds(tickSeconds));
+            _idleMonitorTask = MonitorIdleAsync(_idleTimer, _connectionToken);
+        }
+
+        private async Task MonitorIdleAsync(PeriodicTimer timer, CancellationToken token)
+        {
+            try {
+                while (await timer.WaitForNextTickAsync(token).ConfigureAwait(false)) {
+                    if (TryIdleTeardown())
+                        return;
+                }
+            }
+            catch (OperationCanceledException) {
+                // Disposal path — expected.
+            }
+            catch (Exception) {
+                // Never propagate from the background loop; the prior async-void
+                // shape made this fatal (haga-rak/fluxzy.core#614). The teardown
+                // path itself is best-effort, so swallowing is correct here.
+            }
+        }
+
+        /// <summary>
+        ///     Returns <c>true</c> when the monitor loop should stop — either the pool
+        ///     is already torn down, or this call performed the teardown. Returns
+        ///     <c>false</c> when the pool is still in use and another tick is needed.
+        ///
+        ///     Snapshot + teardown happen under <see cref="_streamCreationLock"/> so a
+        ///     concurrent <see cref="Send"/> cannot allocate a stream id on a connection
+        ///     that is about to send GOAWAY. <see cref="SemaphoreSlim.Wait(int)"/> with
+        ///     timeout 0 means "yield this tick if a Send is mid-flight" — a Send in
+        ///     progress is itself proof the connection is not idle.
+        /// </summary>
+        internal bool TryIdleTeardown()
+        {
+            if (_complete) return true;
+            if (_streamPool.ActiveStreamCount != 0) return false;
+
+            // Fast path: a draining pool with no in-flight streams has nothing to do —
+            // tear down immediately without waiting for the idle timer. Prevents the pool
+            // from lingering in the dictionary after a graceful GOAWAY drained cleanly.
+            if (_streamPool.IsDraining) {
+                if (!_streamCreationLock.Wait(0)) return false;
+                try {
+                    if (_complete) return true;
+                    if (_streamPool.ActiveStreamCount != 0) return false;
+
+                    OnLoopEnd(null, true);
+                    _logger.Trace(0, () => "Drain complete. Connection closed.");
+                    return true;
+                }
+                finally {
+                    _streamCreationLock.Release();
+                }
+            }
+
+            var instant = ITimingProvider.Default.Instant();
+            if (instant - _lastActivity <= TimeSpan.FromSeconds(Setting.MaxIdleSeconds))
+                return false;
+
+            if (!_streamCreationLock.Wait(0))
+                return false;
+
+            try {
+                if (_complete) return true;
+                if (_streamPool.ActiveStreamCount != 0) return false;
+
+                instant = ITimingProvider.Default.Instant();
+                if (instant - _lastActivity <= TimeSpan.FromSeconds(Setting.MaxIdleSeconds))
+                    return false;
+
+                // Only emit our own GOAWAY if the remote hasn't already sent us one.
+                // IsDraining is set exclusively by StreamPool.OnRemoteGoAway.
+                if (!_streamPool.IsDraining) {
+                    try {
+                        EmitGoAway(H2ErrorCode.NoError);
+                    }
+                    catch {
+                        // Best-effort GOAWAY; teardown proceeds either way.
+                    }
+                }
+
+                OnLoopEnd(null, true);
+
+                _logger.Trace(0, () => "IDLE timeout. Connection closed.");
+
+                return true;
+            }
+            finally {
+                _streamCreationLock.Release();
+            }
         }
 
         /// <summary>
@@ -162,42 +263,6 @@ namespace Fluxzy.Clients.H2
 
         /// <summary>Test seam: direct access to the stream pool for unit-level assertions.</summary>
         internal StreamPool StreamPoolForTests => _streamPool;
-
-        public ValueTask<bool> CheckAlive()
-        {
-            var instant = ITimingProvider.Default.Instant();
-
-            // Fast path: a draining pool with no in-flight streams has nothing to do —
-            // tear down immediately without waiting for the idle timer. Prevents the pool
-            // from lingering in the dictionary after a graceful GOAWAY drained cleanly.
-            if (!_complete && _streamPool.IsDraining && _streamPool.ActiveStreamCount == 0) {
-                OnLoopEnd(null, true);
-                _logger.Trace(0, () => "Drain complete. Connection closed.");
-                return new ValueTask<bool>(false);
-            }
-
-            if (!_complete && _streamPool.ActiveStreamCount == 0 &&
-                instant - _lastActivity > TimeSpan.FromSeconds(Setting.MaxIdleSeconds)) {
-                // Only emit our own GOAWAY if the remote hasn't already sent us one.
-                // IsDraining is set exclusively by StreamPool.OnRemoteGoAway.
-                if (!_streamPool.IsDraining) {
-                    try {
-                        EmitGoAway(H2ErrorCode.NoError);
-                    }
-                    catch {
-                        // Ignore go away error
-                    }
-                }
-
-                OnLoopEnd(null, true);
-
-                _logger.Trace(0, () => "IDLE timeout. Connection closed.");
-
-                return new ValueTask<bool>(false);
-            }
-
-            return new ValueTask<bool>(true);
-        }
 
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe _, RsBuffer buffer, ExchangeScope __,
@@ -251,6 +316,11 @@ namespace Fluxzy.Clients.H2
 
             _overallWindowSizeHolder?.Dispose();
 
+            // Stop the idle monitor first: PeriodicTimer.Dispose causes any pending
+            // WaitForNextTickAsync to return false, so the monitor exits cleanly
+            // without observing a cancelled CTS.
+            _idleTimer?.Dispose();
+
             _logger.Trace(0, () => "Disposed");
             _connectionCancellationTokenSource?.Cancel();
             _connectionCancellationTokenSource?.Dispose();
@@ -265,6 +335,15 @@ namespace Fluxzy.Clients.H2
 
             if (_innerWriteRun != null)
                 await _innerWriteRun.ConfigureAwait(false);
+
+            if (_idleMonitorTask != null) {
+                try {
+                    await _idleMonitorTask.ConfigureAwait(false);
+                }
+                catch {
+                    // Monitor already swallows; this is belt-and-braces.
+                }
+            }
 
             try {
 
@@ -391,7 +470,7 @@ namespace Fluxzy.Clients.H2
 
             // Notify last so the callback observes a fully-quiesced pool. Use a
             // CAS-guarded fire so concurrent teardown paths (read-loop exit racing
-            // with idle CheckAlive, or Send-path error racing with transport close)
+            // with the idle monitor, or Send-path error racing with transport close)
             // cannot double-evict the pool from PoolBuilder or double-schedule
             // disposal via ObserveDisposal.
             if (Interlocked.CompareExchange(ref _faultCallbackFired, 1, 0) == 0)
@@ -721,7 +800,7 @@ namespace Fluxzy.Clients.H2
                 // Do NOT break the read loop here. In-flight streams with id <= LastStreamId
                 // are still expected to receive HEADERS/DATA/RST/trailers from the server.
                 // The loop exits naturally when the server half-closes the transport or the
-                // idle CheckAlive fast path fires once draining completes.
+                // idle monitor's drain fast path fires once draining completes.
                 return false;
             }
 

--- a/src/Fluxzy.Core/Clients/IHttpConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/IHttpConnectionPool.cs
@@ -19,8 +19,6 @@ namespace Fluxzy.Clients
 
         void Init();
 
-        ValueTask<bool> CheckAlive();
-
         ValueTask Send(Exchange exchange, IDownStreamPipe downstreamPipe, RsBuffer buffer, ExchangeScope exchangeScope, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Fluxzy.Core/Clients/Mock/MockedConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/Mock/MockedConnectionPool.cs
@@ -32,11 +32,6 @@ namespace Fluxzy.Clients.Mock
         {
         }
 
-        public ValueTask<bool> CheckAlive()
-        {
-            return new ValueTask<bool>(Complete);
-        }
-
         public async ValueTask Send(
             Exchange exchange,
             IDownStreamPipe downStreamPipe, RsBuffer buffer, ExchangeScope __,

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +21,7 @@ namespace Fluxzy.Clients
     /// <summary>
     ///     Main entry of remote connection
     /// </summary>
-    internal class PoolBuilder : IDisposable
+    internal class PoolBuilder
     {
         private static readonly List<SslApplicationProtocol> AllProtocols = new() {
             SslApplicationProtocol.Http2,
@@ -40,7 +39,6 @@ namespace Fluxzy.Clients
         private readonly IDnsSolver _dnsSolver;
 
         private readonly ConcurrentDictionary<Authority, IHttpConnectionPool> _connectionPools = new();
-        private readonly CancellationTokenSource _poolCheckHaltSource = new();
 
         private readonly RemoteConnectionBuilder _remoteConnectionBuilder;
         private readonly ITimingProvider _timingProvider;
@@ -59,59 +57,6 @@ namespace Fluxzy.Clients
             _timingProvider = timingProvider;
             _archiveWriter = archiveWriter;
             _dnsSolver = dnsSolver;
-            CheckPoolStatus(_poolCheckHaltSource.Token);
-        }
-        
-        public void Dispose()
-        {
-            _poolCheckHaltSource.Cancel();
-        }
-
-        private async void CheckPoolStatus(CancellationToken token)
-        {
-            try {
-                while (!token.IsCancellationRequested) {
-                    // TODO put delay into config files or settings
-
-                    await Task.Delay(5000, token).ConfigureAwait(false);
-
-                    await CheckAllPoolsOnceAsync().ConfigureAwait(false);
-                }
-            }
-            catch (TaskCanceledException) {
-                // Disposed was called
-            }
-        }
-
-        /// <summary>
-        ///     Performs one health-check pass over the currently registered pools.
-        ///     Extracted from <see cref="CheckPoolStatus"/> so tests can drive a single
-        ///     tick deterministically.
-        ///
-        ///     A failure in one pool's <c>CheckAlive</c> must NEVER propagate out of
-        ///     this method: the caller is the async-void <see cref="CheckPoolStatus"/>
-        ///     loop, and an unhandled exception there terminates the process
-        ///     (haga-rak/fluxzy.core#614). Each pool is checked in a try/catch and the
-        ///     sweep continues regardless of individual failures.
-        /// </summary>
-        internal async Task CheckAllPoolsOnceAsync()
-        {
-            var activePools = _connectionPools.Values.ToList();
-
-            // Sequential: CheckAlive does no network I/O on either the alive or the
-            // idle-teardown branch, so concurrency would only add coordination cost.
-            // Per-pool try/catch ensures one bad pool can't poison the sweep.
-            for (var i = 0; i < activePools.Count; i++) {
-                try {
-                    await activePools[i].CheckAlive().ConfigureAwait(false);
-                }
-                catch (Exception) {
-                    // Swallow: if a pool's health check throws, the next sweep will
-                    // observe Complete==true (assuming the failure put it in that
-                    // state) and reap it via the GetPool fast path. Logging hook
-                    // can be added once the project has a structured logger here.
-                }
-            }
         }
 
         /// <summary>
@@ -306,16 +251,6 @@ namespace Fluxzy.Clients
                 _dnsSolver : _dnsSolversCache.GetOrAdd(exchange.Context.DnsOverHttpsNameOrUrl,
                     n => new DnsOverHttpsResolver(n, exchange.Context.DnsOverHttpsCapture ?
                         proxyRuntimeSetting.GetInternalProxyAuthentication() : null));
-        }
-
-        /// <summary>
-        ///     Test seam: directly inserts a pool into the active pool dictionary so
-        ///     <see cref="CheckAllPoolsOnceAsync"/> picks it up. Avoids constructing
-        ///     the full <see cref="GetPool"/> collaborator stack.
-        /// </summary>
-        internal void TryAddPoolForTests(Authority authority, IHttpConnectionPool pool)
-        {
-            _connectionPools[authority] = pool;
         }
 
         private void OnConnectionFaulted(IHttpConnectionPool h2ConnectionPool)

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolDisposalTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolDisposalTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Fluxzy.Clients;
 using Fluxzy.Clients.H2;
 using Fluxzy.Core;
 using Fluxzy.Misc.Streams;
@@ -13,50 +12,32 @@ using Xunit;
 namespace Fluxzy.Tests.UnitTests.H2Client
 {
     /// <summary>
-    ///     Reproducers for the H2 connection-pool disposal race documented in
+    ///     Reproducer for the H2 connection-pool disposal race documented in
     ///     haga-rak/fluxzy.core#614.
     ///
-    ///     These tests are RED on the current code and document the structural
-    ///     defects that need to be fixed:
-    ///
-    ///     1) <see cref="CheckAlive_IdleTeardown_DrainsWriterChannelAndCancelsCtsBeforeFaultCallback"/>
-    ///        — <c>H2ConnectionPool.OnLoopEnd</c> calls the fault callback BEFORE it
-    ///        cancels its CTS and drains its writer channel, so the callback (which in
-    ///        production fire-and-forgets <c>DisposeAsync</c>) races with the rest of
-    ///        OnLoopEnd's cleanup.
-    ///
-    ///     2) <see cref="CheckAllPoolsOnceAsync_WhenPoolThrows_DoesNotPropagate"/>
-    ///        — <c>PoolBuilder.CheckPoolStatus</c> only catches
-    ///        <see cref="TaskCanceledException"/>, so any other exception from a pool's
-    ///        <c>CheckAlive</c> escapes the async-void method and crashes the process.
+    ///     Idle teardown now lives in <see cref="H2ConnectionPool.TryIdleTeardown"/>,
+    ///     driven by a per-connection <see cref="System.Threading.PeriodicTimer"/>
+    ///     started in <c>Init</c>. The test calls the seam directly so the assertion
+    ///     does not depend on wall-clock timer firing.
     /// </summary>
     public class H2ConnectionPoolDisposalTests
     {
-        // ------------------------------------------------------------------
-        // Test 1: structural ordering invariant
-        // ------------------------------------------------------------------
         [Fact]
-        public async Task CheckAlive_IdleTeardown_DrainsWriterChannelAndCancelsCtsBeforeFaultCallback()
+        public async Task TryIdleTeardown_DrainsWriterChannelAndCancelsCtsBeforeFaultCallback()
         {
-            // Arrange ----------------------------------------------------------
             using var pipe = new DuplexPipe();
 
-            // The pool's base stream is a single bidirectional stream, recomposed
-            // from the two unidirectional pipe halves on the client side.
             var baseStream = new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream);
 
             var authority = new Authority("test.local", 443, true);
             var setting = new H2StreamSetting {
                 // 0 means "any positive elapsed time qualifies as idle"; combined with
-                // setting LastActivity to MinValue below, the very first CheckAlive
+                // setting LastActivity to MinValue below, the very first TryIdleTeardown
                 // call deterministically takes the idle-teardown branch.
                 MaxIdleSeconds = 0
             };
             var connection = new Connection(authority, new TestIdProvider());
 
-            // Snapshot of the pool's internal state at the moment the fault callback
-            // fires. Captured non-destructively via SnapshotForTests so the assertions
-            // can run after the pool has been quiesced.
             H2ConnectionPool.H2ConnectionPoolStateSnapshot? snapshotAtCallback = null;
             var faultCallbackInvocations = 0;
 
@@ -72,135 +53,32 @@ namespace Fluxzy.Tests.UnitTests.H2Client
 
             pool.Init();
 
-            // Force the idle branch deterministically (no wall-clock dependency).
             pool.LastActivity = DateTime.MinValue;
 
-            // Act --------------------------------------------------------------
-            // CheckAlive observes idle, calls EmitGoAway (queues a GoAway WriteTask
-            // on the writer channel), then calls OnLoopEnd(null, true). OnLoopEnd
-            // is the unit under test for the ordering invariant.
-            await pool.CheckAlive();
+            // Drive idle teardown deterministically (no wall-clock dependency).
+            var tornDown = pool.TryIdleTeardown();
 
-            // Quiesce: dispose the pool so the read/write loops exit cleanly before
-            // we tear down the duplex pipe in the using-block.
             await pool.DisposeAsync();
 
-            // Assert -----------------------------------------------------------
+            Assert.True(tornDown, "TryIdleTeardown must report it took the teardown branch");
             Assert.Equal(1, faultCallbackInvocations);
             Assert.NotNull(snapshotAtCallback);
 
             var snap = snapshotAtCallback!.Value;
 
             // The fault callback should observe a pool that has already finished its
-            // own internal cleanup. Today this is NOT the case — OnLoopEnd notifies
-            // the callback first and only then cancels the CTS / drains the channel.
+            // own internal cleanup. OnLoopEnd cancels the CTS / drains the writer
+            // channel BEFORE notifying the callback.
+            Assert.True(snap.Complete,
+                "_complete must be set before the fault callback runs");
 
-            Assert.True(
-                snap.Complete,
-                "_complete must be set before the fault callback runs (currently true)");
+            Assert.True(snap.CtsCancelled,
+                "the connection CTS must be cancelled before the fault callback runs");
 
-            Assert.True(
-                snap.CtsCancelled,
-                "the connection CTS must be cancelled before the fault callback runs " +
-                "(currently NOT — OnLoopEnd cancels after returning from the callback)");
-
-            Assert.True(
-                snap.WriterChannelDrainedAndClosed,
-                "the writer channel must be completed and drained before the fault " +
-                "callback runs (currently NOT — OnLoopEnd drains after the callback)");
+            Assert.True(snap.WriterChannelDrainedAndClosed,
+                "the writer channel must be completed and drained before the fault callback runs");
 
             Assert.Equal(0, snap.WriterChannelPendingCount);
-        }
-
-        // ------------------------------------------------------------------
-        // Test 4: async-void crash vector
-        // ------------------------------------------------------------------
-        [Fact]
-        public async Task CheckAllPoolsOnceAsync_WhenPoolThrows_DoesNotPropagate()
-        {
-            // Arrange ----------------------------------------------------------
-            // We only exercise the per-tick check pass via the internal seam; the
-            // GetPool collaborator stack is never touched, so we can pass null! for
-            // the four constructor dependencies.
-            var poolBuilder = new PoolBuilder(
-                remoteConnectionBuilder: null!,
-                timingProvider: null!,
-                archiveWriter: null!,
-                dnsSolver: null!);
-
-            // Cancel the background CheckPoolStatus loop immediately so it can't
-            // race with our test by hitting the throwing pool on its own 5s tick.
-            poolBuilder.Dispose();
-
-            var authority = new Authority("throwing.local", 443, true);
-            var throwingPool = new ThrowingHttpConnectionPool(authority);
-            poolBuilder.TryAddPoolForTests(authority, throwingPool);
-
-            // Act --------------------------------------------------------------
-            Exception? caught = null;
-            try {
-                await poolBuilder.CheckAllPoolsOnceAsync();
-            }
-            catch (Exception ex) {
-                caught = ex;
-            }
-
-            // Assert -----------------------------------------------------------
-            // In production, this exception would escape the async-void
-            // CheckPoolStatus and terminate the process. The fix must catch and log
-            // it inside the check loop instead of propagating.
-            Assert.Null(caught);
-            Assert.Equal(1, throwingPool.CheckAliveInvocations);
-        }
-
-        // ------------------------------------------------------------------
-        // Test doubles
-        // ------------------------------------------------------------------
-
-        /// <summary>
-        ///     Stub <see cref="IHttpConnectionPool"/> whose <see cref="CheckAlive"/>
-        ///     throws a <see cref="NullReferenceException"/> — mirroring the prod
-        ///     symptom in haga-rak/fluxzy.core#614. Other members are unused by the
-        ///     test and throw if invoked.
-        /// </summary>
-        private sealed class ThrowingHttpConnectionPool : IHttpConnectionPool
-        {
-            public ThrowingHttpConnectionPool(Authority authority)
-            {
-                Authority = authority;
-            }
-
-            public Authority Authority { get; }
-
-            public bool Complete => false;
-
-            public int CheckAliveInvocations { get; private set; }
-
-            public void Init()
-            {
-            }
-
-            public ValueTask<bool> CheckAlive()
-            {
-                CheckAliveInvocations++;
-                throw new NullReferenceException(
-                    "Simulated NRE from H2ConnectionPool.OnLoopEnd (haga-rak/fluxzy.core#614)");
-            }
-
-            public ValueTask Send(
-                Exchange exchange,
-                IDownStreamPipe downstreamPipe,
-                Fluxzy.Misc.ResizableBuffers.RsBuffer buffer,
-                ExchangeScope exchangeScope,
-                CancellationToken cancellationToken = default)
-            {
-                throw new NotSupportedException("Send is not exercised by this test.");
-            }
-
-            public ValueTask DisposeAsync()
-            {
-                return default;
-            }
         }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolGoAwayTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolGoAwayTests.cs
@@ -167,7 +167,7 @@ namespace Fluxzy.Tests.UnitTests.H2Client
         // Test: emitted GOAWAY carries LastStreamId=0 (RFC 9113 §6.8 compliance)
         //
         // Asserts the invariant directly at the frame-build seam rather than through
-        // an end-to-end write, because CheckAlive's idle path queues the GOAWAY on
+        // an end-to-end write, because the idle-teardown path queues the GOAWAY on
         // the writer channel and then immediately calls OnLoopEnd, which cancels the
         // task before the writer loop drains it — a pre-existing best-effort
         // behaviour. The seam guarantees the LastStreamId never leaks our own outgoing


### PR DESCRIPTION
## Summary
- `H2ConnectionPool` owns its own `PeriodicTimer`-driven idle monitor, replacing the centralized `PoolBuilder.CheckPoolStatus` async-void sweeper.
- Removes `CheckAlive` from `IHttpConnectionPool` and its no-op overrides.
- Idle snapshot and teardown run under the stream-creation lock so a concurrent `Send` cannot allocate a stream id on a connection about to send GOAWAY.