### PR TITLE
Normalize HTTP/1.1 framing to prevent request smuggling

### DIFF
--- a/src/Fluxzy.Core/Core/Header.cs
+++ b/src/Fluxzy.Core/Core/Header.cs
@@ -22,24 +22,124 @@ namespace Fluxzy.Core
         {
             _rawHeaderFields = headerFields as List<HeaderField> ?? new List<HeaderField>(headerFields);
 
-            // Single pass to compute ChunkedBody and ContentLength
-            var contentLength = -1L;
+            NormalizeMessageFraming();
+        }
+
+        /// <summary>
+        ///     Reconciles Transfer-Encoding and Content-Length once, at parse time, so the
+        ///     body we frame on the read side matches the framing we forward to the peer.
+        ///     Closes the HTTP/1.1 smuggling vectors (RFC 7230 §3.3.3): a Content-Length kept
+        ///     alongside Transfer-Encoding: chunked, duplicate/conflicting Content-Length, and
+        ///     invalid (negative, non-numeric, overflowing) Content-Length values.
+        /// </summary>
+        private void NormalizeMessageFraming()
+        {
+            var chunked = false;
 
             foreach (var field in _rawHeaderFields) {
-                if (!ChunkedBody &&
-                    field.Name.Span.Equals(Http11Constants.TransferEncodingVerb.Span,
-                        StringComparison.OrdinalIgnoreCase) &&
-                    field.Value.Span.Equals("chunked", StringComparison.OrdinalIgnoreCase)) {
-                    ChunkedBody = true;
-                }
-
-                if (field.Name.Span.Equals(Http11Constants.ContentLength.Span,
-                        StringComparison.OrdinalIgnoreCase) &&
-                    long.TryParse(field.Value.Span, out contentLength)) {
-                    // In case of multiple content length we take the last
-                    ContentLength = contentLength;
+                if (field.Name.Span.Equals(Http11Constants.TransferEncodingVerb.Span,
+                        StringComparison.OrdinalIgnoreCase)) {
+                    // Multiple Transfer-Encoding fields fold into one ordered list; the body
+                    // is chunked when the final coding is chunked.
+                    chunked = EndsWithChunkedToken(field.Value.Span);
                 }
             }
+
+            if (chunked) {
+                // Transfer-Encoding overrides Content-Length; a forwarding proxy MUST drop
+                // Content-Length so the peer cannot frame the body a second way.
+                RemoveHeader("content-length");
+                ChunkedBody = true;
+                ContentLength = -1;
+
+                return;
+            }
+
+            long? agreedLength = null;
+            var contentLengthCount = 0;
+
+            foreach (var field in _rawHeaderFields) {
+                if (!field.Name.Span.Equals(Http11Constants.ContentLength.Span,
+                        StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                contentLengthCount++;
+
+                if (!TryParseContentLength(field.Value.Span, out var value)) {
+                    throw new InvalidHttpFramingException(
+                        $"Rejected message: invalid Content-Length value '{field.Value.ToString()}'.");
+                }
+
+                if (agreedLength is { } previous && previous != value) {
+                    throw new InvalidHttpFramingException(
+                        "Rejected message: conflicting Content-Length header values.");
+                }
+
+                agreedLength = value;
+            }
+
+            if (agreedLength is { } length) {
+                ContentLength = length;
+
+                if (contentLengthCount > 1) {
+                    // Equal duplicates are recoverable: collapse to a single canonical field
+                    // so we never forward more than one Content-Length downstream.
+                    RemoveHeader("content-length");
+                    _rawHeaderFields.Add(new HeaderField("Content-Length", length.ToString()));
+                }
+            }
+        }
+
+        // RFC 7230 §3.3.2: Content-Length = 1*DIGIT. Reject signs, lists, and other
+        // non-digit content; tolerate surrounding OWS (SP / HTAB) only.
+        private static bool TryParseContentLength(ReadOnlySpan<char> value, out long result)
+        {
+            result = -1;
+
+            var start = 0;
+            var end = value.Length;
+
+            while (start < end && (value[start] == ' ' || value[start] == '\t')) {
+                start++;
+            }
+
+            while (end > start && (value[end - 1] == ' ' || value[end - 1] == '\t')) {
+                end--;
+            }
+
+            if (start == end) {
+                return false;
+            }
+
+            long acc = 0;
+
+            for (var i = start; i < end; i++) {
+                var c = value[i];
+
+                if (c < '0' || c > '9') {
+                    return false;
+                }
+
+                acc = acc * 10 + (c - '0');
+
+                if (acc < 0) {
+                    return false; // overflowed past long.MaxValue
+                }
+            }
+
+            result = acc;
+
+            return true;
+        }
+
+        // True when the last comma-separated transfer-coding token is "chunked".
+        private static bool EndsWithChunkedToken(ReadOnlySpan<char> value)
+        {
+            var lastComma = value.LastIndexOf(',');
+            var token = lastComma < 0 ? value : value.Slice(lastComma + 1);
+
+            return token.Trim().Equals("chunked", StringComparison.OrdinalIgnoreCase);
         }
 
         protected Header(
@@ -408,6 +508,11 @@ namespace Fluxzy.Core
                 // Appending a second entry breaks strict HTTP clients (issue #615).
                 return;
             }
+
+            // Switching to chunked: drop any Content-Length so the peer cannot frame the
+            // body two different ways (CL/TE desync = smuggling).
+            RemoveHeader("content-length");
+            ContentLength = -1;
 
             _rawHeaderFields.Add(new HeaderField("Transfer-Encoding", "chunked"));
             ChunkedBody = true;

--- a/src/Fluxzy.Core/InvalidHttpFramingException.cs
+++ b/src/Fluxzy.Core/InvalidHttpFramingException.cs
@@ -1,0 +1,20 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+
+namespace Fluxzy
+{
+    /// <summary>
+    ///     Thrown when an HTTP/1.1 message declares ambiguous or invalid body framing
+    ///     (conflicting or duplicate Content-Length values, or a non 1*DIGIT value).
+    ///     The connection is dropped to prevent request/response smuggling
+    ///     (RFC 7230 §3.3.3).
+    /// </summary>
+    public class InvalidHttpFramingException : FluxzyException
+    {
+        public InvalidHttpFramingException(string message, Exception? innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Core/Http11FramingTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/Http11FramingTests.cs
@@ -1,0 +1,166 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Text;
+using Fluxzy;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    /// <summary>
+    ///     Covers the HTTP/1.1 request/response framing normalization that closes the
+    ///     smuggling vectors (RFC 7230 §3.3.3): Content-Length kept alongside
+    ///     Transfer-Encoding: chunked, duplicate/conflicting Content-Length, and invalid
+    ///     Content-Length values.
+    /// </summary>
+    public class Http11FramingTests
+    {
+        private static RequestHeader BuildRequest(params string[] headerLines)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append("POST /submit HTTP/1.1\r\n");
+            builder.Append("Host: example.com\r\n");
+
+            foreach (var line in headerLines) {
+                builder.Append(line);
+                builder.Append("\r\n");
+            }
+
+            builder.Append("\r\n");
+
+            return new RequestHeader(builder.ToString().AsMemory(), false);
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            var count = 0;
+            var index = 0;
+
+            while ((index = haystack.IndexOf(needle, index, StringComparison.OrdinalIgnoreCase)) >= 0) {
+                count++;
+                index += needle.Length;
+            }
+
+            return count;
+        }
+
+        [Fact]
+        public void ChunkedBody_Strips_Content_Length()
+        {
+            // Vector 2: Content-Length next to Transfer-Encoding: chunked. The proxy must
+            // forward chunked only, otherwise an origin that trusts Content-Length desyncs.
+            var header = BuildRequest("Content-Length: 8", "Transfer-Encoding: chunked");
+
+            Assert.True(header.ChunkedBody);
+            Assert.Equal(-1, header.ContentLength);
+
+            var forwarded = header.GetHttp11Header().ToString();
+
+            Assert.Equal(0, CountOccurrences(forwarded, "content-length"));
+            Assert.Contains("transfer-encoding: chunked", forwarded, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ChunkedBody_Detected_When_It_Is_The_Final_Coding()
+        {
+            // "gzip, chunked" still means the body is chunked on the wire.
+            var header = BuildRequest("Content-Length: 8", "Transfer-Encoding: gzip, chunked");
+
+            Assert.True(header.ChunkedBody);
+            Assert.Equal(-1, header.ContentLength);
+            Assert.Equal(0, CountOccurrences(header.GetHttp11Header().ToString(), "content-length"));
+        }
+
+        [Fact]
+        public void Duplicate_Equal_Content_Length_Collapses_To_One()
+        {
+            // Vector 1 (benign variant): equal duplicates are recoverable, but we must
+            // never forward two Content-Length fields.
+            var header = BuildRequest("Content-Length: 5", "Content-Length: 5");
+
+            Assert.False(header.ChunkedBody);
+            Assert.Equal(5, header.ContentLength);
+            Assert.Equal(1, CountOccurrences(header.GetHttp11Header().ToString(), "content-length"));
+        }
+
+        [Fact]
+        public void Duplicate_Conflicting_Content_Length_Is_Rejected()
+        {
+            // Vector 1: differing duplicates are an unrecoverable framing conflict.
+            Assert.Throws<InvalidHttpFramingException>(
+                () => BuildRequest("Content-Length: 5", "Content-Length: 6"));
+        }
+
+        [Theory]
+        [InlineData("-1")]
+        [InlineData("+5")]
+        [InlineData("abc")]
+        [InlineData("5, 5")]
+        [InlineData("0x10")]
+        [InlineData("")]
+        [InlineData("9223372036854775808")] // long.MaxValue + 1
+        public void Invalid_Content_Length_Is_Rejected(string value)
+        {
+            // Vector 3: a value that is not 1*DIGIT cannot be framed; reject instead of
+            // silently treating the body as empty and leaving the bytes on the socket.
+            Assert.Throws<InvalidHttpFramingException>(
+                () => BuildRequest($"Content-Length: {value}"));
+        }
+
+        [Theory]
+        [InlineData("0", 0L)]
+        [InlineData("42", 42L)]
+        [InlineData("9223372036854775807", long.MaxValue)]
+        public void Valid_Content_Length_Is_Preserved(string value, long expected)
+        {
+            var header = BuildRequest($"Content-Length: {value}");
+
+            Assert.False(header.ChunkedBody);
+            Assert.Equal(expected, header.ContentLength);
+            Assert.Equal(1, CountOccurrences(header.GetHttp11Header().ToString(), "content-length"));
+        }
+
+        [Fact]
+        public void Content_Length_Tolerates_Surrounding_Whitespace()
+        {
+            // OWS (HTAB) around the value is allowed and must not be mistaken for an
+            // invalid value.
+            var header = BuildRequest("Content-Length: \t42\t");
+
+            Assert.Equal(42, header.ContentLength);
+        }
+
+        [Fact]
+        public void ForceTransferChunked_Strips_Content_Length()
+        {
+            // The request-body substitution path calls ForceTransferChunked; without
+            // dropping Content-Length it would emit CL + TE to the origin itself.
+            var header = BuildRequest("Content-Length: 10");
+
+            Assert.Equal(10, header.ContentLength);
+            Assert.False(header.ChunkedBody);
+
+            header.ForceTransferChunked();
+
+            Assert.True(header.ChunkedBody);
+            Assert.Equal(-1, header.ContentLength);
+
+            var forwarded = header.GetHttp11Header().ToString();
+
+            Assert.Equal(0, CountOccurrences(forwarded, "content-length"));
+            Assert.Contains("transfer-encoding: chunked", forwarded, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Response_With_Conflicting_Content_Length_Is_Rejected()
+        {
+            // The same normalization protects the response path (response splitting).
+            var raw = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\nContent-Length: 4\r\n\r\n";
+
+            Assert.Throws<InvalidHttpFramingException>(
+                () => new ResponseHeader(raw.AsMemory(), false, true));
+        }
+    }
+}


### PR DESCRIPTION
Closes a few HTTP/1.1 request smuggling vectors where fluxzy framed a body one way but forwarded headers that let the origin frame it another way.

What changed, all centered on a single normalization pass in the Header parser so the body we read always matches what we forward:

- Strip Content-Length when Transfer-Encoding chunked is present (chunked wins, detected on the final transfer-coding token so gzip, chunked is caught too).
- Collapse equal duplicate Content-Length to one field.
- Reject conflicting duplicates and invalid values (non-digit, sign, list, overflow) by throwing, which drops the connection at the existing Proxy catch. This also kills the negative Content-Length case where the leftover body bytes used to get read as a smuggled next request.
- Strip Content-Length inside ForceTransferChunked, so the request body substitution path stops emitting CL plus TE to the origin itself.

New unit tests in Http11FramingTests cover all three vectors plus the collapse, final-token detection, OWS tolerance, ForceTransferChunked and the response side. Full UnitTests suite is green apart from the libpcap capture tests that need elevated privileges.