### PR TITLE
Remove sharpziplib and make extra content decoders pluggable

### DIFF
--- a/src/Fluxzy.Core/Archiving/Extensions/CompressionHelper.cs
+++ b/src/Fluxzy.Core/Archiving/Extensions/CompressionHelper.cs
@@ -1,9 +1,9 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
 using System.IO;
 using System.IO.Compression;
 using Fluxzy.Misc.Streams;
-using ICSharpCode.SharpZipLib.Lzw;
 
 namespace Fluxzy.Extensions
 {
@@ -13,11 +13,16 @@ namespace Fluxzy.Extensions
             ExchangeInfo exchangeInfo,
             Stream responseBodyInStream, int maximumLength, out CompressionInfo compressionInfo)
         {
-            // Check for chunked body 
+            // Check for chunked body
             var workStream = GetDecodedResponseBodyStream(exchangeInfo, responseBodyInStream, out var compressionType);
 
+            var encodingToken = exchangeInfo.GetResponseContentEncoding();
+
             compressionInfo = new CompressionInfo {
-                CompressionName = compressionType.ToString()
+                CompressionName = compressionType != CompressionType.None
+                    ? compressionType.ToString()
+                    : encodingToken ?? CompressionType.None.ToString(),
+                EncodingToken = encodingToken
             };
 
             try {
@@ -28,7 +33,7 @@ namespace Fluxzy.Extensions
             }
         }
 
-        public static Stream GetDecodedResponseBodyStream(this 
+        public static Stream GetDecodedResponseBodyStream(this
             IExchange exchangeInfo, Stream responseBodyInStream,
             out CompressionType compressionType, bool skipForwarded = false)
         {
@@ -37,14 +42,15 @@ namespace Fluxzy.Extensions
             if (exchangeInfo.IsResponseChunkedTransferEncoded(skipForwarded))
                 workStream = GetUnChunkedStream(workStream);
 
-            compressionType = exchangeInfo.GetResponseCompressionType();
+            var encodingToken = exchangeInfo.GetResponseContentEncoding();
+            compressionType = ExchangeExtensions.TokenToCompressionType(encodingToken);
 
-            workStream = GetDecodedStream(compressionType, workStream);
+            workStream = GetDecodedStream(encodingToken, workStream);
 
             return workStream;
         }
 
-        public static Stream GetDecodedRequestBodyStream(this 
+        public static Stream GetDecodedRequestBodyStream(this
             IExchange exchangeInfo, Stream requestBodyStream,
             out CompressionType compressionType, bool skipForwarded = false)
         {
@@ -53,9 +59,10 @@ namespace Fluxzy.Extensions
             if (exchangeInfo.IsRequestChunkedTransferEncoded(skipForwarded))
                 workStream = new ChunkedTransferReadStream(workStream, true);
 
-            compressionType = exchangeInfo.GetRequestCompressionType();
+            var encodingToken = exchangeInfo.GetRequestContentEncoding();
+            compressionType = ExchangeExtensions.TokenToCompressionType(encodingToken);
 
-            workStream = GetDecodedStream(compressionType, workStream);
+            workStream = GetDecodedStream(encodingToken, workStream);
 
             return workStream;
         }
@@ -67,41 +74,69 @@ namespace Fluxzy.Extensions
             return workStream;
         }
 
-
         internal static Stream GetDecodedStream(CompressionType compressionType, Stream workStream)
         {
-            switch (compressionType)
-            {
-                case CompressionType.None:
-                    break;
-
-                case CompressionType.Gzip:
-                    workStream = new GZipStream(workStream, CompressionMode.Decompress, false);
-                    break;
-
-                case CompressionType.Deflate:
-                    workStream = new DeflateStream(workStream, CompressionMode.Decompress, false);
-                    break;
-
-                case CompressionType.Compress:
-                    workStream = new LzwInputStream(workStream);
-
-                    break;
-
-                case CompressionType.Brotli:
-                    workStream = new BrotliStream(workStream, CompressionMode.Decompress, false);
-
-                    break;
-            }
-
-            return workStream;
+            return GetDecodedStream(CompressionTypeToToken(compressionType), workStream);
         }
 
+        /// <summary>
+        ///     Wraps <paramref name="workStream" /> with a decoding stream for the given content-encoding token.
+        ///     gzip, deflate and brotli are decoded natively; any other non-empty token is resolved through
+        ///     <see cref="ContentDecoderRegistry" />. A <see cref="FluxzyException" /> is thrown when no decoder
+        ///     is registered for the encoding.
+        /// </summary>
+        internal static Stream GetDecodedStream(string? encodingToken, Stream workStream)
+        {
+            if (string.IsNullOrEmpty(encodingToken))
+                return workStream;
 
+            switch (encodingToken) {
+                case "gzip":
+                    return new GZipStream(workStream, CompressionMode.Decompress, false);
+
+                case "deflate":
+                    return new DeflateStream(workStream, CompressionMode.Decompress, false);
+
+                case "br":
+                case "brotli":
+                    return new BrotliStream(workStream, CompressionMode.Decompress, false);
+
+                default:
+                    if (ContentDecoderRegistry.TryGet(encodingToken, out var decoder))
+                        return decoder.GetDecodedStream(workStream);
+
+                    throw new FluxzyException(
+                        $"No decoder registered for content-encoding '{encodingToken}'. " +
+                        $"gzip, deflate and brotli are supported out of the box; register a decoder for " +
+                        $"other encodings via ContentDecoderRegistry.Register(...).");
+            }
+        }
+
+        private static string? CompressionTypeToToken(CompressionType compressionType)
+        {
+            switch (compressionType) {
+                case CompressionType.Gzip:
+                    return "gzip";
+                case CompressionType.Deflate:
+                    return "deflate";
+                case CompressionType.Brotli:
+                    return "br";
+                case CompressionType.Compress:
+                    return "compress";
+                default:
+                    return null;
+            }
+        }
     }
 
     public class CompressionInfo
     {
         public string CompressionName { get; set; } = CompressionType.None.ToString();
+
+        /// <summary>
+        ///     The raw content-encoding token (lowercased, e.g. "gzip", "br", "zstd"), or null when not encoded.
+        ///     Used to resolve a decoder, including those provided through <see cref="ContentDecoderRegistry" />.
+        /// </summary>
+        public string? EncodingToken { get; set; }
     }
 }

--- a/src/Fluxzy.Core/Archiving/Extensions/ContentDecoderRegistry.cs
+++ b/src/Fluxzy.Core/Archiving/Extensions/ContentDecoderRegistry.cs
@@ -1,0 +1,78 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace Fluxzy
+{
+    /// <summary>
+    ///     A process-wide registry of <see cref="IContentDecoder" /> instances allowing callers to plug in
+    ///     decoders for HTTP content-encodings the .NET runtime cannot decode natively (e.g. <c>compress</c>/LZW,
+    ///     <c>zstd</c>).
+    ///     gzip, deflate and brotli are always handled by Fluxzy and do not need to be registered.
+    /// </summary>
+    /// <remarks>
+    ///     The goal of this extension point is to keep <c>Fluxzy.Core</c> free of extra third-party dependencies:
+    ///     a caller that needs an additional encoding brings the decoding library of their choice and registers
+    ///     it here. When Fluxzy encounters an encoding with no registered decoder it throws a
+    ///     <see cref="FluxzyException" /> rather than silently leaving the body encoded.
+    /// </remarks>
+    public static class ContentDecoderRegistry
+    {
+        private static readonly ConcurrentDictionary<string, IContentDecoder> Decoders =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        ///     Registers (or replaces) a decoder for its <see cref="IContentDecoder.EncodingToken" />.
+        /// </summary>
+        public static void Register(IContentDecoder decoder)
+        {
+            if (decoder == null)
+                throw new ArgumentNullException(nameof(decoder));
+
+            if (string.IsNullOrWhiteSpace(decoder.EncodingToken))
+                throw new ArgumentException("Decoder encoding token must not be empty", nameof(decoder));
+
+            Decoders[decoder.EncodingToken] = decoder;
+        }
+
+        /// <summary>
+        ///     Registers (or replaces) a decoder for <paramref name="encodingToken" /> from a delegate.
+        /// </summary>
+        public static void Register(string encodingToken, Func<Stream, Stream> factory)
+        {
+            Register(ContentDecoder.Create(encodingToken, factory));
+        }
+
+        /// <summary>
+        ///     Attempts to resolve a registered decoder for <paramref name="encodingToken" /> (case-insensitive).
+        /// </summary>
+        public static bool TryGet(string encodingToken, out IContentDecoder decoder)
+        {
+            if (string.IsNullOrEmpty(encodingToken)) {
+                decoder = null!;
+
+                return false;
+            }
+
+            return Decoders.TryGetValue(encodingToken, out decoder!);
+        }
+
+        /// <summary>
+        ///     Returns true if a decoder is registered for <paramref name="encodingToken" /> (case-insensitive).
+        /// </summary>
+        public static bool Contains(string encodingToken)
+        {
+            return !string.IsNullOrEmpty(encodingToken) && Decoders.ContainsKey(encodingToken);
+        }
+
+        /// <summary>
+        ///     Removes the decoder registered for <paramref name="encodingToken" />, if any.
+        /// </summary>
+        public static bool Unregister(string encodingToken)
+        {
+            return !string.IsNullOrEmpty(encodingToken) && Decoders.TryRemove(encodingToken, out _);
+        }
+    }
+}

--- a/src/Fluxzy.Core/Archiving/Extensions/ExchangeExtensions.cs
+++ b/src/Fluxzy.Core/Archiving/Extensions/ExchangeExtensions.cs
@@ -92,12 +92,7 @@ namespace Fluxzy.Extensions
 
         public static CompressionType GetResponseCompressionType(this IExchange exchangeInfo)
         {
-            var headers = exchangeInfo.GetResponseHeaders();
-
-            if (headers == null)
-                return CompressionType.None; 
-            
-            return InternalGetCompressionType(headers);
+            return TokenToCompressionType(exchangeInfo.GetResponseContentEncoding());
         }
 
         public static CompressionType GetRequestCompressionType(this IExchange exchangeInfo)
@@ -107,10 +102,55 @@ namespace Fluxzy.Extensions
             if (headers == null)
                 throw new InvalidOperationException("This exchange does not have request body");
 
-            return InternalGetCompressionType(headers);
+            return TokenToCompressionType(InternalGetEncodingToken(headers));
         }
 
-        private static CompressionType InternalGetCompressionType(IEnumerable<HeaderFieldInfo> headers)
+        /// <summary>
+        ///     Returns the raw response content-encoding token (lowercased, e.g. "gzip", "br", "compress", "zstd"),
+        ///     or null when the response is not encoded. Unlike <see cref="GetResponseCompressionType" /> this also
+        ///     surfaces encodings that are not represented by <see cref="CompressionType" /> (e.g. "zstd"), which are
+        ///     resolved through <see cref="ContentDecoderRegistry" />.
+        /// </summary>
+        public static string? GetResponseContentEncoding(this IExchange exchangeInfo)
+        {
+            var headers = exchangeInfo.GetResponseHeaders();
+
+            return headers == null ? null : InternalGetEncodingToken(headers);
+        }
+
+        /// <summary>
+        ///     Returns the raw request content-encoding token (lowercased), or null when the request is not encoded.
+        /// </summary>
+        public static string? GetRequestContentEncoding(this IExchange exchangeInfo)
+        {
+            var headers = exchangeInfo.GetRequestHeaders();
+
+            return headers == null ? null : InternalGetEncodingToken(headers);
+        }
+
+        internal static CompressionType TokenToCompressionType(string? encodingToken)
+        {
+            if (string.IsNullOrEmpty(encodingToken))
+                return CompressionType.None;
+
+            switch (encodingToken) {
+                case "gzip":
+                    return CompressionType.Gzip;
+                case "deflate":
+                    return CompressionType.Deflate;
+                case "br":
+                case "brotli":
+                    return CompressionType.Brotli;
+                case "compress":
+                    return CompressionType.Compress;
+                default:
+                    // Registry-handled encodings (e.g. "zstd") are not represented by the enum; callers
+                    // that need to act on them should use the raw token via GetResponse/RequestContentEncoding.
+                    return CompressionType.None;
+            }
+        }
+
+        private static string? InternalGetEncodingToken(IEnumerable<HeaderFieldInfo> headers)
         {
             var encodingHeaders = headers.Where(h => (h.Forwarded &&
                                                       h.Name.Span.Equals("Transfer-Encoding",
@@ -118,19 +158,38 @@ namespace Fluxzy.Extensions
                                                      || h.Name.Span.Equals("Content-encoding",
                                                          StringComparison.OrdinalIgnoreCase)).ToList();
 
+            if (encodingHeaders.Count == 0)
+                return null;
+
             if (encodingHeaders.Any(h => h.Value.Span.Contains("gzip", StringComparison.OrdinalIgnoreCase)))
-                return CompressionType.Gzip;
+                return "gzip";
 
             if (encodingHeaders.Any(h => h.Value.Span.Contains("deflate", StringComparison.OrdinalIgnoreCase)))
-                return CompressionType.Deflate;
+                return "deflate";
 
             if (encodingHeaders.Any(h => h.Value.Span.Contains("br", StringComparison.OrdinalIgnoreCase)))
-                return CompressionType.Brotli;
+                return "br";
 
             if (encodingHeaders.Any(h => h.Value.Span.Contains("compress", StringComparison.OrdinalIgnoreCase)))
-                return CompressionType.Compress;
+                return "compress";
 
-            return CompressionType.None;
+            // Unknown / non-native encoding (e.g. zstd) — return the raw token so a registered
+            // IContentDecoder can be resolved through ContentDecoderRegistry. Only Content-Encoding
+            // carries a content codec; Transfer-Encoding tokens such as "chunked" are framing, not
+            // compression, and must NOT be treated as decodable encodings.
+            foreach (var header in encodingHeaders) {
+                if (!header.Name.Span.Equals("Content-encoding", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var value = header.Value.ToString().Trim();
+
+                if (value.Length > 0
+                    && !value.Equals("identity", StringComparison.OrdinalIgnoreCase)
+                    && !value.Equals("chunked", StringComparison.OrdinalIgnoreCase))
+                    return value.ToLowerInvariant();
+            }
+
+            return null;
         }
     }
 

--- a/src/Fluxzy.Core/Archiving/Extensions/IContentDecoder.cs
+++ b/src/Fluxzy.Core/Archiving/Extensions/IContentDecoder.cs
@@ -1,0 +1,69 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+
+namespace Fluxzy
+{
+    /// <summary>
+    ///     Decodes an HTTP content-encoding that the .NET runtime cannot handle natively.
+    ///     gzip, deflate and brotli are decoded by Fluxzy out of the box; any other encoding
+    ///     (e.g. <c>compress</c>/LZW or <c>zstd</c>) requires a decoder to be registered through
+    ///     <see cref="ContentDecoderRegistry" />.
+    /// </summary>
+    /// <example>
+    ///     Using a delegate:
+    ///     <code>
+    ///     ContentDecoderRegistry.Register("zstd", compressed => new MyZstdDecodeStream(compressed));
+    ///     </code>
+    /// </example>
+    public interface IContentDecoder
+    {
+        /// <summary>
+        ///     The content-encoding token this decoder handles, lowercase (e.g. <c>"zstd"</c>, <c>"compress"</c>).
+        /// </summary>
+        string EncodingToken { get; }
+
+        /// <summary>
+        ///     Wraps a compressed input stream and returns a stream yielding the decoded bytes.
+        /// </summary>
+        /// <param name="compressed">The raw, still-encoded stream.</param>
+        /// <returns>A readable stream producing the decoded content.</returns>
+        Stream GetDecodedStream(Stream compressed);
+    }
+
+    /// <summary>
+    ///     Factory methods for creating <see cref="IContentDecoder" /> instances.
+    /// </summary>
+    public static class ContentDecoder
+    {
+        /// <summary>
+        ///     Creates an <see cref="IContentDecoder" /> from a delegate.
+        /// </summary>
+        /// <param name="encodingToken">The content-encoding token handled (e.g. <c>"zstd"</c>).</param>
+        /// <param name="decode">A function wrapping a compressed stream into a decoding stream.</param>
+        public static IContentDecoder Create(string encodingToken, Func<Stream, Stream> decode)
+        {
+            if (string.IsNullOrWhiteSpace(encodingToken))
+                throw new ArgumentException("Encoding token must not be empty", nameof(encodingToken));
+
+            return new DelegateContentDecoder(encodingToken,
+                decode ?? throw new ArgumentNullException(nameof(decode)));
+        }
+
+        private class DelegateContentDecoder : IContentDecoder
+        {
+            private readonly Func<Stream, Stream> _decode;
+
+            public DelegateContentDecoder(string encodingToken, Func<Stream, Stream> decode)
+            {
+                EncodingToken = encodingToken;
+                _decode = decode;
+            }
+
+            public string EncodingToken { get; }
+
+            public Stream GetDecodedStream(Stream compressed) => _decode(compressed);
+        }
+    }
+}

--- a/src/Fluxzy.Core/Archiving/ZipHelper.cs
+++ b/src/Fluxzy.Core/Archiving/ZipHelper.cs
@@ -3,32 +3,31 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Threading.Tasks;
-using ICSharpCode.SharpZipLib.Zip;
 
 namespace Fluxzy
 {
     /// <summary>
-    ///     Utilities for zipping a directory
+    ///     Utilities for zipping a directory using the runtime's <see cref="System.IO.Compression" />.
     /// </summary>
     internal static class ZipHelper
     {
-        public static Task DecompressAsync(
+        // ZipArchiveEntry timestamps must not predate the MS-DOS epoch (1980-01-01).
+        private static readonly DateTime DosEpoch = new(1980, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        public static async Task DecompressAsync(
             Stream input,
             DirectoryInfo directoryInfo)
         {
-            new FastZip().ExtractZip(input, directoryInfo.FullName, FastZip.Overwrite.Always,
-                s => true, ".*", ".*", true, true);
-
-            return Task.CompletedTask;
+            await InternalDecompress(input, directoryInfo, true);
         }
 
         public static void Decompress(
             Stream input,
             DirectoryInfo directoryInfo)
         {
-            new FastZip().ExtractZip(input, directoryInfo.FullName, FastZip.Overwrite.Always,
-                s => true, ".*", ".*", true, true);
+            InternalDecompress(input, directoryInfo, false).GetAwaiter().GetResult();
         }
 
         public static async Task Compress(
@@ -39,13 +38,14 @@ namespace Fluxzy
             if (!directoryInfo.Exists)
                 throw new ArgumentException($"Directory {directoryInfo.FullName} does not exists");
 
-            await using var zipStream = new ZipOutputStream(output) {
-                IsStreamOwner = false
-            };
+            using var zipArchive = new ZipArchive(output, ZipArchiveMode.Create, true);
 
-            zipStream.SetLevel(3);
+            foreach (var fileInfo in directoryInfo.EnumerateFiles("*", SearchOption.AllDirectories)) {
+                if (!fileInfo.Exists || !policy(fileInfo))
+                    continue;
 
-            await InternalCompressDirectory(directoryInfo, zipStream, policy);
+                await AddEntry(zipArchive, directoryInfo, fileInfo, false);
+            }
         }
 
         public static async Task CompressWithFileInfos(
@@ -55,90 +55,130 @@ namespace Fluxzy
             if (!directoryInfo.Exists)
                 throw new InvalidOperationException($"Directory {directoryInfo.FullName} does not exists");
 
-            await using var zipStream = new ZipOutputStream(output);
-
-            zipStream.SetLevel(3);
-
-            await InternaCompressDirectoryWithFileInfos(directoryInfo, zipStream, fileInfos);
-        }
-
-        private static async Task InternalCompressDirectory(
-            DirectoryInfo directoryInfo, ZipOutputStream zipStream,
-            Func<FileInfo, bool> policy)
-        {
-            var fileInfos = directoryInfo.EnumerateFiles("*", SearchOption.AllDirectories);
-            var directoryName = directoryInfo.FullName;
+            using var zipArchive = new ZipArchive(output, ZipArchiveMode.Create, false);
 
             foreach (var fileInfo in fileInfos) {
-                if (!fileInfo.Exists)
-                    continue;
+                await AddEntry(zipArchive, directoryInfo, fileInfo, true);
+            }
+        }
 
-                if (!policy(fileInfo))
-                    continue;
+        private static async Task AddEntry(
+            ZipArchive zipArchive, DirectoryInfo directoryInfo, FileInfo fileInfo, bool ignoreIoErrors)
+        {
+            try {
+                if (!fileInfo.Exists)
+                    return;
 
                 await using var fsInput = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
                 if (fsInput.Length == 0)
-                    continue;
+                    return;
 
-                var entryName = fileInfo.FullName.Replace(directoryName, string.Empty);
+                var entryName = CleanEntryName(fileInfo.FullName, directoryInfo.FullName);
 
-                entryName = ZipEntry.CleanName(entryName);
+                // pcap/pcapng files are already large binary captures that don't compress well.
+                var compressionLevel =
+                    fileInfo.Name.EndsWith("pcap", StringComparison.OrdinalIgnoreCase) ||
+                    fileInfo.Name.EndsWith("pcapng", StringComparison.OrdinalIgnoreCase)
+                        ? CompressionLevel.NoCompression
+                        : CompressionLevel.Fastest;
 
-                var newEntry = new ZipEntry(entryName) {
-                    DateTime = fileInfo.LastWriteTime
-                };
+                var newEntry = zipArchive.CreateEntry(entryName, compressionLevel);
 
-                if (fileInfo.Name.EndsWith("pcap", StringComparison.OrdinalIgnoreCase) ||
-                    fileInfo.Name.EndsWith("pcapng", StringComparison.OrdinalIgnoreCase)) {
-                    // We don't want to compress pcap files
-                    newEntry.CompressionMethod = CompressionMethod.Stored;
-                }
+                var lastWriteTime = fileInfo.LastWriteTime;
+                newEntry.LastWriteTime = lastWriteTime < DosEpoch ? DosEpoch : lastWriteTime;
 
-                await zipStream.PutNextEntryAsync(newEntry);
-                await fsInput.CopyToAsync(zipStream);
-                zipStream.CloseEntry();
+                await using var entryStream = newEntry.Open();
+                await fsInput.CopyToAsync(entryStream);
+            }
+            catch (IOException) when (ignoreIoErrors) {
+                // read input is ignored, file may currently be used by engine
             }
         }
 
-        private static async Task InternaCompressDirectoryWithFileInfos(
-            DirectoryInfo directoryInfo, ZipOutputStream zipStream,
-            IEnumerable<FileInfo> fileInfos)
+        private static async Task InternalDecompress(Stream input, DirectoryInfo directoryInfo, bool useAsync)
         {
-            var directoryName = directoryInfo.FullName;
+            // ZipArchive (Read) needs a seekable stream to locate the central directory.
+            Stream seekableInput;
+            MemoryStream? bufferedInput = null;
 
-            foreach (var fileInfo in fileInfos) {
-                try {
-                    if (!fileInfo.Exists)
+            if (input.CanSeek) {
+                seekableInput = input;
+            }
+            else {
+                bufferedInput = new MemoryStream();
+
+                if (useAsync)
+                    await input.CopyToAsync(bufferedInput);
+                else
+                    input.CopyTo(bufferedInput);
+
+                bufferedInput.Position = 0;
+                seekableInput = bufferedInput;
+            }
+
+            try {
+                using var zipArchive = new ZipArchive(seekableInput, ZipArchiveMode.Read, true);
+
+                var destinationRoot = Path.GetFullPath(directoryInfo.FullName);
+
+                Directory.CreateDirectory(destinationRoot);
+
+                foreach (var entry in zipArchive.Entries) {
+                    var fullPath = Path.GetFullPath(Path.Combine(destinationRoot, entry.FullName));
+
+                    // Zip-slip protection: reject entries that resolve outside the destination directory.
+                    if (!fullPath.StartsWith(destinationRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                        && !string.Equals(fullPath, destinationRoot, StringComparison.Ordinal))
                         continue;
 
-                    await using var fsInput = fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    // Directory entries have an empty name.
+                    if (string.IsNullOrEmpty(entry.Name)) {
+                        Directory.CreateDirectory(fullPath);
 
-                    if (fsInput.Length == 0)
                         continue;
-
-                    var entryName = fileInfo.FullName.Replace(directoryName, string.Empty);
-                    entryName = ZipEntry.CleanName(entryName);
-
-                    var newEntry = new ZipEntry(entryName) {
-                        DateTime = fileInfo.LastWriteTime
-                    };
-
-                    if (
-                        fileInfo.Name.EndsWith("pcap", StringComparison.OrdinalIgnoreCase) ||
-                        fileInfo.Name.EndsWith("pcapng", StringComparison.OrdinalIgnoreCase)) {
-                        // We don't want to compress pcap files
-                        newEntry.CompressionMethod = CompressionMethod.Stored;
                     }
 
-                    await zipStream.PutNextEntryAsync(newEntry);
-                    await fsInput.CopyToAsync(zipStream);
-                    zipStream.CloseEntry();
-                }
-                catch (IOException) {
-                    // read input is ignored, file may currently used by engine
+                    var parentDirectory = Path.GetDirectoryName(fullPath);
+
+                    if (parentDirectory != null)
+                        Directory.CreateDirectory(parentDirectory);
+
+                    await using (var entryStream = entry.Open())
+                    await using (var outputFileStream = File.Create(fullPath)) {
+                        if (useAsync)
+                            await entryStream.CopyToAsync(outputFileStream);
+                        else
+                            entryStream.CopyTo(outputFileStream);
+                    }
+
+                    try {
+                        File.SetLastWriteTime(fullPath, entry.LastWriteTime.LocalDateTime);
+                    }
+                    catch (IOException) {
+                        // restoring the timestamp is best-effort
+                    }
+                    catch (ArgumentOutOfRangeException) {
+                        // entry timestamp out of range, ignored
+                    }
                 }
             }
+            finally {
+                if (bufferedInput != null)
+                    await bufferedInput.DisposeAsync();
+            }
+        }
+
+        /// <summary>
+        ///     Builds a normalized, forward-slash zip entry name relative to <paramref name="directoryName" />.
+        /// </summary>
+        private static string CleanEntryName(string fullName, string directoryName)
+        {
+            var entryName = fullName.Replace(directoryName, string.Empty);
+
+            entryName = entryName.Replace('\\', '/');
+
+            return entryName.TrimStart('/');
         }
     }
 }

--- a/src/Fluxzy.Core/Core/ExchangeContext.cs
+++ b/src/Fluxzy.Core/Core/ExchangeContext.cs
@@ -243,9 +243,9 @@ namespace Fluxzy.Core
         }
 
         internal ValueTask<Stream> GetSubstitutedResponseBody(
-            Stream original, bool chunkedTransfer, CompressionType compressionType)
+            Stream original, bool chunkedTransfer, string? encodingToken)
         {
-            // remove compression from exchange 
+            // remove compression from exchange
 
             var decoded = original;
 
@@ -253,8 +253,8 @@ namespace Fluxzy.Core
                 decoded = CompressionHelper.GetUnChunkedStream(decoded);
             }
 
-            if (compressionType != CompressionType.None) {
-                decoded = CompressionHelper.GetDecodedStream(compressionType, decoded);
+            if (!string.IsNullOrEmpty(encodingToken)) {
+                decoded = CompressionHelper.GetDecodedStream(encodingToken, decoded);
             }
 
             return SubstitutionHelper.GetSubstitutedStream(decoded, _responseBodySubstitutions ??
@@ -263,9 +263,10 @@ namespace Fluxzy.Core
 
         internal ValueTask<Stream> GetSubstitutedRequestBody(Stream original, Exchange exchange)
         {
-            var decoded = exchange.GetDecodedRequestBodyStream(original, out var compressionType);
+            var encodingToken = exchange.GetRequestContentEncoding();
+            var decoded = exchange.GetDecodedRequestBodyStream(original, out _);
 
-            if (compressionType != CompressionType.None) {
+            if (!string.IsNullOrEmpty(encodingToken)) {
                 exchange.Request.Header.RemoveHeader("content-encoding");
             }
 

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -572,14 +572,14 @@ namespace Fluxzy.Core
                     var responseBodyStream = exchange.Response.Body;
 
                     var responseBodyChunked = false;
-                    var compressionType = CompressionType.None;
+                    string? responseEncodingToken = null;
 
                     if (exchange.Context.HasResponseBodySubstitution)
                     {
                         responseBodyChunked = exchange.IsResponseChunkedTransferEncoded();
-                        compressionType = exchange.GetResponseCompressionType();
+                        responseEncodingToken = exchange.GetResponseContentEncoding();
 
-                        if (compressionType != CompressionType.None)
+                        if (!string.IsNullOrEmpty(responseEncodingToken))
                         {
                             exchange.Response.Header.RemoveHeader("content-encoding");
                         }
@@ -634,7 +634,7 @@ namespace Fluxzy.Core
 
                                 responseBodyStream = await
                                     exchange.Context.GetSubstitutedResponseBody(
-                                                responseBodyStream, responseBodyChunked, compressionType)
+                                                responseBodyStream, responseBodyChunked, responseEncodingToken)
                                             .ConfigureAwait(false);
                             }
 

--- a/src/Fluxzy.Core/Fluxzy.Core.csproj
+++ b/src/Fluxzy.Core/Fluxzy.Core.csproj
@@ -46,7 +46,6 @@
     <PackageReference Include="Fluxzy.BouncyCastle.Crypto.Async" Version="2.6.0" />
     <PackageReference Include="MessagePack" Version="2.5.198" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>

--- a/src/Fluxzy.Core/Formatters/Producers/ProducerActions/Actions/SaveResponseBodyAction.cs
+++ b/src/Fluxzy.Core/Formatters/Producers/ProducerActions/Actions/SaveResponseBodyAction.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.IO;
-using System.IO.Compression;
 using System.Threading.Tasks;
 using Fluxzy.Extensions;
-using ICSharpCode.SharpZipLib.Lzw;
 
 namespace Fluxzy.Formatters.Producers.ProducerActions.Actions
 {
@@ -38,48 +36,17 @@ namespace Fluxzy.Formatters.Producers.ProducerActions.Actions
                 return true;
             }
 
-            if (context.CompressionInfo?.CompressionName == null ||
-                context.CompressionInfo?.CompressionName == nameof(CompressionType.None)) {
+            var encodingToken = context.CompressionInfo?.EncodingToken;
+
+            if (string.IsNullOrEmpty(encodingToken)) {
                 await rawFileStream.CopyToAsync(outStream);
 
                 return true;
             }
 
-            var compressionType = Enum.Parse<CompressionType>(context.CompressionInfo!.CompressionName);
-
-            Stream resultStream;
-
-            switch (compressionType) {
-                case CompressionType.None:
-                    resultStream = rawFileStream;
-
-                    break;
-
-                case CompressionType.Gzip:
-                    resultStream = new GZipStream(rawFileStream, CompressionMode.Decompress, true);
-
-                    break;
-
-                case CompressionType.Deflate:
-                    resultStream = new DeflateStream(rawFileStream, CompressionMode.Decompress, true);
-
-                    break;
-
-                case CompressionType.Compress:
-                    resultStream = new LzwInputStream(rawFileStream);
-
-                    break;
-
-                case CompressionType.Brotli:
-                    resultStream = new BrotliStream(rawFileStream, CompressionMode.Decompress, true);
-
-                    break;
-
-                default:
-                    resultStream = rawFileStream;
-
-                    break;
-            }
+            // gzip/deflate/brotli are decoded natively; other encodings (e.g. compress/LZW, zstd) require a
+            // decoder registered via ContentDecoderRegistry, otherwise a FluxzyException is thrown.
+            var resultStream = CompressionHelper.GetDecodedStream(encodingToken, rawFileStream);
 
             await resultStream.CopyToAsync(outStream);
 

--- a/src/Fluxzy.Core/Rules/Actions/HighLevelActions/InjectHtmlTagAction.cs
+++ b/src/Fluxzy.Core/Rules/Actions/HighLevelActions/InjectHtmlTagAction.cs
@@ -15,12 +15,15 @@ namespace Fluxzy.Rules.Actions.HighLevelActions
     /// <summary>
     ///     This action stream a response body and inject a text after the first specified html tag.
     ///     This action can be used to inject a html code snippet after opening `<head>` tag in a html page.
-    ///     This action supports chunked transfer stream and the following body encodings: gzip, deflate, brotli and lzw.This action supports chunked transfer stream and the following content encodings: gzip, deflate, brotli and lzw.
+    ///     This action supports chunked transfer stream and decodes gzip, deflate and brotli out of the box.
+    ///     Other content encodings (e.g. compress/LZW, zstd) are supported only when a matching decoder is
+    ///     registered through <see cref="ContentDecoderRegistry" />.
     /// </summary>
     [ActionMetadata(
         "This action stream a response body and inject a text after the first specified html tag." +
         "This action can be used to inject a html code snippet after opening `<head>` tag in any traversing html page." +
-        "This action supports chunked transfer stream and the following body encodings: gzip, deflate, brotli and lzw.",
+        "This action supports chunked transfer stream and decodes gzip, deflate and brotli out of the box; " +
+        "other content encodings require a decoder registered via ContentDecoderRegistry.",
         NonDesktopAction = true)]
     public class InjectHtmlTagAction : Action
     {

--- a/test/Fluxzy.Tests/Cli/Pack/PackCommandTests.cs
+++ b/test/Fluxzy.Tests/Cli/Pack/PackCommandTests.cs
@@ -1,8 +1,7 @@
-using Fluxzy.Tests._Fixtures;
 using Fluxzy.Tests.Cli.Scaffolding;
 using System.Threading.Tasks;
 using System.IO;
-using System.Runtime.InteropServices;
+using System.IO.Compression;
 using Xunit;
 
 namespace Fluxzy.Tests.Cli.Pack
@@ -18,15 +17,33 @@ namespace Fluxzy.Tests.Cli.Pack
         [Fact]
         public async Task To_Fluxzy_Archive()
         {
+            const string sourceDirectory = ".artefacts/tests/pink-floyd";
             var fileName = $"Drop/{nameof(To_Fluxzy_Archive)}.fxzy";
 
-            var runResult = await InternalRun($".artefacts/tests/pink-floyd", fileName);
+            var runResult = await InternalRun(sourceDirectory, fileName);
 
             Assert.Equal(0, runResult.ExitCode);
             Assert.True(File.Exists(fileName));
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                Assert.Equal(Startup.DefaultArchiveHash, HashHelper.MakeWinGetHash(fileName));
+            // The exact archive bytes are not portable: the zip container records OS specific file
+            // attributes and the deflate output depends on the runtime. Rather than pinning a hash, verify
+            // the archive opens and every entry round-trips byte for byte against its source file, since the
+            // packager stores the directory files verbatim.
+            using var archive = new ZipArchive(File.OpenRead(fileName), ZipArchiveMode.Read);
+
+            Assert.NotEmpty(archive.Entries);
+
+            foreach (var entry in archive.Entries) {
+                var sourcePath = Path.Combine(sourceDirectory, entry.FullName);
+
+                Assert.True(File.Exists(sourcePath), $"Archive entry '{entry.FullName}' has no matching source file");
+
+                using var entryStream = entry.Open();
+                using var buffer = new MemoryStream();
+                entryStream.CopyTo(buffer);
+
+                Assert.Equal(File.ReadAllBytes(sourcePath), buffer.ToArray());
+            }
         }
 
         [Fact]

--- a/test/Fluxzy.Tests/Startup.cs
+++ b/test/Fluxzy.Tests/Startup.cs
@@ -80,9 +80,6 @@ namespace Fluxzy.Tests
         public static string DefaultMergeArchivePcapHash { get; } =
             "5cf21b2c48ae241f46ddebf30fca6de2f757df52d00d9cf939b750f0296d33b8";
 
-        public static string DefaultArchiveHash { get; } =
-            "b74d2bb7de2579a46bd782d3133c7acce8353352fd22fb14067e264f6ba93540";
-
         private static void ExtractDirectory(byte[] binary, string directoryName)
         {
             using var zipArchive = new ZipArchive(new MemoryStream(binary), ZipArchiveMode.Read);

--- a/test/Fluxzy.Tests/UnitTests/Misc/ContentDecoderRegistryTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ContentDecoderRegistryTests.cs
@@ -1,0 +1,156 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Fluxzy;
+using Fluxzy.Extensions;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     Covers the pluggable content-decoder feature that replaced the bundled SharpZipLib LZW support:
+    ///     gzip/deflate/brotli are decoded natively, anything else is resolved through
+    ///     <see cref="ContentDecoderRegistry" /> and throws when no decoder is registered.
+    /// </summary>
+    public class ContentDecoderRegistryTests
+    {
+        private const string Payload = "the quick brown fox jumps over the lazy dog";
+
+        [Theory]
+        [InlineData("gzip")]
+        [InlineData("deflate")]
+        [InlineData("br")]
+        public void Native_encodings_decode_out_of_the_box(string token)
+        {
+            var compressed = Compress(token, Payload);
+
+            Assert.Equal(Payload, DecodeToString(token, compressed));
+        }
+
+        [Fact]
+        public void Empty_token_passes_the_stream_through_unchanged()
+        {
+            var raw = Encoding.UTF8.GetBytes(Payload);
+
+            using var result = CompressionHelper.GetDecodedStream((string?) null, new MemoryStream(raw));
+            using var reader = new StreamReader(result, Encoding.UTF8);
+
+            Assert.Equal(Payload, reader.ReadToEnd());
+        }
+
+        [Fact]
+        public void Unregistered_encoding_throws_a_clear_exception()
+        {
+            // No decoder registered for this token.
+            var token = "x-unregistered-" + Guid.NewGuid().ToString("N");
+
+            var ex = Assert.Throws<FluxzyException>(
+                () => CompressionHelper.GetDecodedStream(token, new MemoryStream()));
+
+            Assert.Contains(token, ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Registered_delegate_decoder_is_used()
+        {
+            var token = "x-deleg-" + Guid.NewGuid().ToString("N");
+
+            try {
+                // Use the gzip codec under a custom token to prove the registry is consulted.
+                ContentDecoderRegistry.Register(token,
+                    compressed => new GZipStream(compressed, CompressionMode.Decompress, false));
+
+                Assert.True(ContentDecoderRegistry.Contains(token));
+
+                var body = Compress("gzip", Payload);
+
+                Assert.Equal(Payload, DecodeToString(token, body));
+            }
+            finally {
+                Assert.True(ContentDecoderRegistry.Unregister(token));
+                Assert.False(ContentDecoderRegistry.Contains(token));
+            }
+        }
+
+        [Fact]
+        public void Registered_interface_decoder_is_used()
+        {
+            var token = "x-iface-" + Guid.NewGuid().ToString("N");
+            var decoder = new GzipBackedDecoder(token);
+
+            try {
+                ContentDecoderRegistry.Register(decoder);
+
+                Assert.True(ContentDecoderRegistry.TryGet(token, out var resolved));
+                Assert.Same(decoder, resolved);
+
+                var body = Compress("gzip", Payload);
+
+                Assert.Equal(Payload, DecodeToString(token, body));
+            }
+            finally {
+                ContentDecoderRegistry.Unregister(token);
+            }
+        }
+
+        [Fact]
+        public void Token_lookup_is_case_insensitive()
+        {
+            var token = "X-Case-" + Guid.NewGuid().ToString("N");
+
+            try {
+                ContentDecoderRegistry.Register(token,
+                    compressed => new GZipStream(compressed, CompressionMode.Decompress, false));
+
+                Assert.True(ContentDecoderRegistry.Contains(token.ToLowerInvariant()));
+                Assert.Equal(Payload, DecodeToString(token.ToLowerInvariant(), Compress("gzip", Payload)));
+            }
+            finally {
+                ContentDecoderRegistry.Unregister(token);
+            }
+        }
+
+        private static string DecodeToString(string token, byte[] compressed)
+        {
+            using var result = CompressionHelper.GetDecodedStream(token, new MemoryStream(compressed));
+            using var reader = new StreamReader(result, Encoding.UTF8);
+
+            return reader.ReadToEnd();
+        }
+
+        private static byte[] Compress(string token, string content)
+        {
+            var data = Encoding.UTF8.GetBytes(content);
+            using var memory = new MemoryStream();
+
+            Stream codec = token switch {
+                "gzip" => new GZipStream(memory, CompressionLevel.Optimal, true),
+                "deflate" => new DeflateStream(memory, CompressionLevel.Optimal, true),
+                "br" => new BrotliStream(memory, CompressionLevel.Optimal, true),
+                _ => throw new ArgumentOutOfRangeException(nameof(token))
+            };
+
+            using (codec) {
+                codec.Write(data, 0, data.Length);
+            }
+
+            return memory.ToArray();
+        }
+
+        private sealed class GzipBackedDecoder : IContentDecoder
+        {
+            public GzipBackedDecoder(string encodingToken)
+            {
+                EncodingToken = encodingToken;
+            }
+
+            public string EncodingToken { get; }
+
+            public Stream GetDecodedStream(Stream compressed) =>
+                new GZipStream(compressed, CompressionMode.Decompress, false);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/InjectHtmlHeadReproTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/InjectHtmlHeadReproTests.cs
@@ -1,0 +1,120 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     Reproduction for "InjectHtmlTagAction can't inject" reported against a page whose markup
+    ///     starts with an attributed root tag (`&lt;html lang="fr"&gt;`) and whose `&lt;head&gt;` is
+    ///     immediately followed by a very large inline `&lt;script&gt;` block.
+    /// </summary>
+    public class InjectHtmlHeadReproTests
+    {
+        // Faithful reproduction of the reported structure:
+        //  - <html> carries an attribute (lang="fr")
+        //  - a newline separates <html ...> from <head>
+        //  - <head> is immediately followed by a large inline <script> block containing quotes/urls/<>
+        private const string ProblemHtml =
+            "<html lang=\"fr\">\n" +
+            "<head><script>\n" +
+            "            var frzScriptsToPreload = document.createDocumentFragment();\n" +
+            "            var frzScriptsToPreloadUrls = [\"https://www.promovacances.com/resources/static/dist/obflnk/obflnk.js?r=a41433c3663743978b0208b64ce78536\",\"//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js\"];\n" +
+            "            var frzScriptsToPreloadScripts = [{\"src\":\"https://www.promovacances.com/resources/static/dist/vendor/vendor.js\",\"module\":false}];\n" +
+            "        </script></head>\n" +
+            "<body>hello</body></html>";
+
+        private const string Injected = "<!--INJECTED-->";
+
+        [Fact]
+        public void Matcher_should_find_head_in_problem_html()
+        {
+            var matcher = new SimpleHtmlTagOpeningMatcher(Encoding.UTF8, StringComparison.OrdinalIgnoreCase, false);
+
+            var (index, length) = matcher.FindIndex(ProblemHtml, "head");
+
+            var expectedIndex = ProblemHtml.IndexOf("<head", StringComparison.Ordinal);
+
+            Assert.Equal(expectedIndex, index);
+            Assert.Equal("<head>".Length, length);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(7)]
+        [InlineData(15)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(23)]
+        [InlineData(64)]
+        [InlineData(256)]
+        [InlineData(512)]
+        [InlineData(516)]
+        [InlineData(1024)]
+        [InlineData(8192)]
+        public void Should_inject_after_head_sync(int bufferSize)
+        {
+            var result = Inject(ProblemHtml, "head", Injected, bufferSize);
+
+            var expected = ProblemHtml.Replace("<head>", "<head>" + Injected);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(7)]
+        [InlineData(15)]
+        [InlineData(16)]
+        [InlineData(17)]
+        [InlineData(23)]
+        [InlineData(64)]
+        [InlineData(256)]
+        [InlineData(512)]
+        [InlineData(516)]
+        [InlineData(1024)]
+        [InlineData(8192)]
+        public async Task Should_inject_after_head_async(int bufferSize)
+        {
+            var result = await InjectAsync(ProblemHtml, "head", Injected, bufferSize);
+
+            var expected = ProblemHtml.Replace("<head>", "<head>" + Injected);
+
+            Assert.Equal(expected, result);
+        }
+
+        private static InjectStreamOnStream BuildStream(string content, string pattern, string inserted)
+        {
+            var matcher = new SimpleHtmlTagOpeningMatcher(Encoding.UTF8, StringComparison.OrdinalIgnoreCase, false);
+
+            return new InjectStreamOnStream(
+                new MemoryStream(Encoding.UTF8.GetBytes(content)),
+                matcher,
+                Encoding.UTF8.GetBytes(pattern),
+                new MemoryStream(Encoding.UTF8.GetBytes(inserted)));
+        }
+
+        private static string Inject(string content, string pattern, string inserted, int bufferSize)
+        {
+            using var stream = BuildStream(content, pattern, inserted);
+
+            return stream.ReadToEndWithCustomBuffer(bufferSize: bufferSize);
+        }
+
+        private static async Task<string> InjectAsync(string content, string pattern, string inserted, int bufferSize)
+        {
+            using var stream = BuildStream(content, pattern, inserted);
+
+            return await stream.ReadToEndWithCustomBufferAsync(bufferSize: bufferSize);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/InjectHtmlTagZstdDiagnosisTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/InjectHtmlTagZstdDiagnosisTests.cs
@@ -1,0 +1,144 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using Fluxzy;
+using Fluxzy.Clients.H11;
+using Fluxzy.Extensions;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Utils.ProcessTracking;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     Diagnosis of "InjectHtmlTagAction can't inject" on pages like promovacances.com.
+    ///
+    ///     The matcher itself is fine (see <see cref="InjectHtmlHeadReproTests" />). The injection only ever
+    ///     runs on a *decoded* body (<c>ExchangeContext.GetSubstitutedResponseBody</c> calls
+    ///     <c>CompressionHelper.GetDecodedStream(compressionType, ...)</c> first). The compression type is
+    ///     derived from the `Content-Encoding` header by <c>ExchangeExtensions.GetResponseCompressionType</c>,
+    ///     which only understands gzip / deflate / compress / brotli.
+    ///
+    ///     fluxzy advertises `Accept-Encoding: gzip, deflate, br, zstd` (see ImpersonateProfileManager), so a
+    ///     CDN may legitimately answer with `Content-Encoding: zstd`. That value maps to
+    ///     <see cref="CompressionType.None" />, the body is therefore NOT decompressed, and
+    ///     <see cref="InjectStreamOnStream" /> ends up scanning raw zstd bytes — it never finds `&lt;head&gt;`,
+    ///     so the body is streamed through unchanged and nothing is injected.
+    /// </summary>
+    public class InjectHtmlTagZstdDiagnosisTests
+    {
+        private const string Html =
+            "<html lang=\"fr\">\n<head><script>var x = 1;</script></head>\n<body>hello</body></html>";
+
+        // 1. The mapping bug: a `zstd` response is reported as "not compressed", so it is never decoded.
+        [Theory]
+        [InlineData("gzip", CompressionType.Gzip)]
+        [InlineData("br", CompressionType.Brotli)]
+        [InlineData("deflate", CompressionType.Deflate)]
+        [InlineData("zstd", CompressionType.None)]   // <-- unsupported: treated as "no compression"
+        public void ContentEncoding_detection(string contentEncoding, CompressionType expected)
+        {
+            var exchange = new FakeResponseExchange(
+                new HeaderFieldInfo("content-type", "text/html; charset=utf-8"),
+                new HeaderFieldInfo("content-encoding", contentEncoding));
+
+            Assert.Equal(expected, exchange.GetResponseCompressionType());
+        }
+
+        // 2. The consequence: feeding the *compressed* (== undecoded zstd) body to the injector finds no
+        //    <head> and injects nothing; feeding the *decoded* body injects correctly.
+        [Fact]
+        public void Injection_fails_on_compressed_body_but_succeeds_on_decoded_body()
+        {
+            var raw = Encoding.UTF8.GetBytes(Html);
+
+            // gzip stands in for "a content-encoding the proxy negotiated"; for zstd the proxy can't decode
+            // it at all, so the substitution stream receives these still-compressed bytes.
+            var compressed = Gzip(raw);
+
+            var onCompressed = Inject(compressed);
+            var onDecoded = Inject(raw);
+
+            // The marker never lands when the body is still compressed -> "can't inject".
+            Assert.DoesNotContain("INJECTED", onCompressed, StringComparison.Ordinal);
+
+            // Same input, but decoded first -> injection works, right after <head>.
+            Assert.Contains("<head><!--INJECTED-->", onDecoded, StringComparison.Ordinal);
+        }
+
+        private static string Inject(byte[] body)
+        {
+            var matcher = new SimpleHtmlTagOpeningMatcher(Encoding.UTF8, StringComparison.OrdinalIgnoreCase, false);
+
+            using var stream = new InjectStreamOnStream(
+                new MemoryStream(body),
+                matcher,
+                Encoding.UTF8.GetBytes("head"),
+                new MemoryStream(Encoding.UTF8.GetBytes("<!--INJECTED-->")));
+
+            // Read raw bytes (the body may not be valid UTF-8 when compressed) then latin1-decode for the assert.
+            using var output = new MemoryStream();
+            var buffer = new byte[64];
+            int read;
+
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0) {
+                output.Write(buffer, 0, read);
+            }
+
+            return Encoding.Latin1.GetString(output.ToArray());
+        }
+
+        private static byte[] Gzip(byte[] data)
+        {
+            using var memory = new MemoryStream();
+
+            using (var gzip = new GZipStream(memory, CompressionLevel.Optimal, true)) {
+                gzip.Write(data, 0, data.Length);
+            }
+
+            return memory.ToArray();
+        }
+
+        /// <summary>
+        ///     Minimal <see cref="IExchange" /> exposing only the response headers needed by
+        ///     <see cref="ExchangeExtensions.GetResponseCompressionType" />.
+        /// </summary>
+        private sealed class FakeResponseExchange : IExchange
+        {
+            private readonly List<HeaderFieldInfo> _responseHeaders;
+
+            public FakeResponseExchange(params HeaderFieldInfo[] responseHeaders)
+            {
+                _responseHeaders = responseHeaders.ToList();
+            }
+
+            public IEnumerable<HeaderFieldInfo>? GetResponseHeaders() => _responseHeaders;
+
+            public int Id => 1;
+            public string FullUrl => "https://www.promovacances.com/";
+            public string KnownAuthority => "www.promovacances.com";
+            public int KnownPort => 443;
+            public string HttpVersion => "HTTP/2";
+            public string Method => "GET";
+            public string Path => "/";
+            public int StatusCode => 200;
+            public string? EgressIp => null;
+            public string? Comment => null;
+            public HashSet<Tag>? Tags => null;
+            public bool IsWebSocket => false;
+            public List<WsMessage>? WebSocketMessages => null;
+            public Agent? Agent => null;
+            public ProcessInfo? ProcessInfo => null;
+            public List<ClientError> ClientErrors => new();
+
+            public IEnumerable<HeaderFieldInfo> GetRequestHeaders() => Array.Empty<HeaderFieldInfo>();
+            public IEnumerable<HeaderFieldInfo>? GetRequestTrailers() => null;
+            public IEnumerable<HeaderFieldInfo>? GetResponseTrailers() => null;
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/ResponseContentEncodingTokenTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ResponseContentEncodingTokenTests.cs
@@ -1,0 +1,104 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fluxzy;
+using Fluxzy.Clients.H11;
+using Fluxzy.Extensions;
+using Fluxzy.Utils.ProcessTracking;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     Guards the raw content-encoding token detection used by the pluggable-decoder dispatch.
+    ///     Regression: a forwarded <c>Transfer-Encoding: chunked</c> (with no Content-Encoding) must NOT be
+    ///     treated as a content codec — otherwise the decode dispatch throws on "chunked" and the proxy
+    ///     returns 502 for any chunked response that has a body substitution (e.g. InjectHtmlTagAction,
+    ///     TransformResponse). See sandbox.fluxzy.io/protocol which answers chunked.
+    /// </summary>
+    public class ResponseContentEncodingTokenTests
+    {
+        [Fact]
+        public void Forwarded_chunked_transfer_encoding_is_not_a_content_encoding()
+        {
+            var exchange = Response(
+                new HeaderFieldInfo("content-type".AsMemory(), "text/plain".AsMemory(), forwarded: true),
+                new HeaderFieldInfo("transfer-encoding".AsMemory(), "chunked".AsMemory(), forwarded: true));
+
+            Assert.Null(exchange.GetResponseContentEncoding());
+            Assert.Equal(CompressionType.None, exchange.GetResponseCompressionType());
+        }
+
+        [Theory]
+        [InlineData("gzip", "gzip", CompressionType.Gzip)]
+        [InlineData("deflate", "deflate", CompressionType.Deflate)]
+        [InlineData("br", "br", CompressionType.Brotli)]
+        [InlineData("compress", "compress", CompressionType.Compress)]
+        [InlineData("zstd", "zstd", CompressionType.None)] // non-native: token surfaced, enum stays None
+        [InlineData("ZSTD", "zstd", CompressionType.None)] // lowercased
+        public void Content_encoding_token_is_detected(string header, string expectedToken, CompressionType expectedEnum)
+        {
+            var exchange = Response(
+                new HeaderFieldInfo("content-encoding".AsMemory(), header.AsMemory(), forwarded: true));
+
+            Assert.Equal(expectedToken, exchange.GetResponseContentEncoding());
+            Assert.Equal(expectedEnum, exchange.GetResponseCompressionType());
+        }
+
+        [Fact]
+        public void Identity_content_encoding_is_treated_as_no_encoding()
+        {
+            var exchange = Response(
+                new HeaderFieldInfo("content-encoding".AsMemory(), "identity".AsMemory(), forwarded: true));
+
+            Assert.Null(exchange.GetResponseContentEncoding());
+        }
+
+        [Fact]
+        public void Forwarded_gzip_transfer_encoding_is_still_detected()
+        {
+            // gzip carried by a forwarded Transfer-Encoding remains detectable (original behavior).
+            var exchange = Response(
+                new HeaderFieldInfo("transfer-encoding".AsMemory(), "gzip".AsMemory(), forwarded: true));
+
+            Assert.Equal("gzip", exchange.GetResponseContentEncoding());
+        }
+
+        private static FakeResponseExchange Response(params HeaderFieldInfo[] headers) => new(headers);
+
+        private sealed class FakeResponseExchange : IExchange
+        {
+            private readonly List<HeaderFieldInfo> _responseHeaders;
+
+            public FakeResponseExchange(IEnumerable<HeaderFieldInfo> responseHeaders)
+            {
+                _responseHeaders = responseHeaders.ToList();
+            }
+
+            public IEnumerable<HeaderFieldInfo>? GetResponseHeaders() => _responseHeaders;
+
+            public int Id => 1;
+            public string FullUrl => "https://sandbox.fluxzy.io/protocol";
+            public string KnownAuthority => "sandbox.fluxzy.io";
+            public int KnownPort => 443;
+            public string HttpVersion => "HTTP/1.1";
+            public string Method => "GET";
+            public string Path => "/protocol";
+            public int StatusCode => 200;
+            public string? EgressIp => null;
+            public string? Comment => null;
+            public HashSet<Tag>? Tags => null;
+            public bool IsWebSocket => false;
+            public List<WsMessage>? WebSocketMessages => null;
+            public Agent? Agent => null;
+            public ProcessInfo? ProcessInfo => null;
+            public List<ClientError> ClientErrors => new();
+
+            public IEnumerable<HeaderFieldInfo> GetRequestHeaders() => Array.Empty<HeaderFieldInfo>();
+            public IEnumerable<HeaderFieldInfo>? GetRequestTrailers() => null;
+            public IEnumerable<HeaderFieldInfo>? GetResponseTrailers() => null;
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/ZipHelperTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ZipHelperTests.cs
@@ -1,0 +1,148 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     Covers the migration of <c>ZipHelper</c> from SharpZipLib to <see cref="System.IO.Compression" />:
+    ///     directory round-trip, pcap files stored uncompressed, and zip-slip protection on extraction.
+    /// </summary>
+    public class ZipHelperTests : IDisposable
+    {
+        private readonly string _root =
+            Path.Combine(Path.GetTempPath(), "fluxzy-ziphelper-tests", Guid.NewGuid().ToString("N"));
+
+        [Fact]
+        public async Task Compress_then_decompress_roundtrips_files_and_subdirectories()
+        {
+            var source = NewDir("src");
+            File.WriteAllText(Path.Combine(source, "a.txt"), "hello A");
+
+            var subDir = Path.Combine(source, "sub");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(subDir, "b.txt"), "hello B nested");
+
+            using var ms = new MemoryStream();
+            await ZipHelper.Compress(new DirectoryInfo(source), ms, _ => true);
+
+            ms.Position = 0;
+            var target = NewDir("dst");
+            await ZipHelper.DecompressAsync(ms, new DirectoryInfo(target));
+
+            Assert.Equal("hello A", File.ReadAllText(Path.Combine(target, "a.txt")));
+            Assert.Equal("hello B nested", File.ReadAllText(Path.Combine(target, "sub", "b.txt")));
+        }
+
+        [Fact]
+        public async Task Sync_decompress_roundtrips()
+        {
+            var source = NewDir("src-sync");
+            File.WriteAllText(Path.Combine(source, "a.txt"), "sync content");
+
+            using var ms = new MemoryStream();
+            await ZipHelper.Compress(new DirectoryInfo(source), ms, _ => true);
+
+            ms.Position = 0;
+            var target = NewDir("dst-sync");
+            ZipHelper.Decompress(ms, new DirectoryInfo(target));
+
+            Assert.Equal("sync content", File.ReadAllText(Path.Combine(target, "a.txt")));
+        }
+
+        [Fact]
+        public async Task Pcap_files_are_stored_uncompressed()
+        {
+            var source = NewDir("src");
+            var compressible = new string('A', 8192);
+
+            File.WriteAllText(Path.Combine(source, "capture.pcapng"), compressible);
+            File.WriteAllText(Path.Combine(source, "data.txt"), compressible);
+
+            using var ms = new MemoryStream();
+            await ZipHelper.Compress(new DirectoryInfo(source), ms, _ => true);
+
+            ms.Position = 0;
+            using var archive = new ZipArchive(ms, ZipArchiveMode.Read);
+
+            var pcap = archive.Entries.Single(e => e.Name == "capture.pcapng");
+            var txt = archive.Entries.Single(e => e.Name == "data.txt");
+
+            Assert.Equal(pcap.Length, pcap.CompressedLength); // stored (NoCompression)
+            Assert.True(txt.CompressedLength < txt.Length);    // compressed
+        }
+
+        [Fact]
+        public void Decompress_rejects_zip_slip_entries()
+        {
+            using var ms = new MemoryStream();
+
+            using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true)) {
+                var entry = archive.CreateEntry("../escaped.txt");
+                using var s = entry.Open();
+                s.Write(Encoding.UTF8.GetBytes("pwned"));
+            }
+
+            ms.Position = 0;
+
+            var target = NewDir("dst-slip");
+            ZipHelper.Decompress(ms, new DirectoryInfo(target));
+
+            var escaped = Path.GetFullPath(Path.Combine(target, "..", "escaped.txt"));
+
+            Assert.False(File.Exists(escaped),
+                "zip-slip entry must not be written outside the target directory");
+        }
+
+        [Fact]
+        public async Task CompressWithFileInfos_roundtrips()
+        {
+            var source = NewDir("src-fi");
+            var file = Path.Combine(source, "x.json");
+            File.WriteAllText(file, "{\"k\":1}");
+
+            byte[] bytes;
+
+            // CompressWithFileInfos owns/closes the output stream, so capture the buffer afterwards.
+            using (var ms = new MemoryStream()) {
+                await ZipHelper.CompressWithFileInfos(new DirectoryInfo(source), ms,
+                    new[] { new FileInfo(file) });
+
+                bytes = ms.ToArray();
+            }
+
+            var target = NewDir("dst-fi");
+
+            using (var input = new MemoryStream(bytes)) {
+                await ZipHelper.DecompressAsync(input, new DirectoryInfo(target));
+            }
+
+            Assert.Equal("{\"k\":1}", File.ReadAllText(Path.Combine(target, "x.json")));
+        }
+
+        private string NewDir(string name)
+        {
+            var path = Path.Combine(_root, name);
+            Directory.CreateDirectory(path);
+
+            return path;
+        }
+
+        public void Dispose()
+        {
+            try {
+                if (Directory.Exists(_root))
+                    Directory.Delete(_root, true);
+            }
+            catch {
+                // best-effort cleanup
+            }
+        }
+    }
+}


### PR DESCRIPTION
Removes the SharpZipLib dependency, which was only used for two things.

Zip handling moves to the built-in System.IO.Compression, the same API the rest of the repo already uses. pcap and pcapng entries stay stored uncompressed, and extraction now rejects zip-slip paths.

For content-encodings, gzip, deflate and brotli still decode natively. Anything else (compress/lzw, zstd, or a custom codec) is now supplied by the caller through ContentDecoderRegistry, and an unregistered encoding throws instead of leaving the body silently encoded. That also lets a registered zstd decoder work for body injection. Decoding dispatches on the raw content-encoding token, with a guard so a normal chunked transfer-encoding is not treated as a codec.

Registering a decoder is a one-liner at startup, using whatever codec library you prefer:

```csharp
// e.g. with ZstdSharp
ContentDecoderRegistry.Register("zstd", compressed => new DecompressionStream(compressed));
```

or implement IContentDecoder when you need more control:

```csharp
public sealed class ZstdDecoder : IContentDecoder
{
    public string EncodingToken => "zstd";
    public Stream GetDecodedStream(Stream compressed) => new DecompressionStream(compressed);
}

ContentDecoderRegistry.Register(new ZstdDecoder());
```

Two commits: the decoder change, then the zip swap and package removal. Builds on net8 and net10, with tests for the registry, the zip round-trip and zip-slip, and the chunked case.