### PR TITLE
Add cert validity dates and serial number to SslInfo

### DIFF
--- a/src/Fluxzy.Core/Archiving/Readers/HarImportEngine.cs
+++ b/src/Fluxzy.Core/Archiving/Readers/HarImportEngine.cs
@@ -75,7 +75,8 @@ namespace Fluxzy.Readers
                             secure
                                 ? new SslInfo(SslProtocols.None, null, null, null, null,
                                     entry.Request.HttpVersion, null!,
-                                    HashAlgorithmType.None, CipherAlgorithmType.None, default, default, default)
+                                    HashAlgorithmType.None, CipherAlgorithmType.None, default, default, default,
+                                    null, null, null, null, null, null)
                                 : null, 1, dnsStart,
                             dnsEnd, connectStart, connectEnd, sslStart, sslEnd, 0, string.Empty,
                             entry.ServerIPAddress ?? string.Empty, entry.Request.HttpVersion

--- a/src/Fluxzy.Core/Archiving/Readers/SazImportEngine.cs
+++ b/src/Fluxzy.Core/Archiving/Readers/SazImportEngine.cs
@@ -155,7 +155,8 @@ namespace Fluxzy.Readers
                         "HTTP/1.1",
                         SazConnectBodyUtility.GetKeyExchange(responseBodyString) ?? string.Empty,
                         HashAlgorithmType.Sha384,
-                        CipherAlgorithmType.Aes256, default, default, default
+                        CipherAlgorithmType.Aes256, default, default, default,
+                        null, null, null, null, null, null
                     );
                     
                     var connectConnectionInfo = new ConnectionInfo(

--- a/src/Fluxzy.Core/Archiving/SslInfo.cs
+++ b/src/Fluxzy.Core/Archiving/SslInfo.cs
@@ -40,11 +40,11 @@ namespace Fluxzy
 
             RemoteCertificateNotBefore = remote?.NotBefore;
             RemoteCertificateNotAfter = remote?.NotAfter;
-            RemoteCertificateSha1Thumbprint = remote?.GetCertHashString();
+            RemoteCertificateSerialNumber = remote?.SerialNumber;
 
             LocalCertificateNotBefore = local?.NotBefore;
             LocalCertificateNotAfter = local?.NotAfter;
-            LocalCertificateSha1Thumbprint = local?.GetCertHashString();
+            LocalCertificateSerialNumber = local?.SerialNumber;
 
             if (dumpCertificate)
             {
@@ -69,12 +69,12 @@ namespace Fluxzy
 
             if (BcCertificateHelper.TryReadDetailedInfo(clientProtocol.SessionParameters.LocalCertificate,
                     out var localSubject, out var localIssuer,
-                    out var localNotBefore, out var localNotAfter, out var localSha1)) {
+                    out var localNotBefore, out var localNotAfter, out var localSerial)) {
                 LocalCertificateIssuer = localIssuer;
                 LocalCertificateSubject = localSubject;
                 LocalCertificateNotBefore = localNotBefore;
                 LocalCertificateNotAfter = localNotAfter;
-                LocalCertificateSha1Thumbprint = localSha1;
+                LocalCertificateSerialNumber = localSerial;
 
                 if (dumpCertificate) {
                     LocalCertificatePem = clientProtocol.SessionParameters.LocalCertificate
@@ -85,12 +85,12 @@ namespace Fluxzy
 
             if (BcCertificateHelper.TryReadDetailedInfo(clientProtocol.SessionParameters.PeerCertificate,
                     out var remoteSubject, out var remoteIssuer,
-                    out var remoteNotBefore, out var remoteNotAfter, out var remoteSha1)) {
+                    out var remoteNotBefore, out var remoteNotAfter, out var remoteSerial)) {
                 RemoteCertificateIssuer = remoteIssuer;
                 RemoteCertificateSubject = remoteSubject;
                 RemoteCertificateNotBefore = remoteNotBefore;
                 RemoteCertificateNotAfter = remoteNotAfter;
-                RemoteCertificateSha1Thumbprint = remoteSha1;
+                RemoteCertificateSerialNumber = remoteSerial;
 
                 if (dumpCertificate) {
                     RemoteCertificatePem = clientProtocol.SessionParameters.PeerCertificate
@@ -109,9 +109,9 @@ namespace Fluxzy
             CipherAlgorithmType cipherAlgorithm, TlsCipherSuite negotiatedCipherSuite,
             string? localCertificatePem, string? remoteCertificatePem,
             DateTime? remoteCertificateNotBefore, DateTime? remoteCertificateNotAfter,
-            string? remoteCertificateSha1Thumbprint,
+            string? remoteCertificateSerialNumber,
             DateTime? localCertificateNotBefore, DateTime? localCertificateNotAfter,
-            string? localCertificateSha1Thumbprint)
+            string? localCertificateSerialNumber)
         {
             SslProtocol = sslProtocol;
             RemoteCertificateIssuer = remoteCertificateIssuer;
@@ -127,10 +127,10 @@ namespace Fluxzy
             RemoteCertificatePem = remoteCertificatePem;
             RemoteCertificateNotBefore = remoteCertificateNotBefore;
             RemoteCertificateNotAfter = remoteCertificateNotAfter;
-            RemoteCertificateSha1Thumbprint = remoteCertificateSha1Thumbprint;
+            RemoteCertificateSerialNumber = remoteCertificateSerialNumber;
             LocalCertificateNotBefore = localCertificateNotBefore;
             LocalCertificateNotAfter = localCertificateNotAfter;
-            LocalCertificateSha1Thumbprint = localCertificateSha1Thumbprint;
+            LocalCertificateSerialNumber = localCertificateSerialNumber;
         }
 
         public SslProtocols SslProtocol { get; }
@@ -165,12 +165,12 @@ namespace Fluxzy
 
         public DateTime? RemoteCertificateNotAfter { get; }
 
-        public string? RemoteCertificateSha1Thumbprint { get; }
+        public string? RemoteCertificateSerialNumber { get; }
 
         public DateTime? LocalCertificateNotBefore { get; }
 
         public DateTime? LocalCertificateNotAfter { get; }
 
-        public string? LocalCertificateSha1Thumbprint { get; }
+        public string? LocalCertificateSerialNumber { get; }
     }
 }

--- a/src/Fluxzy.Core/Archiving/SslInfo.cs
+++ b/src/Fluxzy.Core/Archiving/SslInfo.cs
@@ -1,7 +1,9 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
 using System.Net.Security;
 using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 using Fluxzy.Clients.Ssl.BouncyCastle;
 using Fluxzy.Extensions;
@@ -26,16 +28,28 @@ namespace Fluxzy
             HashAlgorithm = sslStream.HashAlgorithm;
             KeyExchangeAlgorithm = sslStream.KeyExchangeAlgorithm.ToString();
             NegotiatedApplicationProtocol = sslStream.NegotiatedApplicationProtocol.ToString();
-            RemoteCertificateSubject = sslStream.RemoteCertificate?.Subject;
-            RemoteCertificateIssuer = sslStream.RemoteCertificate?.Issuer;
-            LocalCertificateIssuer = sslStream.LocalCertificate?.Issuer;
-            LocalCertificateSubject = sslStream.LocalCertificate?.Subject;
+
+            var remote = sslStream.RemoteCertificate as X509Certificate2;
+            var local = sslStream.LocalCertificate as X509Certificate2;
+
+            RemoteCertificateSubject = remote?.Subject;
+            RemoteCertificateIssuer = remote?.Issuer;
+            LocalCertificateIssuer = local?.Issuer;
+            LocalCertificateSubject = local?.Subject;
             SslProtocol = sslStream.SslProtocol;
+
+            RemoteCertificateNotBefore = remote?.NotBefore;
+            RemoteCertificateNotAfter = remote?.NotAfter;
+            RemoteCertificateSha1Thumbprint = remote?.GetCertHashString();
+
+            LocalCertificateNotBefore = local?.NotBefore;
+            LocalCertificateNotAfter = local?.NotAfter;
+            LocalCertificateSha1Thumbprint = local?.GetCertHashString();
 
             if (dumpCertificate)
             {
-                RemoteCertificatePem = sslStream.RemoteCertificate?.ToPem();
-                LocalCertificatePem = sslStream.RemoteCertificate?.ToPem();
+                RemoteCertificatePem = remote?.ToPem();
+                LocalCertificatePem = local?.ToPem();
             }
         }
 
@@ -47,16 +61,20 @@ namespace Fluxzy
         internal SslInfo(FluxzyClientProtocol clientProtocol, bool dumpCertificate)
         {
 //#if NET6_0
-//            CipherAlgorithm = ((System.Net.Security.TlsCipherSuite) clientProtocol.SessionParameters.CipherSuite).ToString(); 
+//            CipherAlgorithm = ((System.Net.Security.TlsCipherSuite) clientProtocol.SessionParameters.CipherSuite).ToString();
 //#endif
-            
+
             NegotiatedApplicationProtocol = clientProtocol.GetApplicationProtocol().ToString();
             SslProtocol = clientProtocol.GetSChannelProtocol();
 
-            if (BcCertificateHelper.ReadInfo(clientProtocol.SessionParameters.LocalCertificate,
-                    out var localSubject, out var localIssuer)) {
+            if (BcCertificateHelper.TryReadDetailedInfo(clientProtocol.SessionParameters.LocalCertificate,
+                    out var localSubject, out var localIssuer,
+                    out var localNotBefore, out var localNotAfter, out var localSha1)) {
                 LocalCertificateIssuer = localIssuer;
                 LocalCertificateSubject = localSubject;
+                LocalCertificateNotBefore = localNotBefore;
+                LocalCertificateNotAfter = localNotAfter;
+                LocalCertificateSha1Thumbprint = localSha1;
 
                 if (dumpCertificate) {
                     LocalCertificatePem = clientProtocol.SessionParameters.LocalCertificate
@@ -65,10 +83,14 @@ namespace Fluxzy
 
             }
 
-            if (BcCertificateHelper.ReadInfo(clientProtocol.SessionParameters.PeerCertificate,
-                    out var remoteSubject, out var remoteIssuer)) {
+            if (BcCertificateHelper.TryReadDetailedInfo(clientProtocol.SessionParameters.PeerCertificate,
+                    out var remoteSubject, out var remoteIssuer,
+                    out var remoteNotBefore, out var remoteNotAfter, out var remoteSha1)) {
                 RemoteCertificateIssuer = remoteIssuer;
                 RemoteCertificateSubject = remoteSubject;
+                RemoteCertificateNotBefore = remoteNotBefore;
+                RemoteCertificateNotAfter = remoteNotAfter;
+                RemoteCertificateSha1Thumbprint = remoteSha1;
 
                 if (dumpCertificate) {
                     RemoteCertificatePem = clientProtocol.SessionParameters.PeerCertificate
@@ -83,9 +105,13 @@ namespace Fluxzy
         public SslInfo(
             SslProtocols sslProtocol, string? remoteCertificateIssuer, string? remoteCertificateSubject,
             string? localCertificateSubject, string? localCertificateIssuer, string negotiatedApplicationProtocol,
-            string keyExchangeAlgorithm, HashAlgorithmType hashAlgorithm, 
+            string keyExchangeAlgorithm, HashAlgorithmType hashAlgorithm,
             CipherAlgorithmType cipherAlgorithm, TlsCipherSuite negotiatedCipherSuite,
-            string ? localCertificatePem, string ? remoteCertificatePem)
+            string? localCertificatePem, string? remoteCertificatePem,
+            DateTime? remoteCertificateNotBefore, DateTime? remoteCertificateNotAfter,
+            string? remoteCertificateSha1Thumbprint,
+            DateTime? localCertificateNotBefore, DateTime? localCertificateNotAfter,
+            string? localCertificateSha1Thumbprint)
         {
             SslProtocol = sslProtocol;
             RemoteCertificateIssuer = remoteCertificateIssuer;
@@ -99,6 +125,12 @@ namespace Fluxzy
             NegotiatedCipherSuite = negotiatedCipherSuite;
             LocalCertificatePem = localCertificatePem;
             RemoteCertificatePem = remoteCertificatePem;
+            RemoteCertificateNotBefore = remoteCertificateNotBefore;
+            RemoteCertificateNotAfter = remoteCertificateNotAfter;
+            RemoteCertificateSha1Thumbprint = remoteCertificateSha1Thumbprint;
+            LocalCertificateNotBefore = localCertificateNotBefore;
+            LocalCertificateNotAfter = localCertificateNotAfter;
+            LocalCertificateSha1Thumbprint = localCertificateSha1Thumbprint;
         }
 
         public SslProtocols SslProtocol { get; }
@@ -128,5 +160,17 @@ namespace Fluxzy
         public string? LocalCertificatePem { get;  }
 
         public string? RemoteCertificatePem { get;  }
+
+        public DateTime? RemoteCertificateNotBefore { get; }
+
+        public DateTime? RemoteCertificateNotAfter { get; }
+
+        public string? RemoteCertificateSha1Thumbprint { get; }
+
+        public DateTime? LocalCertificateNotBefore { get; }
+
+        public DateTime? LocalCertificateNotAfter { get; }
+
+        public string? LocalCertificateSha1Thumbprint { get; }
     }
 }

--- a/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BcCertificateHelper.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BcCertificateHelper.cs
@@ -1,5 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
+using System.Security.Cryptography;
 using Org.BouncyCastle.Tls.Crypto;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 
@@ -31,6 +33,34 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
             var cert = certificate.GetCertificateAt(0);
 
             return ReadInfo(cert, out subject, out issuer);
+        }
+
+        public static bool TryReadDetailedInfo(
+            Org.BouncyCastle.Tls.Certificate? certificate,
+            out string? subject, out string? issuer,
+            out DateTime? notBefore, out DateTime? notAfter,
+            out string? sha1Thumbprint)
+        {
+            subject = issuer = sha1Thumbprint = null;
+            notBefore = notAfter = null;
+
+            if (certificate == null || certificate.Length == 0)
+                return false;
+
+            if (!(certificate.GetCertificateAt(0) is BcTlsCertificate bcTlsCertificate))
+                return false;
+
+            var structure = bcTlsCertificate.X509CertificateStructure;
+
+            subject = structure.Subject.ToString();
+            issuer = structure.Issuer.ToString();
+            notBefore = structure.StartDate.ToDateTime();
+            notAfter = structure.EndDate.ToDateTime();
+
+            var hash = SHA1.HashData(structure.GetEncoded());
+            sha1Thumbprint = Convert.ToHexString(hash);
+
+            return true;
         }
     }
 }

--- a/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BcCertificateHelper.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BcCertificateHelper.cs
@@ -1,7 +1,6 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
-using System.Security.Cryptography;
 using Org.BouncyCastle.Tls.Crypto;
 using Org.BouncyCastle.Tls.Crypto.Impl.BC;
 
@@ -39,9 +38,9 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
             Org.BouncyCastle.Tls.Certificate? certificate,
             out string? subject, out string? issuer,
             out DateTime? notBefore, out DateTime? notAfter,
-            out string? sha1Thumbprint)
+            out string? serialNumber)
         {
-            subject = issuer = sha1Thumbprint = null;
+            subject = issuer = serialNumber = null;
             notBefore = notAfter = null;
 
             if (certificate == null || certificate.Length == 0)
@@ -56,9 +55,7 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
             issuer = structure.Issuer.ToString();
             notBefore = structure.StartDate.ToDateTime();
             notAfter = structure.EndDate.ToDateTime();
-
-            var hash = SHA1.HashData(structure.GetEncoded());
-            sha1Thumbprint = Convert.ToHexString(hash);
+            serialNumber = Convert.ToHexString(structure.SerialNumber.Value.ToByteArrayUnsigned());
 
             return true;
         }

--- a/test/Fluxzy.Tests/UnitTests/Handlers/CertificateMetadataInSslInfoTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Handlers/CertificateMetadataInSslInfoTests.cs
@@ -34,38 +34,38 @@ namespace Fluxzy.Tests.UnitTests.Handlers
         [Theory]
         [InlineData(SslProvider.OsDefault)]
         [InlineData(SslProvider.BouncyCastle)]
-        public async Task RemoteCertificate_Sha1Thumbprint_IsUppercaseHex40(SslProvider sslProvider)
+        public async Task RemoteCertificate_SerialNumber_IsUppercaseHex(SslProvider sslProvider)
         {
             var sslInfo = await GetSslInfoForGoogle(sslProvider);
 
             Assert.NotNull(sslInfo);
-            Assert.NotNull(sslInfo.RemoteCertificateSha1Thumbprint);
+            Assert.NotNull(sslInfo.RemoteCertificateSerialNumber);
 
-            var thumbprint = sslInfo.RemoteCertificateSha1Thumbprint!;
-            Assert.Equal(40, thumbprint.Length);
-            Assert.All(thumbprint, c => Assert.True(
+            var serial = sslInfo.RemoteCertificateSerialNumber!;
+            Assert.NotEmpty(serial);
+            Assert.All(serial, c => Assert.True(
                 (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'),
                 $"Character '{c}' is not uppercase hex"));
         }
 
         [Fact]
-        public async Task RemoteCertificate_Sha1Thumbprint_IsConsistentAcrossProviders()
+        public async Task RemoteCertificate_SerialNumber_IsConsistentAcrossProviders()
         {
             // Hit both providers back-to-back to maximise odds of landing on the same cert.
             // If the host rotates certs between calls this will flake; the value of the test
-            // is catching a wrong-bytes hash bug in the BC path, not load-balancer behaviour.
+            // is catching a wrong-bytes bug in the BC path, not load-balancer behaviour.
             var fromOs = await GetSslInfoForGoogle(SslProvider.OsDefault);
             var fromBc = await GetSslInfoForGoogle(SslProvider.BouncyCastle);
 
-            Assert.NotNull(fromOs?.RemoteCertificateSha1Thumbprint);
-            Assert.NotNull(fromBc?.RemoteCertificateSha1Thumbprint);
+            Assert.NotNull(fromOs?.RemoteCertificateSerialNumber);
+            Assert.NotNull(fromBc?.RemoteCertificateSerialNumber);
 
-            // Same subject => same cert => same thumbprint.
+            // Same subject => same cert => same serial.
             if (string.Equals(fromOs.RemoteCertificateSubject, fromBc.RemoteCertificateSubject,
                     StringComparison.Ordinal))
             {
-                Assert.Equal(fromOs.RemoteCertificateSha1Thumbprint,
-                    fromBc.RemoteCertificateSha1Thumbprint);
+                Assert.Equal(fromOs.RemoteCertificateSerialNumber,
+                    fromBc.RemoteCertificateSerialNumber);
             }
         }
 
@@ -80,7 +80,7 @@ namespace Fluxzy.Tests.UnitTests.Handlers
             Assert.NotNull(sslInfo);
             Assert.Null(sslInfo.LocalCertificateNotBefore);
             Assert.Null(sslInfo.LocalCertificateNotAfter);
-            Assert.Null(sslInfo.LocalCertificateSha1Thumbprint);
+            Assert.Null(sslInfo.LocalCertificateSerialNumber);
         }
 
         private static async Task<SslInfo?> GetSslInfoForGoogle(SslProvider sslProvider)

--- a/test/Fluxzy.Tests/UnitTests/Handlers/CertificateMetadataInSslInfoTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Handlers/CertificateMetadataInSslInfoTests.cs
@@ -1,0 +1,103 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fluxzy.Clients.DotNetBridge;
+using Fluxzy.Core;
+using Fluxzy.Writers;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Handlers
+{
+    public class CertificateMetadataInSslInfoTests
+    {
+        [Theory]
+        [InlineData(SslProvider.OsDefault)]
+        [InlineData(SslProvider.BouncyCastle)]
+        public async Task RemoteCertificate_ValidityDates_AreWithinPlausibleWindow(SslProvider sslProvider)
+        {
+            var sslInfo = await GetSslInfoForGoogle(sslProvider);
+
+            Assert.NotNull(sslInfo);
+            Assert.NotNull(sslInfo.RemoteCertificateNotBefore);
+            Assert.NotNull(sslInfo.RemoteCertificateNotAfter);
+
+            var now = DateTime.UtcNow;
+            Assert.True(sslInfo.RemoteCertificateNotBefore <= now,
+                $"NotBefore {sslInfo.RemoteCertificateNotBefore} should be in the past");
+            Assert.True(sslInfo.RemoteCertificateNotAfter >= now,
+                $"NotAfter {sslInfo.RemoteCertificateNotAfter} should be in the future");
+            Assert.True(sslInfo.RemoteCertificateNotBefore < sslInfo.RemoteCertificateNotAfter);
+        }
+
+        [Theory]
+        [InlineData(SslProvider.OsDefault)]
+        [InlineData(SslProvider.BouncyCastle)]
+        public async Task RemoteCertificate_Sha1Thumbprint_IsUppercaseHex40(SslProvider sslProvider)
+        {
+            var sslInfo = await GetSslInfoForGoogle(sslProvider);
+
+            Assert.NotNull(sslInfo);
+            Assert.NotNull(sslInfo.RemoteCertificateSha1Thumbprint);
+
+            var thumbprint = sslInfo.RemoteCertificateSha1Thumbprint!;
+            Assert.Equal(40, thumbprint.Length);
+            Assert.All(thumbprint, c => Assert.True(
+                (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F'),
+                $"Character '{c}' is not uppercase hex"));
+        }
+
+        [Fact]
+        public async Task RemoteCertificate_Sha1Thumbprint_IsConsistentAcrossProviders()
+        {
+            // Hit both providers back-to-back to maximise odds of landing on the same cert.
+            // If the host rotates certs between calls this will flake; the value of the test
+            // is catching a wrong-bytes hash bug in the BC path, not load-balancer behaviour.
+            var fromOs = await GetSslInfoForGoogle(SslProvider.OsDefault);
+            var fromBc = await GetSslInfoForGoogle(SslProvider.BouncyCastle);
+
+            Assert.NotNull(fromOs?.RemoteCertificateSha1Thumbprint);
+            Assert.NotNull(fromBc?.RemoteCertificateSha1Thumbprint);
+
+            // Same subject => same cert => same thumbprint.
+            if (string.Equals(fromOs.RemoteCertificateSubject, fromBc.RemoteCertificateSubject,
+                    StringComparison.Ordinal))
+            {
+                Assert.Equal(fromOs.RemoteCertificateSha1Thumbprint,
+                    fromBc.RemoteCertificateSha1Thumbprint);
+            }
+        }
+
+        [Theory]
+        [InlineData(SslProvider.OsDefault)]
+        [InlineData(SslProvider.BouncyCastle)]
+        public async Task LocalCertificate_NotPresented_FieldsAreNull(SslProvider sslProvider)
+        {
+            // No client cert configured for these tests => local fields stay null.
+            var sslInfo = await GetSslInfoForGoogle(sslProvider);
+
+            Assert.NotNull(sslInfo);
+            Assert.Null(sslInfo.LocalCertificateNotBefore);
+            Assert.Null(sslInfo.LocalCertificateNotAfter);
+            Assert.Null(sslInfo.LocalCertificateSha1Thumbprint);
+        }
+
+        private static async Task<SslInfo?> GetSslInfoForGoogle(SslProvider sslProvider)
+        {
+            await using var tcpProvider = ITcpConnectionProvider.Default;
+
+            using var handler = new FluxzyDefaultHandler(sslProvider, tcpProvider, new EventOnlyArchiveWriter());
+
+            using var httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(15) };
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Get, "https://www.google.com/");
+
+            var response = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode();
+
+            var fluxzyResponse = Assert.IsType<FluxzyHttpResponseMessage>(response);
+            return fluxzyResponse.Exchange.Connection?.SslInfo;
+        }
+    }
+}


### PR DESCRIPTION
Populate `NotBefore`, `NotAfter` and `SerialNumber` for both the remote and local certificates on `SslInfo`, covering the .NET `SslStream` path and the BouncyCastle path. Also fixes `LocalCertificatePem` being sourced from the remote certificate.