### PR TITLE
Add SkipInternalRules option to suppress built-in mount rules

### DIFF
--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -291,6 +291,19 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     If true, Fluxzy will not register its built-in rules
+        ///     (welcome page on self-requests, CA download endpoint at /ca).
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public FluxzySetting SetSkipInternalRules(bool value)
+        {
+            SkipInternalRules = value;
+
+            return this;
+        }
+
+        /// <summary>
         ///     Change the default certificate used by fluxzy
         /// </summary>
         /// <returns></returns>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -281,10 +281,21 @@ namespace Fluxzy
                 "X-Auth-Token"
             };
 
+        /// <summary>
+        ///     When true, Fluxzy will not register its built-in rules
+        ///     (welcome page on self-requests, CA download endpoint at /ca).
+        /// </summary>
+        [JsonInclude]
+        public bool SkipInternalRules { get; internal set; }
+
         internal IEnumerable<Rule> FixedRules()
         {
             if (GlobalSkipSslDecryption) {
                 yield return new Rule(new SkipSslTunnelingAction(), AnyFilter.Default);
+            }
+
+            if (SkipInternalRules) {
+                yield break;
             }
 
             yield return new Rule(

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -95,6 +95,7 @@ namespace Fluxzy.Cli.Commands
             command.AddOption(StartCommandOptions.CreateEnableDiscoveryOption());
             command.AddOption(StartCommandOptions.CreateProtoDirectoryOption());
             command.AddOption(StartCommandOptions.CreateTraceOption());
+            command.AddOption(StartCommandOptions.CreateSkipInternalRulesOption());
 
             command.SetHandler(context => Run(context, cancellationToken));
 
@@ -138,6 +139,7 @@ namespace Fluxzy.Cli.Commands
             var enableDiscovery = invocationContext.Value<bool>("enable-discovery");
             var protoDirectories = invocationContext.Value<List<string>>("proto-dir");
             var traceMode = invocationContext.Value<TraceMode>("trace");
+            var skipInternalRules = invocationContext.Value<bool>("skip-internal-rules");
 
             FluxzySharedSetting.Use528 = !use502;
 
@@ -293,6 +295,7 @@ namespace Fluxzy.Cli.Commands
             proxyStartUpSetting.SetIncludeAndroidEmulatorHost(!noAndroidEmulator);
             proxyStartUpSetting.SetServeH2(serveH2);
             proxyStartUpSetting.SetEnableDiscoveryService(enableDiscovery);
+            proxyStartUpSetting.SetSkipInternalRules(skipInternalRules);
 
             if (protoDirectories != null) {
                 foreach (var dir in protoDirectories) {

--- a/src/Fluxzy/Commands/StartCommandOptions.cs
+++ b/src/Fluxzy/Commands/StartCommandOptions.cs
@@ -110,6 +110,18 @@ namespace Fluxzy.Cli.Commands
             return option;
         }
 
+        public static Option CreateSkipInternalRulesOption()
+        {
+            var option = new Option<bool>(
+                "--skip-internal-rules",
+                "Do not add Fluxzy's built-in rules (welcome page, /ca certificate endpoint)");
+
+            option.SetDefaultValue(false);
+            option.Arity = ArgumentArity.Zero;
+
+            return option;
+        }
+
         public static Option CreateListenLocalhost()
         {
             var option = new Option<bool>(

--- a/test/Fluxzy.Benchmarks/ProxyThroughputBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/ProxyThroughputBenchmark.cs
@@ -61,6 +61,7 @@ public class ProxyThroughputBenchmark
             // 2. Start Fluxzy proxy (equivalent to: fluxzy start -k --serve-h2)
             var setting = FluxzySetting.CreateLocalRandomPort();
             setting.SetServeH2(ServeH2);
+            setting.SetSkipInternalRules(true);
             setting.ConfigureRule()
                 .WhenAny()
                 .Do(new SkipRemoteCertificateValidationAction()); // -k flag

--- a/test/Fluxzy.Tests/UnitTests/Settings/SkipInternalRulesTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Settings/SkipInternalRulesTests.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Rules.Actions.HighLevelActions;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Settings
+{
+    public class SkipInternalRulesTests
+    {
+        [Fact]
+        public void Default_Includes_Welcome_And_Ca_Mounts()
+        {
+            var setting = FluxzySetting.CreateDefault();
+
+            var actionTypes = setting.FixedRules().Select(r => r.Action.GetType()).ToList();
+
+            Assert.Contains(typeof(MountCertificateAuthorityAction), actionTypes);
+            Assert.Contains(typeof(MountWelcomePageAction), actionTypes);
+        }
+
+        [Fact]
+        public void SkipInternalRules_Removes_Welcome_And_Ca_Mounts()
+        {
+            var setting = FluxzySetting.CreateDefault().SetSkipInternalRules(true);
+
+            var actionTypes = setting.FixedRules().Select(r => r.Action.GetType()).ToList();
+
+            Assert.DoesNotContain(typeof(MountCertificateAuthorityAction), actionTypes);
+            Assert.DoesNotContain(typeof(MountWelcomePageAction), actionTypes);
+        }
+
+        [Fact]
+        public void SkipInternalRules_Preserves_GlobalSkipSslDecryption_Rule()
+        {
+            var setting = FluxzySetting.CreateDefault()
+                                       .SetSkipInternalRules(true)
+                                       .SetSkipGlobalSslDecryption(true);
+
+            var actionTypes = setting.FixedRules().Select(r => r.Action.GetType()).ToList();
+
+            Assert.Contains(typeof(SkipSslTunnelingAction), actionTypes);
+            Assert.DoesNotContain(typeof(MountCertificateAuthorityAction), actionTypes);
+            Assert.DoesNotContain(typeof(MountWelcomePageAction), actionTypes);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `FluxzySetting.SkipInternalRules` boolean (with `SetSkipInternalRules(bool)` fluent setter) that prevents the welcome page and `/ca` CA download endpoints from being registered in `FixedRules()`. Placed after the `GlobalSkipSslDecryption` branch so the two flags remain orthogonal.
- Exposes the same toggle as a `--skip-internal-rules` flag on `fluxzy start`, mirroring the existing `--skip-ssl-decryption` / `SetSkipGlobalSslDecryption` triplet (kebab-case, default false, no short alias).
- Enables the option by default in `ProxyThroughputBenchmark` so throughput numbers reflect raw forwarding cost without the built-in self-request handlers.
- Adds 3 unit tests in `SkipInternalRulesTests` covering the default behavior, the suppression behavior, and the orthogonality with `GlobalSkipSslDecryption`.