### PR TITLE
Use DefaultAzureCredential env vars for sign tool

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -35,9 +35,10 @@ jobs:
         AZURE_VAULT_DESCRIPTION_URL : ${{ secrets.AZURE_VAULT_DESCRIPTION_URL }}
         AZURE_VAULT_URL : ${{ secrets.AZURE_VAULT_URL }}
         AZURE_VAULT_CERTIFICATE : ${{ secrets.AZURE_VAULT_CERTIFICATE }}
-        AZURE_VAULT_CLIENT_ID : ${{ secrets.AZURE_VAULT_CLIENT_ID }}
-        AZURE_VAULT_CLIENT_SECRET : ${{ secrets.AZURE_VAULT_CLIENT_SECRET }}
-        AZURE_VAULT_TENANT_ID : ${{ secrets.AZURE_VAULT_TENANT_ID }}
+
+        AZURE_CLIENT_ID : ${{ secrets.AZURE_VAULT_CLIENT_ID }}
+        AZURE_CLIENT_SECRET : ${{ secrets.AZURE_VAULT_CLIENT_SECRET }}
+        AZURE_TENANT_ID : ${{ secrets.AZURE_VAULT_TENANT_ID }}
 
       run: bash build.sh fluxzy-cli-publish-with-note
 

--- a/build/Fluxzy.Build/SignHelper.cs
+++ b/build/Fluxzy.Build/SignHelper.cs
@@ -13,9 +13,6 @@ namespace Fluxzy.Build
             var azureVaultDescriptionUrl = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_DESCRIPTION_URL");
             var azureVaultUrl = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_URL");
             var azureVaultCertificate = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CERTIFICATE");
-            var azureVaultClientId = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CLIENT_ID");
-            var azureVaultClientSecret = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CLIENT_SECRET");
-            var azureVaultTenantId = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_TENANT_ID");
 
             foreach (var file in signableFiles)
             {
@@ -29,10 +26,7 @@ namespace Fluxzy.Build
                         " --description \"Fluxzy Signed\"" +
                         $" --description-url {azureVaultDescriptionUrl}" +
                         $" --azure-key-vault-url {azureVaultUrl}" +
-                        $" --azure-key-vault-certificate {azureVaultCertificate}" +
-                        $" --azure-key-vault-client-id {azureVaultClientId}" +
-                        $" --azure-key-vault-client-secret {azureVaultClientSecret}" +
-                        $" --azure-key-vault-tenant-id {azureVaultTenantId}"
+                        $" --azure-key-vault-certificate {azureVaultCertificate}"
                         , noEcho: true,
                         workingDirectory: workingDirectory
                     );
@@ -49,9 +43,6 @@ namespace Fluxzy.Build
             var azureVaultDescriptionUrl = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_DESCRIPTION_URL");
             var azureVaultUrl = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_URL");
             var azureVaultCertificate = "FluxzyCodeSigningGS"; // EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CERTIFICATE");
-            var azureVaultClientId = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CLIENT_ID");
-            var azureVaultClientSecret = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_CLIENT_SECRET");
-            var azureVaultTenantId = EnvironmentHelper.GetEvOrFail("AZURE_VAULT_TENANT_ID");
 
             await RunAsync("sign",
                 "code azure-key-vault *.nupkg " +
@@ -59,10 +50,7 @@ namespace Fluxzy.Build
                 " --description \"Fluxzy Signed\"" +
                 $" --description-url {azureVaultDescriptionUrl}" +
                 $" --azure-key-vault-url {azureVaultUrl}" +
-                $" --azure-key-vault-certificate {azureVaultCertificate}" +
-                $" --azure-key-vault-client-id {azureVaultClientId}" +
-                $" --azure-key-vault-client-secret {azureVaultClientSecret}" +
-                $" --azure-key-vault-tenant-id {azureVaultTenantId}"
+                $" --azure-key-vault-certificate {azureVaultCertificate}"
                 , noEcho: true,
                 workingDirectory: workingDirectory
             );


### PR DESCRIPTION
## Summary
- Drop deprecated `--azure-key-vault-client-id/-secret/-tenant-id` flags from `SignHelper`. Newer `sign` tool versions (>= 0.9.1-beta.25330.2) deprecate these and partially fail when they are passed.
- Expose the existing `AZURE_VAULT_*` GitHub secrets under the standard `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID` env var names so `DefaultAzureCredential` resolves them automatically.

No GitHub secret changes required.