### PR TITLE
Add IsRegisteredOn to match system proxy against fluxzy endpoint

### DIFF
--- a/src/Fluxzy.Core/Core/Impl/SystemProxyRegistrationManager.cs
+++ b/src/Fluxzy.Core/Core/Impl/SystemProxyRegistrationManager.cs
@@ -79,6 +79,30 @@ namespace Fluxzy.Core
         }
 
         /// <summary>
+        /// Returns true only if the OS proxy is currently enabled AND bound to the given endpoint.
+        /// Unlike <see cref="GetSystemProxySetting"/>, this filters out unrelated proxies
+        /// (corporate, Fiddler, another Fluxzy instance on a different port, ...).
+        /// </summary>
+        public async Task<bool> IsRegisteredOn(IPEndPoint endPoint)
+        {
+            var setting = await GetSystemProxySetting().ConfigureAwait(false);
+            var host = GetConnectableIpAddr(endPoint.Address);
+
+            return setting.MatchesEndPoint(new IPEndPoint(host, endPoint.Port));
+        }
+
+        /// <summary>
+        /// Overload mirroring the selection logic of <c>Register(IEnumerable&lt;IPEndPoint&gt;, ...)</c>:
+        /// prefers the loopback endpoint when multiple are provided.
+        /// </summary>
+        public Task<bool> IsRegisteredOn(IEnumerable<IPEndPoint> endPoints)
+        {
+            return IsRegisteredOn(endPoints.OrderByDescending(t => Equals(t.Address, IPAddress.Loopback)
+                                                                   || t.Address.Equals(IPAddress.IPv6Loopback))
+                                           .First());
+        }
+
+        /// <summary>
         /// Unregister any previous setting
         /// </summary>
         /// <returns></returns>

--- a/src/Fluxzy.Core/Core/Proxy/SystemProxySetting.cs
+++ b/src/Fluxzy.Core/Core/Proxy/SystemProxySetting.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace Fluxzy.Core.Proxy
 {
@@ -31,6 +32,22 @@ namespace Fluxzy.Core.Proxy
         ///     This is used to store specif OS related proxy format
         /// </summary>
         public Dictionary<string, object> PrivateValues { get; } = new();
+
+        /// <summary>
+        ///     True only if the OS proxy is enabled AND its host/port match the given endpoint.
+        ///     Used to distinguish "Fluxzy is the active system proxy" from "some other proxy is on".
+        /// </summary>
+        public bool MatchesEndPoint(IPEndPoint endPoint)
+        {
+            if (!Enabled)
+                return false;
+
+            if (ListenPort != endPoint.Port)
+                return false;
+
+            return string.Equals(BoundHost, endPoint.Address.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        }
 
         public bool Equals(SystemProxySetting? other)
         {

--- a/test/Fluxzy.Tests/UnitTests/Core/SystemProxyRegistrationManagerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SystemProxyRegistrationManagerTests.cs
@@ -172,6 +172,93 @@ namespace Fluxzy.Tests.UnitTests.Core
         }
 
         [Fact]
+        public async Task IsRegisteredOn_Returns_False_When_Proxy_Disabled()
+        {
+            var setting = CreateSetting("127.0.0.1", 8080, enabled: false);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            Assert.False(await manager.IsRegisteredOn(new IPEndPoint(IPAddress.Loopback, 8080)));
+        }
+
+        [Fact]
+        public async Task IsRegisteredOn_Returns_False_When_Port_Differs()
+        {
+            var setting = CreateSetting("127.0.0.1", 9090, enabled: true);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            Assert.False(await manager.IsRegisteredOn(new IPEndPoint(IPAddress.Loopback, 8080)));
+        }
+
+        [Fact]
+        public async Task IsRegisteredOn_Returns_False_When_Host_Differs()
+        {
+            var setting = CreateSetting("corp-proxy.local", 8080, enabled: true);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            Assert.False(await manager.IsRegisteredOn(new IPEndPoint(IPAddress.Loopback, 8080)));
+        }
+
+        [Fact]
+        public async Task IsRegisteredOn_Returns_True_On_Exact_Match()
+        {
+            var setting = CreateSetting("127.0.0.1", 8080, enabled: true);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            Assert.True(await manager.IsRegisteredOn(new IPEndPoint(IPAddress.Loopback, 8080)));
+        }
+
+        [Fact]
+        public async Task IsRegisteredOn_Normalizes_AnyAddress_To_Loopback()
+        {
+            // Fluxzy binds 0.0.0.0 but writes 127.0.0.1 to the registry (via GetConnectableIpAddr).
+            // IsRegisteredOn must apply the same normalization so callers can pass their raw bind endpoint.
+            var setting = CreateSetting("127.0.0.1", 8080, enabled: true);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            Assert.True(await manager.IsRegisteredOn(new IPEndPoint(IPAddress.Any, 8080)));
+        }
+
+        [Fact]
+        public async Task IsRegisteredOn_Endpoints_Prefers_Loopback()
+        {
+            // When several endpoints are given, the loopback one is the one actually written to
+            // the registry by Register(), so it must also be the one matched here.
+            var setting = CreateSetting("127.0.0.1", 8080, enabled: true);
+
+            var setter = Substitute.For<ISystemProxySetter>();
+            setter.ReadSetting().Returns(Task.FromResult(setting));
+
+            var manager = new SystemProxyRegistrationManager(setter);
+
+            var endpoints = new[] {
+                new IPEndPoint(IPAddress.Parse("192.168.1.10"), 8080),
+                new IPEndPoint(IPAddress.Loopback, 8080),
+            };
+
+            Assert.True(await manager.IsRegisteredOn(endpoints));
+        }
+
+        [Fact]
         public async Task Unregister_Should_Preserve_Raw_ProxyServer_For_Legacy_Formats()
         {
             // Arrange: Windows registry contains a legacy per-protocol ProxyServer


### PR DESCRIPTION
## Summary

- New `SystemProxySetting.MatchesEndPoint(IPEndPoint)` returns true only when the OS proxy is enabled and its host/port match the given endpoint.
- New `SystemProxyRegistrationManager.IsRegisteredOn(IPEndPoint)` (and `IEnumerable<IPEndPoint>` overload) lets callers check whether fluxzy specifically is the active system proxy, instead of just "some proxy is on".
- Raw OS reads (`WindowsProxyHelper.GetSetting`, `GetSystemProxySetting`) are untouched, so backup/restore semantics are preserved.