### PR TITLE
Fix Proxy startup failure with custom Action or Filter

### DIFF
--- a/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
+++ b/src/Fluxzy.Core/Archiving/Writers/DirectoryArchiveWriter.cs
@@ -45,8 +45,16 @@ namespace Fluxzy.Writers
                 return null;
 
             // Snapshot the live setting so subsequent mutations don't leak into persisted meta.
-            var json = JsonSerializer.Serialize(capturedSetting, GlobalArchiveOption.ConfigSerializerOptions);
-            return JsonSerializer.Deserialize<FluxzySetting>(json, GlobalArchiveOption.ConfigSerializerOptions);
+            try {
+                var json = JsonSerializer.Serialize(capturedSetting, GlobalArchiveOption.ConfigSerializerOptions);
+                return JsonSerializer.Deserialize<FluxzySetting>(json, GlobalArchiveOption.ConfigSerializerOptions);
+            }
+            catch (Exception) {
+                // A custom Action/Filter defined outside the Fluxzy.Core assembly cannot be
+                // round-tripped by PolymorphicConverter. The snapshot is best-effort meta data,
+                // so fall back to the live reference rather than failing proxy startup.
+                return capturedSetting;
+            }
         }
 
         private readonly string _archiveMetaInformationPath;

--- a/test/Fluxzy.Tests/UnitTests/Archiving/CapturedSettingTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Archiving/CapturedSettingTests.cs
@@ -6,7 +6,10 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Fluxzy.Certificates;
+using Fluxzy.Core;
+using Fluxzy.Core.Breakpoints;
 using Fluxzy.Readers;
+using Fluxzy.Rules;
 using Fluxzy.Rules.Actions;
 using Fluxzy.Rules.Filters.RequestFilters;
 using Fluxzy.Writers;
@@ -175,6 +178,46 @@ namespace Fluxzy.Tests.UnitTests.Archiving
             var meta = reader.ReadMetaInformation();
 
             Assert.Null(meta.CapturedSetting);
+        }
+
+        [Fact]
+        public void Captured_Setting_With_Custom_Action_Does_Not_Throw()
+        {
+            // Regression (#653): a custom Action subclass declared outside the Fluxzy.Core
+            // assembly cannot be resolved by PolymorphicConverter, so the snapshot round-trip
+            // in FreezeCapturedSetting fails. Constructing the archive writer (and therefore
+            // the Proxy) must degrade gracefully instead of throwing a JsonException.
+            var setting = FluxzySetting.CreateDefault();
+            setting.AddAlterationRules(new CustomLabelingAction { Label = "vip" },
+                new HostFilter("example.com"));
+
+            var exception = Record.Exception(() => {
+                var writer = new DirectoryArchiveWriter(_baseDirectory, saveFilter: null, capturedSetting: setting);
+                writer.Init();
+                writer.Dispose();
+            });
+
+            Assert.Null(exception);
+        }
+    }
+
+    /// <summary>
+    /// A custom action declared in the test assembly, i.e. outside Fluxzy.Core, used to
+    /// reproduce the polymorphic deserialization failure of <see cref="CapturedSettingTests"/>.
+    /// </summary>
+    internal class CustomLabelingAction : Fluxzy.Rules.Action
+    {
+        public string Label { get; set; } = "default";
+
+        public override FilterScope ActionScope => FilterScope.RequestHeaderReceivedFromClient;
+
+        public override string DefaultDescription => "Custom labeling action";
+
+        public override ValueTask InternalAlter(
+            ExchangeContext context, Exchange? exchange, Connection? connection, FilterScope scope,
+            BreakPointManager breakPointManager)
+        {
+            return default;
         }
     }
 }


### PR DESCRIPTION
`DirectoryArchiveWriter.FreezeCapturedSetting` snapshots the `FluxzySetting` with a JSON serialize/deserialize round-trip. When a rule uses a custom `Action` or `Filter` declared outside the `Fluxzy.Core` assembly, `PolymorphicConverter` cannot resolve the type on read and throws a `JsonException`, which fails `Proxy` construction.

Catch the failure in `FreezeCapturedSetting` and fall back to the live `FluxzySetting` reference. The snapshot is best-effort metadata, so it should degrade gracefully instead of breaking proxy startup.

Adds a regression test that constructs `DirectoryArchiveWriter` with a custom `Action` declared in the test assembly and asserts no exception is thrown. The test fails without the fix.