### PR TITLE
Restrict leaf certificate cache files to owner only

### DIFF
--- a/src/Fluxzy.Core/Core/Impl/FileSystemCertificateCache.cs
+++ b/src/Fluxzy.Core/Core/Impl/FileSystemCertificateCache.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Fluxzy.Core
@@ -70,11 +71,16 @@ namespace Fluxzy.Core
 
             var directory = Path.GetDirectoryName(fullFileName);
 
-            if (directory != null)
+            if (directory != null) {
                 Directory.CreateDirectory(directory);
+                RestrictToOwner(directory, isDirectory: true);
+            }
 
             // Write header (8 bytes ticks) + certificate bytes
             using (var stream = File.Create(fullFileName)) {
+                // Lock down to owner before writing the embedded private key.
+                RestrictToOwner(fullFileName, isDirectory: false);
+
                 Span<byte> header = stackalloc byte[ExpirationHeaderSize];
                 BitConverter.TryWriteBytes(header, notAfterDate.Ticks);
                 stream.Write(header);
@@ -82,6 +88,19 @@ namespace Fluxzy.Core
             }
 
             return certContent;
+        }
+
+        private static void RestrictToOwner(string path, bool isDirectory)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
+            var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+            if (isDirectory)
+                mode |= UnixFileMode.UserExecute; // traversal bit, yields 0700
+
+            File.SetUnixFileMode(path, mode);
         }
 
         private static DateTime GetCertificateNotAfter(byte[] certificateBytes)


### PR DESCRIPTION
On Unix the on-the-fly leaf .pfx files were created at 0644, so any other user on a shared host could read them and extract the private key. Now they're written 0600 (the mode is set before the key bytes are written, so there's no 0644 window) and the per-serial cache directory is 0700. No-op on Windows, same File.SetUnixFileMode pattern already used in PcapngWriter.