### PR TITLE
Drain WebSocket capture pipe on disposal

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/WebSocketStream.cs
+++ b/src/Fluxzy.Core/Clients/H11/WebSocketStream.cs
@@ -22,7 +22,6 @@ namespace Fluxzy.Clients.H11
         private readonly Pipe _pipe;
         private readonly Task _runningTask;
         private readonly ITimingProvider _timingProvider;
-        private readonly CancellationToken _token;
 
         private WsMessage? _current;
 
@@ -35,7 +34,11 @@ namespace Fluxzy.Clients.H11
         {
             _innerStream = innerStream;
             _timingProvider = timingProvider;
-            _token = token;
+            // token is kept on the constructor for API compatibility but intentionally
+            // not propagated to the internal pipe loop: InitRead must drain via
+            // _pipe.Writer.Complete() (called from Dispose) so a Sent frame buffered
+            // just before disposal isn't lost when the proxy halt token races ahead.
+            _ = token;
             _onMessage = onMessage;
             _outStream = outStream;
             _pipe = new Pipe();
@@ -56,9 +59,9 @@ namespace Fluxzy.Clients.H11
         {
             while (true) {
                 if (!_pipe.Reader.TryRead(out var readResult))
-                    readResult = await _pipe.Reader.ReadAsync(_token).ConfigureAwait(false);
+                    readResult = await _pipe.Reader.ReadAsync().ConfigureAwait(false);
 
-                if (readResult.IsCompleted || readResult.IsCanceled)
+                if (readResult.IsCanceled)
                     return;
 
                 var buffer = readResult.Buffer;
@@ -67,9 +70,13 @@ namespace Fluxzy.Clients.H11
                 WsFrame wsFrame = default;
 
                 if ((headerLength = TryReadWsFrameHeader(ref buffer, ref wsFrame)) < 0) {
-                    // not enough data to complete the header frame send back to read 
-
+                    // Not enough data to complete the header — wait for more.
                     _pipe.Reader.AdvanceTo(buffer.Start);
+
+                    // Writer has finished and the residual bytes can't form a header,
+                    // so no more frames are coming. Drain done.
+                    if (readResult.IsCompleted)
+                        return;
 
                     continue;
                 }
@@ -82,7 +89,7 @@ namespace Fluxzy.Clients.H11
                     var immediateMessage = new WsMessage(++_messageCounter);
                     wsFrame.FinalFragment = true;
 
-                    await immediateMessage.AddFrame(wsFrame, _maxBufferedWsMessage, _pipe.Reader, _outStream, _token)
+                    await immediateMessage.AddFrame(wsFrame, _maxBufferedWsMessage, _pipe.Reader, _outStream, CancellationToken.None)
                                           .ConfigureAwait(false);
                     immediateMessage.MessageEnd = _timingProvider.Instant();
                     _onMessage(immediateMessage);
@@ -96,7 +103,7 @@ namespace Fluxzy.Clients.H11
 
                 await _current
                     .AddFrame(wsFrame, _maxBufferedWsMessage,
-                        _pipe.Reader, _outStream, _token).ConfigureAwait(false);
+                        _pipe.Reader, _outStream, CancellationToken.None).ConfigureAwait(false);
 
                 if (wsFrame.FinalFragment) {
                     _current.MessageEnd = _timingProvider.Instant();

--- a/src/Fluxzy.Core/Clients/H11/WsMessage.cs
+++ b/src/Fluxzy.Core/Clients/H11/WsMessage.cs
@@ -98,14 +98,17 @@ namespace Fluxzy.Clients.H11
 
                 var readResult = await pipeReader.ReadAtLeastAsync((int) wsFrame.PayloadLength, token).ConfigureAwait(false);
 
-                // ReadAtLeastAsync may return more than requested; only take this frame's payload
-                Data = readResult.Buffer.Slice(0, wsFrame.PayloadLength).ToArray();
+                // ReadAtLeastAsync returns more than requested when extra bytes are buffered, and
+                // can return less when the writer completes early. Clamp on both sides so the slice
+                // never overshoots and a truncated payload is captured rather than thrown away.
+                var available = (int) Math.Min(readResult.Buffer.Length, wsFrame.PayloadLength);
+                Data = readResult.Buffer.Slice(0, available).ToArray();
 
                 ApplyXor(Data, wsFrame.MaskedPayload, 0);
 
                 WrittenLength = Data.Length;
 
-                pipeReader.AdvanceTo(readResult.Buffer.GetPosition(wsFrame.PayloadLength));
+                pipeReader.AdvanceTo(readResult.Buffer.GetPosition(available));
             }
             else {
                 await using var stream = outStream(Id);
@@ -113,15 +116,27 @@ namespace Fluxzy.Clients.H11
                 long frameWritten = 0;
 
                 while (frameWritten < wsFrame.PayloadLength) {
-                    // Write into file 
+                    // Write into file
 
                     if (!pipeReader.TryRead(out var readResult))
                         readResult = await pipeReader.ReadAsync().ConfigureAwait(false);
+
+                    if (readResult.IsCanceled)
+                        break;
 
                     // readResult.Buffer.Slice()
 
                     var effectiveBufferLength =
                         (int) Math.Min(readResult.Buffer.Length, wsFrame.PayloadLength - frameWritten);
+
+                    // Writer is done and the buffer can't fill the rest of the frame: stop draining
+                    // a truncated message instead of spinning forever on empty IsCompleted reads.
+                    if (effectiveBufferLength == 0) {
+                        pipeReader.AdvanceTo(readResult.Buffer.Start);
+                        if (readResult.IsCompleted)
+                            break;
+                        continue;
+                    }
 
                     var totalWriteInSequence = 0;
 


### PR DESCRIPTION
Fixes a race that lets a Sent WS frame go missing from the archive when the proxy disposes right after delivery. Behind both `WebSocketFramingTests.FastPath_Small_Message_Is_Captured_Intact` and `CliWebSockets.Run_Cli_For_Web_Socket_Req_Res(length: 1048576)` flaking on the self-hosted Linux runner.

`WebSocketStream.InitRead` returned on `IsCompleted` before parsing the buffer, so frames flushed just before `_pipe.Writer.Complete()` were dropped. The proxy halt token, threaded into the pipe reads, made the same race throw `OperationCanceledException` out of `_runningTask`. And `WsMessage.AddFrame`'s slow path had no break condition, so a writer that completed mid-frame caused an infinite loop.

Changes:
- `InitRead` parses the buffer first; the `IsCompleted` check fires only after a failed header parse.
- Pipe reads no longer take the halt token. Pipe completion is the only exit signal. Constructor parameter kept for API compatibility.
- Slow path breaks on `IsCanceled` and on `(effectiveBufferLength == 0 && IsCompleted)`.
- Fast path clamps the slice with `Math.Min` so a short `ReadAtLeastAsync` captures what arrived instead of throwing.