### PR TITLE
Register a zstd content decoder in the CLI

### DIFF
--- a/src/Fluxzy/FluxzyStartup.cs
+++ b/src/Fluxzy/FluxzyStartup.cs
@@ -14,9 +14,14 @@ namespace Fluxzy.Cli
 {
     public static class FluxzyStartup
     {
-        public static async Task<int> Run(string[] args, OutputConsole? outputConsole, CancellationToken token, 
+        private static int _decodersRegistered;
+
+        public static async Task<int> Run(string[] args, OutputConsole? outputConsole, CancellationToken token,
             EnvironmentProvider? environmentProvider = null)
         {
+            if (Interlocked.Exchange(ref _decodersRegistered, 1) == 0)
+                ContentDecoderRegistry.Register(new ZstandardContentDecoder());
+
             var currentEnvironmentProvider = environmentProvider ?? new SystemEnvironmentProvider();
 
             if (currentEnvironmentProvider.GetEnvironmentVariable("FLUXZY_STDOUT_ARGS") == "1") {

--- a/src/Fluxzy/ZstandardContentDecoder.cs
+++ b/src/Fluxzy/ZstandardContentDecoder.cs
@@ -1,0 +1,20 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.IO;
+using ZstdSharp;
+
+namespace Fluxzy.Cli
+{
+    /// <summary>
+    ///     zstd content-encoding decoder for the CLI, backed by ZstdSharp. Fluxzy.Core ships no zstd codec
+    ///     by design; the CLI plugs this in through <see cref="ContentDecoderRegistry" /> at startup.
+    /// </summary>
+    internal sealed class ZstandardContentDecoder : IContentDecoder
+    {
+        public string EncodingToken => "zstd";
+
+        // leaveOpen:false to match Fluxzy's native gzip/deflate/brotli decoders.
+        public Stream GetDecodedStream(Stream compressed)
+            => new DecompressionStream(compressed, leaveOpen: false);
+    }
+}

--- a/src/Fluxzy/fluxzy.csproj
+++ b/src/Fluxzy/fluxzy.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageReference Include="Spectre.Console" Version="0.55.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Fluxzy.Tests/UnitTests/Misc/ZstdContentDecoderCliTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ZstdContentDecoderCliTests.cs
@@ -1,0 +1,91 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Cli;
+using Fluxzy.Cli.Commands;
+using Fluxzy.Extensions;
+using Fluxzy.Misc.Streams;
+using Xunit;
+using ZstdSharp;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    /// <summary>
+    ///     The CLI plugs a zstd decoder into <see cref="ContentDecoderRegistry" /> at startup (Fluxzy.Core
+    ///     ships none by design). These tests check the registration happens and that the body-decode path
+    ///     used by injection/substitution now handles a <c>Content-Encoding: zstd</c> body — closing the gap
+    ///     described in <see cref="InjectHtmlTagZstdDiagnosisTests" />.
+    /// </summary>
+    public class ZstdContentDecoderCliTests
+    {
+        private const string Html =
+            "<html lang=\"fr\">\n<head><script>var x = 1;</script></head>\n<body>hello</body></html>";
+
+        [Fact]
+        public async Task Run_registers_zstd_decoder()
+        {
+            await FluxzyStartup.Run(new[] { "--version" }, OutputConsole.CreateEmpty(), CancellationToken.None);
+
+            Assert.True(ContentDecoderRegistry.Contains("zstd"));
+        }
+
+        [Fact]
+        public async Task Registered_decoder_round_trips()
+        {
+            await FluxzyStartup.Run(new[] { "--version" }, OutputConsole.CreateEmpty(), CancellationToken.None);
+
+            var raw = Encoding.UTF8.GetBytes(Html);
+
+            using var decoded = CompressionHelper.GetDecodedStream("zstd", new MemoryStream(Zstd(raw)));
+            using var output = new MemoryStream();
+            decoded.CopyTo(output);
+
+            Assert.Equal(Html, Encoding.UTF8.GetString(output.ToArray()));
+        }
+
+        [Fact]
+        public async Task Injection_succeeds_on_zstd_encoded_body()
+        {
+            await FluxzyStartup.Run(new[] { "--version" }, OutputConsole.CreateEmpty(), CancellationToken.None);
+
+            var compressed = Zstd(Encoding.UTF8.GetBytes(Html));
+
+            // The substitution path decodes the body first, then scans for <head>.
+            using var decoded = CompressionHelper.GetDecodedStream("zstd", new MemoryStream(compressed));
+            var injected = Inject(decoded);
+
+            Assert.Contains("<head><!--INJECTED-->", injected, StringComparison.Ordinal);
+        }
+
+        private static string Inject(Stream body)
+        {
+            var matcher = new SimpleHtmlTagOpeningMatcher(Encoding.UTF8, StringComparison.OrdinalIgnoreCase, false);
+
+            using var stream = new InjectStreamOnStream(
+                body,
+                matcher,
+                Encoding.UTF8.GetBytes("head"),
+                new MemoryStream(Encoding.UTF8.GetBytes("<!--INJECTED-->")));
+
+            using var output = new MemoryStream();
+            stream.CopyTo(output);
+
+            return Encoding.UTF8.GetString(output.ToArray());
+        }
+
+        private static byte[] Zstd(byte[] data)
+        {
+            using var memory = new MemoryStream();
+
+            using (var zstd = new CompressionStream(memory, leaveOpen: true)) {
+                zstd.Write(data, 0, data.Length);
+            }
+
+            return memory.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Fluxzy.Core deliberately ships no zstd codec (see #677): gzip, deflate and brotli decode natively, everything else is caller-pluggable through `ContentDecoderRegistry`. Until now the CLI registered nothing, so a `Content-Encoding: zstd` response threw `FluxzyException` for an unregistered encoding.

The CLI now plugs a zstd decoder in at startup using `ZstdSharp.Port`, so zstd bodies decode end to end for the live proxy, body injection, `dissect` and `pack`. This closes the injection gap reported on zstd-serving CDNs.

Notes:
- The decoder wraps `ZstdSharp.DecompressionStream` with `leaveOpen:false` to match the native gzip/deflate/brotli disposal contract in `CompressionHelper`.
- Registration lives in `FluxzyStartup.Run` (guarded so it runs once), which also covers the CLI integration tests since they enter through `Run`.
- Only the CLI project takes the new dependency; Core is untouched, and unregistered encodings still throw loudly as designed.
- Only the standard `zstd` token is registered (RFC 8878 / what `ImpersonateProfileManager` advertises).

Tests: startup registers the decoder, a real zstd buffer round-trips, and a `Content-Encoding: zstd` body decodes and receives `<head>` injection.