### PR TITLE
Embed FluxzySetting snapshot in archive meta

### DIFF
--- a/src/Fluxzy.Core/Archiving/ArchiveMetaInformation.cs
+++ b/src/Fluxzy.Core/Archiving/ArchiveMetaInformation.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Reflection;
 using Fluxzy.Rules.Filters;
 
@@ -30,7 +31,7 @@ namespace Fluxzy
         /// <summary>
         /// Archive version
         /// </summary>
-        public string ArchiveVersion { get; set; } = "0.2.0";
+        public string ArchiveVersion { get; set; } = "0.3.0";
 
         /// <summary>
         ///  Information about the environment where the archive was created.
@@ -41,6 +42,23 @@ namespace Fluxzy
         /// Fluxzy version used to create this archive
         /// </summary>
         public string FluxzyVersion { get; set; } = Assembly.GetExecutingAssembly().GetName().Version!.ToString();
+
+        /// <summary>
+        ///     Snapshot of the <see cref="FluxzySetting"/> that was active when the archive was produced.
+        ///     Sensitive fields (PKCS#12 password and file path, proxy authentication password,
+        ///     certificate cache directory, user agent configuration file) are scrubbed before serialization.
+        ///     When <see cref="FluxzySharedSetting.RedactSettingsInArchive"/> is true, alteration rules
+        ///     and the save filter are also omitted.
+        ///     Null on archives produced by Fluxzy &lt;= 0.2.0 and on archives produced by import engines.
+        /// </summary>
+        public FluxzySetting? CapturedSetting { get; set; }
+
+        /// <summary>
+        ///     Endpoints the proxy was actually listening on once <c>Proxy.Run()</c> resolved them.
+        ///     Differs from <see cref="FluxzySetting.BoundPoints"/> when a configured port of 0
+        ///     was replaced by an OS-assigned ephemeral port.
+        /// </summary>
+        public List<IPEndPoint> ResolvedEndPoints { get; set; } = new();
 
         /// <summary>
         ///  Can be used to store additional information about the archive.

--- a/src/Fluxzy.Core/Archiving/GlobalArchiveOption.cs
+++ b/src/Fluxzy.Core/Archiving/GlobalArchiveOption.cs
@@ -25,7 +25,7 @@ namespace Fluxzy
             new IFormatterResolver[] { StandardResolverAllowPrivate.Instance, ContractlessStandardResolver.Instance }));
 
         /// <summary>
-        /// STJ default archive option 
+        /// STJ default archive option
         /// </summary>
         public static JsonSerializerOptions DefaultSerializerOptions { get; } = new() {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -37,7 +37,8 @@ namespace Fluxzy
                 new IpAddressConverter(),
                 new IpEndPointConverter(),
                 new PolymorphicConverter<Filter>(),
-                new PolymorphicConverter<Action>()
+                new PolymorphicConverter<Action>(),
+                new RedactingFluxzySettingConverter()
             },
             NumberHandling = JsonNumberHandling.AllowReadingFromString
         };

--- a/src/Fluxzy.Core/Archiving/Readers/ArchiveMetaInformationReader.cs
+++ b/src/Fluxzy.Core/Archiving/Readers/ArchiveMetaInformationReader.cs
@@ -1,0 +1,36 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Fluxzy.Readers
+{
+    internal static class ArchiveMetaInformationReader
+    {
+        /// <summary>
+        ///     Deserializes a meta.json blob, falling back to a meta with a null
+        ///     <see cref="ArchiveMetaInformation.CapturedSetting"/> when the embedded
+        ///     setting can't be deserialized (e.g. a Filter/Action discriminator from a
+        ///     newer plugin).
+        /// </summary>
+        public static ArchiveMetaInformation Read(byte[] bytes)
+        {
+            try {
+                return JsonSerializer.Deserialize<ArchiveMetaInformation>(bytes,
+                    GlobalArchiveOption.DefaultSerializerOptions) ?? new ArchiveMetaInformation();
+            }
+            catch (JsonException) {
+                var node = JsonNode.Parse(bytes);
+
+                if (node is JsonObject obj && obj.ContainsKey("capturedSetting")) {
+                    obj.Remove("capturedSetting");
+
+                    return JsonSerializer.Deserialize<ArchiveMetaInformation>(obj.ToJsonString(),
+                        GlobalArchiveOption.DefaultSerializerOptions) ?? new ArchiveMetaInformation();
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Fluxzy.Core/Archiving/Readers/DirectoryArchiveReader.cs
+++ b/src/Fluxzy.Core/Archiving/Readers/DirectoryArchiveReader.cs
@@ -47,10 +47,8 @@ namespace Fluxzy.Readers
                 return new ArchiveMetaInformation();
             }
 
-            using var metaStream = File.Open(metaPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-
-            return JsonSerializer.Deserialize<ArchiveMetaInformation>(metaStream,
-                GlobalArchiveOption.DefaultSerializerOptions)!;
+            var bytes = File.ReadAllBytes(metaPath);
+            return ArchiveMetaInformationReader.Read(bytes);
         }
 
         public IEnumerable<ExchangeInfo> ReadAllExchanges()

--- a/src/Fluxzy.Core/Archiving/Readers/FluxzyArchiveReader.cs
+++ b/src/Fluxzy.Core/Archiving/Readers/FluxzyArchiveReader.cs
@@ -43,9 +43,10 @@ namespace Fluxzy.Readers
             }
 
             using var metaStream = metaEntry.Open();
+            using var ms = new MemoryStream();
+            metaStream.CopyTo(ms);
 
-            return JsonSerializer.Deserialize<ArchiveMetaInformation>(metaStream,
-                GlobalArchiveOption.DefaultSerializerOptions)!;
+            return ArchiveMetaInformationReader.Read(ms.ToArray());
         }
 
         public IEnumerable<ExchangeInfo> ReadAllExchanges()

--- a/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
+++ b/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
@@ -16,10 +17,10 @@ namespace Fluxzy.Writers
 {
     public class DirectoryArchiveWriter : RealtimeArchiveWriter
     {
-        private readonly ArchiveMetaInformation _archiveMetaInformation = CreateNewCaptureArchiveMetaInformation();
+        private readonly ArchiveMetaInformation _archiveMetaInformation;
         private readonly object _metaLock = new object();
 
-        private static ArchiveMetaInformation CreateNewCaptureArchiveMetaInformation()
+        private static ArchiveMetaInformation CreateNewCaptureArchiveMetaInformation(FluxzySetting? capturedSetting)
         {
             var metaInformation = new ArchiveMetaInformation
             {
@@ -31,10 +32,21 @@ namespace Fluxzy.Writers
                     "unknown",
 #endif
                     FluxzySharedSetting.SkipCollectingEnvironmentInformation ? "" : Environment.MachineName
-                )
+                ),
+                CapturedSetting = FreezeCapturedSetting(capturedSetting)
             };
 
             return metaInformation;
+        }
+
+        private static FluxzySetting? FreezeCapturedSetting(FluxzySetting? capturedSetting)
+        {
+            if (capturedSetting == null)
+                return null;
+
+            // Snapshot the live setting so subsequent mutations don't leak into persisted meta.
+            var json = JsonSerializer.Serialize(capturedSetting, GlobalArchiveOption.ConfigSerializerOptions);
+            return JsonSerializer.Deserialize<FluxzySetting>(json, GlobalArchiveOption.ConfigSerializerOptions);
         }
 
         private readonly string _archiveMetaInformationPath;
@@ -47,7 +59,13 @@ namespace Fluxzy.Writers
         private readonly string _connectionDirectory;
 
         public DirectoryArchiveWriter(string baseDirectory, Filter? saveFilter)
+            : this(baseDirectory, saveFilter, capturedSetting: null)
         {
+        }
+
+        public DirectoryArchiveWriter(string baseDirectory, Filter? saveFilter, FluxzySetting? capturedSetting)
+        {
+            _archiveMetaInformation = CreateNewCaptureArchiveMetaInformation(capturedSetting);
             _baseDirectory = baseDirectory;
             _saveFilter = saveFilter;
             _contentDirectory = Path.Combine(baseDirectory, "contents");
@@ -57,6 +75,14 @@ namespace Fluxzy.Writers
             _connectionDirectory = Path.Combine(baseDirectory, "connections");
 
             _archiveMetaInformationPath = DirectoryArchiveHelper.GetMetaPath(baseDirectory);
+        }
+
+        public void SetResolvedEndPoints(IEnumerable<IPEndPoint> endPoints)
+        {
+            lock (_metaLock) {
+                _archiveMetaInformation.ResolvedEndPoints = endPoints.ToList();
+                UpdateMeta(true);
+            }
         }
 
         public override void Init()

--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -22,6 +22,9 @@ namespace Fluxzy
             SkipCollectingEnvironmentInformation =
                 Environment.GetEnvironmentVariable("SkipCollectingEnvironmentInformation") == "1";
 
+            RedactSettingsInArchive =
+                Environment.GetEnvironmentVariable("FLUXZY_REDACT_SETTINGS_IN_ARCHIVE") == "1";
+
             if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("appdata"))) {
                 // for macOS and linux, this environment variable used in several temp file (certcache) is not 
                 // set leading unwanted folder creation
@@ -51,6 +54,14 @@ namespace Fluxzy
         ///     When set to true, the proxy will not collect environment information on the archive file
         /// </summary>
         public static bool SkipCollectingEnvironmentInformation { get; set; }
+
+        /// <summary>
+        ///     When set to true, the FluxzySetting snapshot embedded in archive meta information will
+        ///     omit alteration rules and the save filter (in addition to the always-on redaction of
+        ///     credentials and local file paths). Settable via the FLUXZY_REDACT_SETTINGS_IN_ARCHIVE
+        ///     environment variable.
+        /// </summary>
+        public static bool RedactSettingsInArchive { get; set; }
 
         /// <summary>
         /// </summary>

--- a/src/Fluxzy.Core/Misc/Converters/RedactingFluxzySettingConverter.cs
+++ b/src/Fluxzy.Core/Misc/Converters/RedactingFluxzySettingConverter.cs
@@ -1,0 +1,55 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Fluxzy.Misc.Converters
+{
+    /// <summary>
+    ///     Serializes <see cref="FluxzySetting"/> for embedding in archive meta information,
+    ///     scrubbing credentials and local file paths. Reading is delegated to the default
+    ///     contract so consumers see a regular <see cref="FluxzySetting"/>.
+    /// </summary>
+    internal class RedactingFluxzySettingConverter : JsonConverter<FluxzySetting>
+    {
+        public override FluxzySetting? Read(ref Utf8JsonReader reader, System.Type typeToConvert, JsonSerializerOptions options)
+        {
+            return JsonSerializer.Deserialize<FluxzySetting>(ref reader, GlobalArchiveOption.ConfigSerializerOptions);
+        }
+
+        public override void Write(Utf8JsonWriter writer, FluxzySetting value, JsonSerializerOptions options)
+        {
+            var node = JsonSerializer.SerializeToNode(value, GlobalArchiveOption.ConfigSerializerOptions)?.AsObject();
+
+            if (node == null) {
+                writer.WriteNullValue();
+                return;
+            }
+
+            Redact(node);
+
+            node.WriteTo(writer);
+        }
+
+        private static void Redact(JsonObject root)
+        {
+            if (root["caCertificate"] is JsonObject cert) {
+                cert.Remove("pkcs12File");
+                cert.Remove("pkcs12Password");
+            }
+
+            if (root["proxyAuthentication"] is JsonObject auth) {
+                auth.Remove("password");
+            }
+
+            root.Remove("certificateCacheDirectory");
+            root.Remove("userAgentActionConfigurationFile");
+
+            if (FluxzySharedSetting.RedactSettingsInArchive) {
+                root.Remove("internalAlterationRules");
+                root.Remove("saveFilter");
+            }
+        }
+    }
+}

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -115,7 +115,7 @@ namespace Fluxzy
                 Directory.CreateDirectory(StartupSetting.ArchivingPolicy.Directory);
 
                 Writer = new DirectoryArchiveWriter(StartupSetting.ArchivingPolicy.Directory,
-                    StartupSetting.SaveFilter);
+                    StartupSetting.SaveFilter, StartupSetting);
             }
 
             if (StartupSetting.ArchivingPolicy.Type == ArchivingPolicyType.None) {
@@ -347,6 +347,10 @@ namespace Fluxzy
             _loopTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
 
             EndPoints = endPoints;
+
+            if (Writer is DirectoryArchiveWriter directoryWriter) {
+                directoryWriter.SetResolvedEndPoints(endPoints);
+            }
 
             if (StartupSetting.EnableDiscoveryService) {
                 StartDiscoveryServices(endPoints);

--- a/test/Fluxzy.Tests/UnitTests/Archiving/CapturedSettingTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Archiving/CapturedSettingTests.cs
@@ -1,0 +1,180 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Fluxzy.Certificates;
+using Fluxzy.Readers;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Rules.Filters.RequestFilters;
+using Fluxzy.Writers;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Archiving
+{
+    public class CapturedSettingTests : IDisposable
+    {
+        private readonly string _baseDirectory;
+
+        public CapturedSettingTests()
+        {
+            _baseDirectory = Path.Combine(Path.GetTempPath(),
+                "fluxzy-capturedsetting-tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_baseDirectory);
+        }
+
+        public void Dispose()
+        {
+            try {
+                if (Directory.Exists(_baseDirectory))
+                    Directory.Delete(_baseDirectory, recursive: true);
+            }
+            catch {
+                // best effort cleanup
+            }
+        }
+
+        private static FluxzySetting BuildRichSetting()
+        {
+            var setting = FluxzySetting.CreateDefault();
+            setting.SetConnectionPerHost(7);
+            setting.SetExpectContinueTimeout(TimeSpan.FromSeconds(3));
+            setting.SetSaveFilter(new HostFilter("example.com"));
+            setting.AddAlterationRules(new AddRequestHeaderAction("X-Test", "value"),
+                new HostFilter("example.com"));
+            return setting;
+        }
+
+        [Fact]
+        public void Captured_Setting_Round_Trip_Directory()
+        {
+            var setting = BuildRichSetting();
+
+            var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null, capturedSetting: setting);
+            writer.Init();
+            writer.SetResolvedEndPoints(new[] { new IPEndPoint(IPAddress.Loopback, 12345) });
+            writer.Dispose();
+
+            var reader = new DirectoryArchiveReader(_baseDirectory);
+            var meta = reader.ReadMetaInformation();
+
+            Assert.NotNull(meta.CapturedSetting);
+            Assert.Equal(7, meta.CapturedSetting!.ConnectionPerHost);
+            Assert.Equal(TimeSpan.FromSeconds(3), meta.CapturedSetting.ExpectContinueTimeout);
+            Assert.NotNull(meta.CapturedSetting.SaveFilter);
+            Assert.Single(meta.CapturedSetting.AlterationRules);
+
+            Assert.Single(meta.ResolvedEndPoints);
+            Assert.Equal(12345, meta.ResolvedEndPoints[0].Port);
+
+            Assert.Equal("0.3.0", meta.ArchiveVersion);
+        }
+
+        [Fact]
+        public void Captured_Setting_Redacts_Secrets()
+        {
+            var setting = FluxzySetting.CreateDefault();
+            setting.SetCaCertificate(Certificate.LoadFromPkcs12("/tmp/secret.p12", "super-secret-passphrase"));
+            setting.SetProxyAuthentication(ProxyAuthentication.Basic("alice", "hunter2"));
+            setting.SetCertificateCacheDirectory("/home/alice/.fluxzy/cache");
+
+            var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null, capturedSetting: setting);
+            writer.Init();
+            writer.Dispose();
+
+            var metaPath = Path.Combine(_baseDirectory, "meta.json");
+            var raw = File.ReadAllText(metaPath);
+
+            Assert.DoesNotContain("super-secret-passphrase", raw);
+            Assert.DoesNotContain("hunter2", raw);
+            Assert.DoesNotContain("/tmp/secret.p12", raw);
+            Assert.DoesNotContain("/home/alice/.fluxzy/cache", raw);
+
+            var reader = new DirectoryArchiveReader(_baseDirectory);
+            var meta = reader.ReadMetaInformation();
+
+            Assert.NotNull(meta.CapturedSetting);
+            Assert.Null(meta.CapturedSetting!.CaCertificate.Pkcs12File);
+            Assert.Null(meta.CapturedSetting.CaCertificate.Pkcs12Password);
+            Assert.NotNull(meta.CapturedSetting.ProxyAuthentication);
+            Assert.Equal("alice", meta.CapturedSetting.ProxyAuthentication!.Username);
+            Assert.Null(meta.CapturedSetting.ProxyAuthentication.Password);
+        }
+
+        [Fact]
+        public async Task Captured_Setting_Round_Trip_Fxzy_Zip()
+        {
+            var setting = BuildRichSetting();
+
+            var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null, capturedSetting: setting);
+            writer.Init();
+            writer.Dispose();
+
+            var fxzyPath = Path.Combine(_baseDirectory, "..", Guid.NewGuid().ToString("N") + ".fxzy");
+            var packager = new FxzyDirectoryPackager();
+            await packager.Pack(_baseDirectory, fxzyPath);
+
+            try {
+                using var zipReader = new FluxzyArchiveReader(fxzyPath);
+                var meta = zipReader.ReadMetaInformation();
+
+                Assert.NotNull(meta.CapturedSetting);
+                Assert.Equal(7, meta.CapturedSetting!.ConnectionPerHost);
+                Assert.Single(meta.CapturedSetting.AlterationRules);
+            }
+            finally {
+                if (File.Exists(fxzyPath))
+                    File.Delete(fxzyPath);
+            }
+        }
+
+        [Fact]
+        public void Captured_Setting_Null_When_Absent_Legacy_Archive()
+        {
+            using var reader = new FluxzyArchiveReader("_Files/Archives/with-request-payload.fxzy");
+            var meta = reader.ReadMetaInformation();
+
+            Assert.Null(meta.CapturedSetting);
+        }
+
+        [Fact]
+        public void RedactSettingsInArchive_Drops_Rules_And_SaveFilter()
+        {
+            var setting = BuildRichSetting();
+
+            var previous = FluxzySharedSetting.RedactSettingsInArchive;
+            FluxzySharedSetting.RedactSettingsInArchive = true;
+
+            try {
+                var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null, capturedSetting: setting);
+                writer.Init();
+                writer.Dispose();
+
+                var reader = new DirectoryArchiveReader(_baseDirectory);
+                var meta = reader.ReadMetaInformation();
+
+                Assert.NotNull(meta.CapturedSetting);
+                Assert.Empty(meta.CapturedSetting!.AlterationRules);
+                Assert.Null(meta.CapturedSetting.SaveFilter);
+            }
+            finally {
+                FluxzySharedSetting.RedactSettingsInArchive = previous;
+            }
+        }
+
+        [Fact]
+        public void Captured_Setting_Null_When_Not_Provided()
+        {
+            var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null);
+            writer.Init();
+            writer.Dispose();
+
+            var reader = new DirectoryArchiveReader(_baseDirectory);
+            var meta = reader.ReadMetaInformation();
+
+            Assert.Null(meta.CapturedSetting);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Persists the active `FluxzySetting` and resolved bind endpoints in `meta.json` so archive consumers can see how the proxy was configured.
- Redacts credentials and local file paths in the snapshot; alteration rules and the save filter can be additionally dropped via `FluxzySharedSetting.RedactSettingsInArchive` (env var `FLUXZY_REDACT_SETTINGS_IN_ARCHIVE=1`).
- Bumps `ArchiveVersion` to `0.3.0`. Readers degrade gracefully (CapturedSetting becomes null) when the embedded setting fails to deserialize, e.g. unknown Filter/Action discriminators from a newer plugin.