### PR TITLE
Fix H2 downstream write loop CPU spin on exhausted connection window

### DIFF
--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -50,6 +50,7 @@ namespace Fluxzy.Core
         private int _connectionWindow = 65535;
         private readonly SemaphoreSlim _writeSignal = new(0);
         private int _writeSignalState;
+        private int _writeLoopIterations;
 
         private readonly H2Logger _logger;
         private readonly CancellationToken _mainLoopToken;
@@ -406,12 +407,33 @@ namespace Fluxzy.Core
             }
         }
 
+        /// <summary>
+        ///     Test seam: outer-while iteration counter for <see cref="WriteLoop"/>. Used
+        ///     to detect spin-loop regressions where the loop re-enters Phase 2 faster
+        ///     than WINDOW_UPDATEs can arrive (see WriteLoop_DoesNotSpinWhenConnectionWindowExhausted).
+        /// </summary>
+        internal int WriteLoopIterationsForTests => Volatile.Read(ref _writeLoopIterations);
+
+        /// <summary>
+        ///     Test seam: injects a synthetic <see cref="DataFrameEntry"/> with the given
+        ///     flow-control cost directly into the data channel, bypassing the
+        ///     ServerStreamWorker/response-body machinery. Lets tests force the
+        ///     "connection window exhausted, entry queued" state deterministically.
+        /// </summary>
+        internal void EnqueueFlowControlledDataForTest(int flowControlledBytes)
+        {
+            var buffer = ArrayPool<byte>.Shared.Rent(9);
+            _dataChannel.Writer.TryWrite(new DataFrameEntry(buffer, 9, flowControlledBytes));
+            SignalWriteLoop();
+        }
+
         private async Task WriteLoop(CancellationToken token)
         {
             var gatherBuffer = ArrayPool<byte>.Shared.Rent(GatherBufferSize);
 
             try {
                 while (!token.IsCancellationRequested) {
+                    Interlocked.Increment(ref _writeLoopIterations);
                     var didWork = false;
 
                     // Phase 1: Drain pending header encodes into the ring buffer, then drain
@@ -521,8 +543,18 @@ namespace Fluxzy.Core
                     if (_ringBuffer.ReadableCount > 0)
                         continue;
 
-                    if (_dataChannel.Reader.TryPeek(out _))
-                        continue;
+                    // Only re-enter the outer loop if the peeked entry can actually make
+                    // progress. A DATA frame whose FlowControlledBytes exceed the current
+                    // connection window cannot be consumed by Phase 2 — treating it as
+                    // "work available" would spin at 100% CPU until a client WINDOW_UPDATE
+                    // arrives (haga-rak/fluxzy.core#634). HandleWindowUpdate calls
+                    // SignalWriteLoop after incrementing _connectionWindow, so parking on
+                    // _writeSignal is the correct response.
+                    if (_dataChannel.Reader.TryPeek(out var nextDataEntry)) {
+                        if (nextDataEntry.FlowControlledBytes == 0 ||
+                            Volatile.Read(ref _connectionWindow) >= nextDataEntry.FlowControlledBytes)
+                            continue;
+                    }
 
                     if (_pendingHeaders.Reader.TryPeek(out _))
                         continue;

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
@@ -493,6 +493,52 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
         }
 
         /// <summary>
+        /// Repro for the 100% CPU regression reported in haga-rak/fluxzy.core#634.
+        ///
+        /// <para>
+        /// When a DATA entry sits at the head of the data channel but
+        /// <c>entry.FlowControlledBytes &gt; _connectionWindow</c>, Phase 2 of
+        /// <c>WriteLoop</c> breaks without consuming the entry. The "double-check"
+        /// at the end of the outer iteration then sees the still-peeked entry and
+        /// <c>continue</c>s back to the top, never reaching the
+        /// <c>_writeSignal.WaitAsync</c> park. Result: the write loop spins at
+        /// 100% CPU until a client WINDOW_UPDATE unblocks it.
+        /// </para>
+        ///
+        /// Default connection window is 65535. Queuing an entry that needs 200 000
+        /// flow-controlled bytes with no matching WINDOW_UPDATE exercises the spin
+        /// directly. On a fixed loop the iteration delta over 200 ms is a handful;
+        /// on the buggy loop it is in the millions.
+        /// </summary>
+        [Fact]
+        public async Task WriteLoop_DoesNotSpinWhenConnectionWindowExhausted()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.CompleteHandshake();
+
+            // Let the write loop settle after the handshake.
+            await Task.Delay(50);
+
+            ctx.DownStreamPipe.EnqueueFlowControlledDataForTest(flowControlledBytes: 200_000);
+
+            // Give the signal a chance to wake the loop and have it (buggy) start spinning
+            // or (fixed) park on WaitAsync.
+            await Task.Delay(50);
+
+            var iterationsBefore = ctx.DownStreamPipe.WriteLoopIterationsForTests;
+
+            await Task.Delay(200);
+
+            var delta = ctx.DownStreamPipe.WriteLoopIterationsForTests - iterationsBefore;
+
+            Assert.True(delta < 50,
+                $"WriteLoop iterated {delta} times in 200ms with no WINDOW_UPDATE — " +
+                "this is a spin loop on connection-window exhaustion. Phase 4's " +
+                "\"_dataChannel.Reader.TryPeek(out _) → continue\" short-circuit " +
+                "must treat window-blocked entries as \"park, not spin\".");
+        }
+
+        /// <summary>
         /// Send POST with multiple DATA frames.
         /// Verify the complete body is received.
         /// </summary>


### PR DESCRIPTION
## Summary

`H2DownStreamPipe.WriteLoop` Phase 2 breaks without consuming a DATA entry when `entry.FlowControlledBytes > _connectionWindow`. The Phase 4 double-check then re-peeks the same entry and `continue`s, spinning at 100% CPU until a `WINDOW_UPDATE` arrives.

The double-check now only re-enters the loop if the peeked entry can actually make progress. Otherwise it falls through to `_writeSignal.WaitAsync`, which `HandleWindowUpdate` signals when the window opens up.

Plausibly one cause of the CPU regression reported in #634, though not confirmed against the user's workload.

Adds an iteration counter and a test seam so the spin can be reproduced deterministically (`WriteLoop_DoesNotSpinWhenConnectionWindowExhausted`): before the fix, 4.4M iterations in 200ms; after the fix, under 50.