### PR TITLE
Bump YamlDotNet to 18 and read rule files with positioned errors

### DIFF
--- a/src/Fluxzy.Core/Fluxzy.Core.csproj
+++ b/src/Fluxzy.Core/Fluxzy.Core.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="MessagePack" Version="2.5.198" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Fluxzy.Core/Misc/Converters/PolymorphicConverter.cs
+++ b/src/Fluxzy.Core/Misc/Converters/PolymorphicConverter.cs
@@ -10,23 +10,14 @@ namespace Fluxzy.Misc.Converters
 {
     public class PolymorphicConverter<T> : JsonConverter<T> where T : PolymorphicObject
     {
-        private readonly Dictionary<string, Type> _typeMapping;
+        private readonly IReadOnlyDictionary<string, Type> _typeMapping;
 
         public PolymorphicConverter(params Type[] args)
         {
-            if (args.Any()) {
-                _typeMapping = args.ToDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
-
-                return;
-            }
-
-            var foundTypes = typeof(T).Assembly.GetTypes()
-                                      .Where(derivedType => typeof(T).IsAssignableFrom(derivedType)
-                                                            && derivedType != typeof(T)
-                                                            && !derivedType.IsAbstract
-                                                            && derivedType.IsClass).ToList();
-
-            _typeMapping = foundTypes.ToDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
+            // Assembly scan shared with the YAML rule reader via PolymorphicTypeResolver.
+            _typeMapping = args.Any()
+                ? args.ToDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase)
+                : PolymorphicTypeResolver.GetMap(typeof(T));
         }
 
         public override bool CanConvert(Type typeToConvert)

--- a/src/Fluxzy.Core/Misc/Converters/PolymorphicTypeResolver.cs
+++ b/src/Fluxzy.Core/Misc/Converters/PolymorphicTypeResolver.cs
@@ -1,0 +1,50 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Fluxzy.Misc.Converters
+{
+    /// <summary>
+    ///     Maps a <c>typeKind</c> to a concrete <see cref="PolymorphicObject" /> type by scanning the
+    ///     declaring assembly. Shared by the System.Text.Json archive path and the YAML rule reader.
+    /// </summary>
+    internal static class PolymorphicTypeResolver
+    {
+        private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, Type>> Maps = new();
+
+        public static IReadOnlyDictionary<string, Type> GetMap(Type baseType)
+        {
+            return Maps.GetOrAdd(baseType, Build);
+        }
+
+        /// <summary>
+        ///     Resolves a <c>typeKind</c> to a concrete type: exact class name, then a
+        ///     <c>typeKind + baseTypeName</c> fallback (so <c>Host</c> resolves to <c>HostFilter</c>).
+        /// </summary>
+        public static bool TryResolve(Type baseType, string typeKind, out Type? type)
+        {
+            var map = GetMap(baseType);
+
+            return map.TryGetValue(typeKind, out type)
+                   || map.TryGetValue(typeKind + baseType.Name, out type);
+        }
+
+        private static IReadOnlyDictionary<string, Type> Build(Type baseType)
+        {
+            var map = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var type in baseType.Assembly.GetTypes()) {
+                if (baseType.IsAssignableFrom(type)
+                    && type != baseType
+                    && !type.IsAbstract
+                    && type.IsClass) {
+                    map[type.Name] = type;
+                }
+            }
+
+            return map;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Rules/IgnorePremadePropertiesFilter.cs
+++ b/src/Fluxzy.Core/Rules/IgnorePremadePropertiesFilter.cs
@@ -41,8 +41,20 @@ namespace Fluxzy.Rules
             // Retains only inverted 
 
             return properties.Where(p =>
-                p.Name.Equals(nameof(Filter.TypeKind), 
+                p.Name.Equals(nameof(Filter.TypeKind),
                     StringComparison.OrdinalIgnoreCase));
         }
+
+        public override string GetEnumName(Type enumType, string name)
+            => _innerTypeInspector.GetEnumName(enumType, name);
+
+        public override string GetEnumValue(object enumValue)
+            => _innerTypeInspector.GetEnumValue(enumValue);
+
+        public override bool HasParseMethod(Type type)
+            => _innerTypeInspector.HasParseMethod(type);
+
+        public override object? Parse(string value, Type expectedType)
+            => _innerTypeInspector.Parse(value, expectedType);
     }
 }

--- a/src/Fluxzy.Core/Rules/RuleConfigParser.cs
+++ b/src/Fluxzy.Core/Rules/RuleConfigParser.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
+using Fluxzy.Rules.Yaml;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
@@ -28,147 +28,111 @@ namespace Fluxzy.Rules
 
         public RuleSet? TryGetRuleSetFromYaml(string yamlContent, out List<RuleConfigReaderError>? readErrors)
         {
-            var deserializer = BuildDefaultDeserializer();
-            using var stringReader = new StringReader(yamlContent);
+            readErrors = new List<RuleConfigReaderError>();
 
-            Dictionary<string, object> rawObject;
+            RuleSet? ruleSet;
 
             try {
-                rawObject = deserializer.Deserialize<Dictionary<string, object>>(stringReader);
-
-                if (rawObject.Any(r => r.Key != "rules")) {
-                    readErrors = new List<RuleConfigReaderError> {
-                        new(
-                            $"Unknown entries found {string.Join(", ", rawObject.Where(r => r.Key != "rules").Select(s => s.Key))}. Expected \"rules\"")
-                    };
-
-                    return null;
-                }
+                using var stringReader = new StringReader(yamlContent);
+                ruleSet = RuleYamlDeserializerFactory.Instance.Deserialize<RuleSet>(stringReader);
             }
-            catch (Exception e) {
-                if (e is SemanticErrorException see) {
-                    readErrors = new List<RuleConfigReaderError> {
-                        new($"{see.Message} {see.End}")
-                    };
+            catch (YamlException ex) {
+                readErrors.Add(ToError(ex));
 
-                    return null;
-                }
-
-                readErrors = new List<RuleConfigReaderError> {
-                    new($"Unable to read yaml file : {e.Message}")
-                };
+                return null;
+            }
+            catch (Exception ex) {
+                readErrors.Add(new RuleConfigReaderError($"Unable to read yaml file : {ex.Message}"));
 
                 return null;
             }
 
-            readErrors = new List<RuleConfigReaderError>();
+            if (ruleSet?.Rules == null || ruleSet.Rules.Count == 0) {
+                readErrors.Add(new RuleConfigReaderError("No rule found. Expected a top-level \"rules\" entry."));
+
+                return null;
+            }
 
             var ruleIndex = 1;
 
-            var result = new RuleSet();
+            foreach (var container in ruleSet.Rules) {
+                var ruleName = container.Name ?? $"Rule #{ruleIndex}";
 
-            if (rawObject.TryGetValue("rules", out var tempList) && tempList is ICollection<object> items) {
-                foreach (var item in items) {
-                    var current = InternalTryGetRuleFromYaml(out var partialErrors, item);
+                ValidateContainer(container, ruleName, $"rules[{ruleIndex - 1}]", readErrors);
 
-                    var ruleName = current?.Name ?? $"Rule #{ruleIndex}";
-
-                    ruleIndex++;
-
-                    if (current == null) {
-                        readErrors.Add(new RuleConfigReaderError($"Error in “{ruleName}”"));
-                        readErrors.AddRange(partialErrors);
-
-                        continue;
-                    }
-
-                    result.Rules.Add(current);
-                }
+                ruleIndex++;
             }
 
-            return readErrors.Any() ? null : result;
+            return readErrors.Any() ? null : ruleSet;
         }
 
         public RuleConfigContainer? TryGetRuleFromYaml(
             string yamlContent,
             out List<RuleConfigReaderError>? readErrors)
         {
-            var deserializer = BuildDefaultDeserializer();
-
-            using var stringReader = new StringReader(yamlContent);
-
-            try {
-                var rawObject = deserializer.Deserialize(stringReader);
-
-                return InternalTryGetRuleFromYaml(out readErrors, rawObject);
-            }
-            catch (Exception ex) {
-                if (ex is SemanticErrorException see) {
-                    readErrors = new List<RuleConfigReaderError> {
-                        new($"{see.Message} {see.End}")
-                    };
-
-                    return null;
-                }
-
-                readErrors = new List<RuleConfigReaderError> {
-                    new("Not a valid yaml " + ex.Message)
-                };
-
-                return null;
-            }
-        }
-
-        private static RuleConfigContainer? InternalTryGetRuleFromYaml(
-            out List<RuleConfigReaderError> readErrors, object? rawObject)
-        {
-            var flatJson = JsonSerializer.Serialize(rawObject, GlobalArchiveOption.ConfigSerializerOptions);
-
             readErrors = new List<RuleConfigReaderError>();
 
-            // TODO skip entirely System.Text.Json bridge 
-            // Main downside of current method is the user is unable to determine in which line the error occurs
-            // 
             RuleConfigContainer? rule;
 
             try {
-                rule = JsonSerializer.Deserialize<RuleConfigContainer?>(flatJson,
-                    GlobalArchiveOption.ConfigSerializerOptions);
+                using var stringReader = new StringReader(yamlContent);
+                rule = RuleYamlDeserializerFactory.Instance.Deserialize<RuleConfigContainer>(stringReader);
             }
-            catch (Exception e) {
-                readErrors.Add(new RuleConfigReaderError(e.Message));
+            catch (YamlException ex) {
+                readErrors.Add(ToError(ex));
+
+                return null;
+            }
+            catch (Exception ex) {
+                readErrors.Add(new RuleConfigReaderError("Not a valid yaml " + ex.Message));
 
                 return null;
             }
 
-            if (rule == null) {
-                readErrors.Add(new RuleConfigReaderError("Cannot parse rule"));
+            ValidateContainer(rule, "rule", path: null, readErrors);
 
-                return null;
-            }
-
-            if (rule.Filter == null!) {
-                readErrors.Add(new RuleConfigReaderError("Unable to detect filter matching this rule"));
-
-                return null;
-            }
-
-            if (!rule.GetAllActions().Any()) {
-                readErrors.Add(new RuleConfigReaderError("Unable to detect action matching this rule"));
-
-                return null;
-            }
-
-            return rule;
+            return readErrors.Any() ? null : rule;
         }
 
-        private static IDeserializer BuildDefaultDeserializer()
+        private static void ValidateContainer(
+            RuleConfigContainer? container, string ruleName, string? path,
+            List<RuleConfigReaderError> readErrors)
         {
-            var deserializer = new DeserializerBuilder()
-                               .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                               .Build();
+            if (container == null) {
+                readErrors.Add(new RuleConfigReaderError("Cannot parse rule"));
 
-            return deserializer;
+                return;
+            }
+
+            if (container.Filter == null!) {
+                readErrors.Add(new RuleConfigReaderError(
+                    $"Unable to detect filter matching this rule (“{ruleName}”)", null, null, path));
+            }
+
+            if (!container.GetAllActions().Any()) {
+                readErrors.Add(new RuleConfigReaderError(
+                    $"Unable to detect action matching this rule (“{ruleName}”)", null, null, path));
+            }
+        }
+
+        /// <summary>
+        ///     Maps a <see cref="YamlException" /> to a reader error, using the innermost exception for the
+        ///     most specific message and position.
+        /// </summary>
+        private static RuleConfigReaderError ToError(YamlException exception)
+        {
+            var innermost = exception;
+
+            while (innermost.InnerException is YamlException inner) {
+                innermost = inner;
+            }
+
+            var start = innermost.Start;
+
+            return new RuleConfigReaderError(
+                innermost.Message,
+                start.Line > 0 ? (int) start.Line : (int?) null,
+                start.Column > 0 ? (int) start.Column : (int?) null);
         }
 
         private static ISerializer BuildDefaultSerializer()

--- a/src/Fluxzy.Core/Rules/RuleConfigReaderError.cs
+++ b/src/Fluxzy.Core/Rules/RuleConfigReaderError.cs
@@ -9,7 +9,38 @@ namespace Fluxzy.Rules
             Message = message;
         }
 
+        /// <summary>
+        ///     Creates an error carrying the YAML position, also appended to <see cref="Message" />.
+        /// </summary>
+        public RuleConfigReaderError(string message, int? line, int? column = null, string? path = null)
+        {
+            Line = line;
+            Column = column;
+            Path = path;
+
+            Message = line.HasValue
+                ? column.HasValue
+                    ? $"{message} (line {line}, col {column})"
+                    : $"{message} (line {line})"
+                : message;
+        }
+
         public string Message { get; }
+
+        /// <summary>
+        ///     The 1-based line where the error occurred, when known.
+        /// </summary>
+        public int? Line { get; }
+
+        /// <summary>
+        ///     The 1-based column where the error occurred, when known.
+        /// </summary>
+        public int? Column { get; }
+
+        /// <summary>
+        ///     Best-effort location within the document (e.g. <c>rules[1]</c>), when known.
+        /// </summary>
+        public string? Path { get; }
 
         public override string ToString()
         {

--- a/src/Fluxzy.Core/Rules/SortedTypeInspector.cs
+++ b/src/Fluxzy.Core/Rules/SortedTypeInspector.cs
@@ -23,5 +23,17 @@ namespace Fluxzy.Rules
 
             return properties.OrderByDescending(x => x.Name == "typeKind");
         }
+
+        public override string GetEnumName(Type enumType, string name)
+            => _innerTypeInspector.GetEnumName(enumType, name);
+
+        public override string GetEnumValue(object enumValue)
+            => _innerTypeInspector.GetEnumValue(enumValue);
+
+        public override bool HasParseMethod(Type type)
+            => _innerTypeInspector.HasParseMethod(type);
+
+        public override object? Parse(string value, Type expectedType)
+            => _innerTypeInspector.Parse(value, expectedType);
     }
 }

--- a/src/Fluxzy.Core/Rules/Yaml/EventBufferParser.cs
+++ b/src/Fluxzy.Core/Rules/Yaml/EventBufferParser.cs
@@ -1,0 +1,33 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Collections.Generic;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace Fluxzy.Rules.Yaml
+{
+    /// <summary>
+    ///     A minimal <see cref="IParser" /> that replays a buffered list of parsing events.
+    /// </summary>
+    internal sealed class EventBufferParser : IParser
+    {
+        private readonly IReadOnlyList<ParsingEvent> _events;
+        private int _index = -1;
+
+        public EventBufferParser(IReadOnlyList<ParsingEvent> events)
+        {
+            _events = events;
+        }
+
+        public ParsingEvent? Current => _index >= 0 && _index < _events.Count ? _events[_index] : null;
+
+        public bool MoveNext()
+        {
+            if (_index < _events.Count) {
+                _index++;
+            }
+
+            return _index < _events.Count;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Rules/Yaml/RuleNodeDeserializer.cs
+++ b/src/Fluxzy.Core/Rules/Yaml/RuleNodeDeserializer.cs
@@ -1,0 +1,204 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Fluxzy.Misc.Converters;
+using Fluxzy.Rules.Filters;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Fluxzy.Rules.Yaml
+{
+    /// <summary>
+    ///     Deserializes the rule model types that cannot be populated through setters alone: the
+    ///     polymorphic <see cref="Filter" />/<see cref="Action" /> hierarchy (resolved from the
+    ///     <c>typeKind</c> discriminator) and immutable value types such as <c>Tag</c>. It buffers the
+    ///     node, resolves the concrete type, then binds keys to constructor parameters and public setters.
+    ///     Errors are positioned <see cref="YamlException" />. Other types fall through to the standard
+    ///     deserializer.
+    /// </summary>
+    internal sealed class RuleNodeDeserializer : INodeDeserializer
+    {
+        private static readonly Assembly ModelAssembly = typeof(PolymorphicObject).Assembly;
+        private static readonly ConcurrentDictionary<Type, bool> ConstructorBindingCache = new();
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new();
+
+        public bool Deserialize(
+            IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer,
+            out object? value, ObjectDeserializer rootDeserializer)
+        {
+            var polymorphic = expectedType == typeof(Filter) || expectedType == typeof(Fluxzy.Rules.Action);
+
+            if (!polymorphic && !NeedsConstructorBinding(expectedType)) {
+                value = null;
+
+                return false;
+            }
+
+            if (reader.Current is not MappingStart) {
+                // Not an object (null or scalar); let the standard pipeline handle it.
+                value = null;
+
+                return false;
+            }
+
+            var events = BufferNode(reader);
+
+            Type concreteType;
+
+            if (polymorphic) {
+                var (typeKind, marker) = FindTypeKind(events);
+
+                if (typeKind == null) {
+                    throw new YamlException(events[0].Start, events[0].End,
+                        $"Missing 'typeKind' to resolve a {expectedType.Name}.");
+                }
+
+                if (!PolymorphicTypeResolver.TryResolve(expectedType, typeKind, out var resolved)) {
+                    throw new YamlException(marker!.Start, marker.End,
+                        $"Cannot resolve '{typeKind}' to a valid {expectedType.Name}.");
+                }
+
+                concreteType = resolved!;
+            }
+            else {
+                concreteType = expectedType;
+            }
+
+            value = Bind(concreteType, events, nestedObjectDeserializer);
+
+            return true;
+        }
+
+        private static object Bind(Type type, IReadOnlyList<ParsingEvent> events, Func<IParser, Type, object?> nested)
+        {
+            var parser = new EventBufferParser(events);
+            parser.MoveNext();
+            parser.Consume<MappingStart>();
+
+            var properties = SerializableProperties(type);
+
+            // Prefer the parameterless constructor; fall back to the greediest one for immutable types.
+            var constructor = type.GetConstructor(Type.EmptyTypes)
+                              ?? type.GetConstructors()
+                                     .OrderByDescending(c => c.GetParameters().Length)
+                                     .First();
+
+            var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+            while (parser.Current is not MappingEnd) {
+                var key = parser.Consume<Scalar>().Value;
+
+                if (string.Equals(key, "typeKind", StringComparison.OrdinalIgnoreCase)) {
+                    parser.SkipThisAndNestedEvents();
+
+                    continue;
+                }
+
+                var memberType =
+                    properties.FirstOrDefault(p => string.Equals(p.Name, key, StringComparison.OrdinalIgnoreCase))
+                              ?.PropertyType
+                    ?? constructor.GetParameters()
+                                  .FirstOrDefault(p => string.Equals(p.Name, key, StringComparison.OrdinalIgnoreCase))
+                                  ?.ParameterType;
+
+                if (memberType == null) {
+                    parser.SkipThisAndNestedEvents();
+
+                    continue;
+                }
+
+                values[key] = nested(parser, memberType);
+            }
+
+            var arguments = constructor.GetParameters()
+                                       .Select(p => values.TryGetValue(p.Name!, out var value)
+                                           ? value
+                                           : p.ParameterType.IsValueType
+                                               ? Activator.CreateInstance(p.ParameterType)
+                                               : null)
+                                       .ToArray();
+
+            var instance = constructor.Invoke(arguments);
+
+            foreach (var property in properties) {
+                if (property.SetMethod is { IsPublic: true } && values.TryGetValue(property.Name, out var value)) {
+                    property.SetValue(instance, value);
+                }
+            }
+
+            return instance;
+        }
+
+        private static List<ParsingEvent> BufferNode(IParser reader)
+        {
+            var events = new List<ParsingEvent>();
+            var depth = 0;
+
+            do {
+                var current = reader.Current!;
+                events.Add(current);
+
+                if (current is MappingStart or SequenceStart) {
+                    depth++;
+                }
+                else if (current is MappingEnd or SequenceEnd) {
+                    depth--;
+                }
+
+                reader.MoveNext();
+            } while (depth > 0);
+
+            return events;
+        }
+
+        private static (string? TypeKind, Scalar? Marker) FindTypeKind(IReadOnlyList<ParsingEvent> events)
+        {
+            var depth = 0;
+
+            for (var i = 0; i < events.Count; i++) {
+                var current = events[i];
+
+                if (current is MappingStart or SequenceStart) {
+                    depth++;
+                }
+                else if (current is MappingEnd or SequenceEnd) {
+                    depth--;
+                }
+                else if (depth == 1
+                         && current is Scalar { Value: "typeKind" }
+                         && i + 1 < events.Count
+                         && events[i + 1] is Scalar valueScalar) {
+                    return (valueScalar.Value, valueScalar);
+                }
+            }
+
+            return (null, null);
+        }
+
+        private static bool NeedsConstructorBinding(Type type)
+        {
+            return ConstructorBindingCache.GetOrAdd(type, static t =>
+                t.IsClass
+                && !t.IsAbstract
+                && t.Assembly == ModelAssembly
+                && !typeof(PolymorphicObject).IsAssignableFrom(t)
+                && t.GetConstructor(Type.EmptyTypes) == null
+                && t.GetConstructors().Length > 0
+                && SerializableProperties(t).Any(p => p.SetMethod is not { IsPublic: true }));
+        }
+
+        private static PropertyInfo[] SerializableProperties(Type type)
+        {
+            return PropertyCache.GetOrAdd(type, static t =>
+                t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                 .Where(p => p.GetMethod is { IsPublic: true }
+                             && p.GetCustomAttribute<YamlIgnoreAttribute>() == null)
+                 .ToArray());
+        }
+    }
+}

--- a/src/Fluxzy.Core/Rules/Yaml/RuleObjectFactory.cs
+++ b/src/Fluxzy.Core/Rules/Yaml/RuleObjectFactory.cs
@@ -1,0 +1,60 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using YamlDotNet.Serialization.ObjectFactories;
+
+namespace Fluxzy.Rules.Yaml
+{
+    /// <summary>
+    ///     Creates rule model types that lack a parameterless constructor by invoking the smallest
+    ///     constructor with placeholder arguments; the deserializer then binds the real values.
+    /// </summary>
+    internal sealed class RuleObjectFactory : DefaultObjectFactory
+    {
+        public override object Create(Type type)
+        {
+            if (type.GetConstructor(Type.EmptyTypes) != null) {
+                return base.Create(type);
+            }
+
+            var constructor = type.GetConstructors()
+                                  .OrderBy(c => c.GetParameters().Length)
+                                  .FirstOrDefault();
+
+            if (constructor == null) {
+                return RuntimeHelpers.GetUninitializedObject(type);
+            }
+
+            var arguments = constructor.GetParameters()
+                                       .Select(GetPlaceholderArgument)
+                                       .ToArray();
+
+            try {
+                return constructor.Invoke(arguments);
+            }
+            catch {
+                // Constructor rejected the placeholder arguments; fall back to an uninitialized instance.
+                return RuntimeHelpers.GetUninitializedObject(type);
+            }
+        }
+
+        private static object? GetPlaceholderArgument(ParameterInfo parameter)
+        {
+            var parameterType = parameter.ParameterType;
+
+            if (parameterType.IsArray) {
+                // Empty array for params arrays so the constructor body does not dereference null.
+                return Array.CreateInstance(parameterType.GetElementType()!, 0);
+            }
+
+            if (parameterType.IsValueType && Nullable.GetUnderlyingType(parameterType) == null) {
+                return Activator.CreateInstance(parameterType);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Rules/Yaml/RuleYamlDeserializerFactory.cs
+++ b/src/Fluxzy.Core/Rules/Yaml/RuleYamlDeserializerFactory.cs
@@ -1,0 +1,28 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Fluxzy.Rules.Yaml
+{
+    /// <summary>
+    ///     Builds the deserializer that reads rule files into the typed model. Unmatched properties are
+    ///     ignored (matching the previous reader, and the <c>typeKind</c> key which has no setter).
+    /// </summary>
+    internal static class RuleYamlDeserializerFactory
+    {
+        private static readonly IDeserializer Shared = Build();
+
+        public static IDeserializer Instance => Shared;
+
+        private static IDeserializer Build()
+        {
+            return new DeserializerBuilder()
+                   .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                   .IgnoreUnmatchedProperties()
+                   .WithObjectFactory(new RuleObjectFactory())
+                   .WithNodeDeserializer(new RuleNodeDeserializer(), s => s.OnTop())
+                   .Build();
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Rules/RuleParsing.cs
+++ b/test/Fluxzy.Tests/UnitTests/Rules/RuleParsing.cs
@@ -354,6 +354,48 @@ namespace Fluxzy.Tests.UnitTests.Rules
             Assert.False(filter.Children.Last().Inverted);
         }
 
+        [Fact]
+        public void Reading_Should_Parse_Nested_Filter_Collection_With_Deep_Values()
+        {
+            var ruleConfigReader = new RuleConfigParser();
+
+            var yamlContent = """
+                filter:
+                  typeKind: FilterCollection
+                  operation: And
+                  children:
+                    - typeKind: HostFilter
+                      pattern: a.com
+                      operation: Exact
+                    - typeKind: FilterCollection
+                      operation: Or
+                      children:
+                        - typeKind: AuthorityFilter
+                          port: 8443
+                          pattern: deep.example
+                          operation: Exact
+                action:
+                  typeKind: ApplyCommentAction
+                  comment: hi
+                """;
+
+            var rule = ruleConfigReader.TryGetRuleFromYaml(yamlContent, out var errors)!;
+
+            Assert.True(errors == null || errors.Count == 0);
+
+            var root = Assert.IsType<FilterCollection>(rule.Filter);
+            Assert.Equal(SelectorCollectionOperation.And, root.Operation);
+            Assert.Equal(2, root.Children.Count);
+            Assert.IsType<HostFilter>(root.Children[0]);
+
+            var nested = Assert.IsType<FilterCollection>(root.Children[1]);
+            Assert.Equal(SelectorCollectionOperation.Or, nested.Operation);
+
+            var leaf = Assert.IsType<AuthorityFilter>(Assert.Single(nested.Children));
+            Assert.Equal(8443, leaf.Port);              // get-only, constructor-bound, two levels deep
+            Assert.Equal("deep.example", leaf.Pattern);
+        }
+
         [Theory]
         [InlineData(SelectorCollectionOperation.And)]
         [InlineData(SelectorCollectionOperation.Or)]

--- a/test/Fluxzy.Tests/UnitTests/Rules/RuleParsingDiagnostics.cs
+++ b/test/Fluxzy.Tests/UnitTests/Rules/RuleParsingDiagnostics.cs
@@ -1,0 +1,164 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Linq;
+using Fluxzy;
+using Fluxzy.Rules;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Rules.Filters;
+using Fluxzy.Rules.Filters.RequestFilters;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Rules
+{
+    /// <summary>
+    ///     Covers the line and column carried by reader errors, and constructor-bound value binding.
+    /// </summary>
+    public class RuleParsingDiagnostics
+    {
+        private static readonly RuleConfigParser Parser = new();
+
+        [Fact]
+        public void Unknown_Filter_TypeKind_Reports_Name_And_Line()
+        {
+            var yaml = """
+                filter:
+                  typeKind: NoMoreFilter
+                action:
+                  typeKind: AddRequestHeaderAction
+                  headerName: fluxzy
+                  headerValue: on
+                """;
+
+            var rule = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.Null(rule);
+            var error = Assert.Single(errors!);
+            Assert.Contains("NoMoreFilter", error.Message);
+            Assert.NotNull(error.Line);
+            Assert.Contains("line ", error.Message);
+        }
+
+        [Fact]
+        public void Invalid_Boolean_Reports_The_Offending_Line()
+        {
+            // 'inverted' carries a non-boolean value on line 3.
+            var yaml = """
+                filter:
+                  typeKind: AnyFilter
+                  inverted: notABoolean
+                action:
+                  typeKind: ApplyCommentAction
+                  comment: hello
+                """;
+
+            var rule = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.Null(rule);
+            var error = Assert.Single(errors!);
+            Assert.Equal(3, error.Line);
+            Assert.Contains("line 3", error.Message);
+        }
+
+        [Fact]
+        public void Malformed_Yaml_Reports_A_Line()
+        {
+            var yaml = """
+                filter:
+                  typeKind: AnyFilter
+                   headerName: misaligned
+                action:
+                  typeKind: ApplyCommentAction
+                """;
+
+            var rule = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.Null(rule);
+            Assert.NotEmpty(errors!);
+            Assert.All(errors!, e => Assert.NotNull(e.Line));
+        }
+
+        [Fact]
+        public void RuleSet_Unknown_TypeKind_Reports_Name_And_Line()
+        {
+            var yaml = """
+                rules:
+                - filter:
+                    typeKind: AnyFilter
+                  action:
+                    typeKind: NoSuchAction
+                """;
+
+            var ruleSet = Parser.TryGetRuleSetFromYaml(yaml, out var errors);
+
+            Assert.Null(ruleSet);
+            Assert.NotEmpty(errors!);
+            Assert.Contains(errors!, e => e.Message.Contains("NoSuchAction") && e.Line.HasValue);
+        }
+
+        [Fact]
+        public void Get_Only_Constructor_Bound_Filter_Property_Is_Preserved()
+        {
+            var yaml = Parser.GetYamlFromRule(new Rule(
+                new ApplyCommentAction("c"),
+                new AuthorityFilter(8080, "fluxzy.io", StringSelectorOperation.Exact)));
+
+            var parsed = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.True(errors == null || errors.Count == 0);
+            var filter = Assert.IsType<AuthorityFilter>(parsed!.Filter);
+            Assert.Equal(8080, filter.Port);          // get-only, constructor-bound
+            Assert.Equal("fluxzy.io", filter.Pattern);
+        }
+
+        [Fact]
+        public void Get_Only_Constructor_Bound_Action_Property_Is_Preserved()
+        {
+            var yaml = Parser.GetYamlFromRule(new Rule(
+                new ForwardAction("https://www.example.com"),
+                new AnyFilter()));
+
+            var parsed = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.True(errors == null || errors.Count == 0);
+            var action = Assert.IsType<ForwardAction>(parsed!.GetSingleAction());
+            Assert.Equal("https://www.example.com", action.Url);   // get-only, constructor-bound
+        }
+
+        [Fact]
+        public void Immutable_Nested_Object_Is_Preserved()
+        {
+            var identifier = Guid.Parse("852D1563-5664-4F17-A4F2-BFE5F7C4993A");
+
+            var yaml = Parser.GetYamlFromRule(new Rule(
+                new ApplyTagAction { Tag = new Tag(identifier, "Hello fluxzy") },
+                new AnyFilter()));
+
+            var parsed = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            Assert.True(errors == null || errors.Count == 0);
+            var action = Assert.IsType<ApplyTagAction>(parsed!.GetSingleAction());
+            Assert.NotNull(action.Tag);
+            Assert.Equal(identifier, action.Tag!.Identifier);   // get-only on immutable Tag
+            Assert.Equal("Hello fluxzy", action.Tag.Value);
+        }
+
+        [Fact]
+        public void Typoed_Root_Key_Is_Reported()
+        {
+            var yaml = """
+                ruldes:
+                - filter:
+                    typeKind: AnyFilter
+                  action:
+                    typeKind: ApplyCommentAction
+                    comment: hi
+                """;
+
+            var ruleSet = Parser.TryGetRuleSetFromYaml(yaml, out var errors);
+
+            Assert.Null(ruleSet);
+            Assert.NotEmpty(errors!);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Rules/RuleParsingExhaustive.cs
+++ b/test/Fluxzy.Tests/UnitTests/Rules/RuleParsingExhaustive.cs
@@ -1,0 +1,185 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Fluxzy;
+using Fluxzy.Rules;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Rules.Filters;
+using Fluxzy.Rules.Yaml;
+using Xunit;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using Action = Fluxzy.Rules.Action;
+
+namespace Fluxzy.Tests.UnitTests.Rules
+{
+    /// <summary>
+    ///     Round-trips every concrete action and filter through the reader so a type that fails surfaces.
+    /// </summary>
+    public class RuleParsingExhaustive
+    {
+        private static readonly RuleConfigParser Parser = new();
+
+        private static IEnumerable<Type> ConcreteTypes(Type baseType)
+        {
+            return baseType.Assembly.GetTypes()
+                           .Where(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(baseType))
+                           .OrderBy(t => t.Name);
+        }
+
+        private static object ForceCreate(Type type)
+        {
+            return new RuleObjectFactory().Create(type);
+        }
+
+        [Fact]
+        public void Every_Concrete_Filter_RoundTrips_To_Same_Type()
+        {
+            var failures = new List<string>();
+
+            foreach (var type in ConcreteTypes(typeof(Filter))) {
+                try {
+                    var filter = (Filter) ForceCreate(type);
+                    var yaml = Parser.GetYamlFromRule(new Rule(new ApplyCommentAction("comment"), filter));
+                    var parsed = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+                    if (errors is { Count: > 0 }) {
+                        failures.Add($"{type.Name}: {string.Join("; ", errors.Select(e => e.Message))}");
+                    }
+                    else if (parsed?.Filter == null) {
+                        failures.Add($"{type.Name}: parsed filter is null");
+                    }
+                    else if (parsed.Filter.GetType() != type) {
+                        failures.Add($"{type.Name}: parsed as {parsed.Filter.GetType().Name}");
+                    }
+                }
+                catch (Exception ex) {
+                    failures.Add($"{type.Name}: threw {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            Assert.True(failures.Count == 0, $"{failures.Count} filter(s) failed round-trip:\n{string.Join("\n", failures)}");
+        }
+
+        [Fact]
+        public void Every_Concrete_Action_RoundTrips_To_Same_Type()
+        {
+            var failures = new List<string>();
+
+            foreach (var type in ConcreteTypes(typeof(Action))) {
+                try {
+                    var action = (Action) ForceCreate(type);
+                    var yaml = Parser.GetYamlFromRule(new Rule(action, new AnyFilter()));
+                    var parsed = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+                    if (errors is { Count: > 0 }) {
+                        failures.Add($"{type.Name}: {string.Join("; ", errors.Select(e => e.Message))}");
+                    }
+                    else if (parsed == null || !parsed.GetAllActions().Any()) {
+                        failures.Add($"{type.Name}: parsed action is null");
+                    }
+                    else if (parsed.GetAllActions().First().GetType() != type) {
+                        failures.Add($"{type.Name}: parsed as {parsed.GetAllActions().First().GetType().Name}");
+                    }
+                }
+                catch (Exception ex) {
+                    failures.Add($"{type.Name}: threw {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+
+            Assert.True(failures.Count == 0, $"{failures.Count} action(s) failed round-trip:\n{string.Join("\n", failures)}");
+        }
+
+        [Fact]
+        public void New_Reader_Matches_Previous_Reader_For_Every_Example()
+        {
+            // For the same YAML the new reader must produce the same object as the old System.Text.Json
+            // bridge. Comparing re-serialized output isolates read divergences from shared serializer quirks.
+            var failures = new List<string>();
+
+            foreach (var type in ConcreteTypes(typeof(Filter))) {
+                var instances = new List<Filter> { (Filter) ForceCreate(type) };
+                instances.AddRange(ExamplesOf(() => ((Filter) ForceCreate(type)).GetExamples().Select(e => e.Filter), type, failures));
+
+                foreach (var instance in instances) {
+                    AssertReaderParity(Parser.GetYamlFromRule(new Rule(new ApplyCommentAction("comment"), instance)),
+                        $"filter {type.Name}", failures);
+                }
+            }
+
+            foreach (var type in ConcreteTypes(typeof(Action))) {
+                var instances = new List<Action> { (Action) ForceCreate(type) };
+                instances.AddRange(ExamplesOf(() => ((Action) ForceCreate(type)).GetExamples().Select(e => e.Action), type, failures));
+
+                foreach (var instance in instances) {
+                    AssertReaderParity(Parser.GetYamlFromRule(new Rule(instance, new AnyFilter())),
+                        $"action {type.Name}", failures);
+                }
+            }
+
+            Assert.True(failures.Count == 0, $"{failures.Count} case(s) diverged from the previous reader:\n{string.Join("\n", failures)}");
+        }
+
+        private static void AssertReaderParity(string yaml, string label, List<string> failures)
+        {
+            RuleConfigContainer? expected;
+
+            try {
+                expected = PreviousReader(yaml);
+            }
+            catch {
+                // The old reader could not handle this type, so there is nothing to compare against.
+                // The new reader is validated here by the type round-trip tests.
+                return;
+            }
+
+            var actual = Parser.TryGetRuleFromYaml(yaml, out var errors);
+
+            if (errors is { Count: > 0 } || actual == null) {
+                failures.Add($"{label}: new reader failed: {string.Join("; ", errors?.Select(e => e.Message) ?? Enumerable.Empty<string>())}\n{yaml}");
+
+                return;
+            }
+
+            var expectedYaml = Parser.GetYamlFromRule(new Rule(expected.GetSingleAction(), expected.Filter));
+            var actualYaml = Parser.GetYamlFromRule(new Rule(actual.GetSingleAction(), actual.Filter));
+
+            if (expectedYaml != actualYaml) {
+                failures.Add($"{label}: read result differs from previous reader\n--- previous ---\n{expectedYaml}\n--- new ---\n{actualYaml}");
+            }
+        }
+
+        /// <summary>
+        ///     Reproduces the previous reader (YamlDotNet object graph bridged through System.Text.Json).
+        /// </summary>
+        private static RuleConfigContainer PreviousReader(string yaml)
+        {
+            var deserializer = new DeserializerBuilder()
+                               .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                               .Build();
+
+            using var reader = new StringReader(yaml);
+            var raw = deserializer.Deserialize(reader);
+
+            var json = JsonSerializer.Serialize(raw, GlobalArchiveOption.ConfigSerializerOptions);
+
+            return JsonSerializer.Deserialize<RuleConfigContainer>(json, GlobalArchiveOption.ConfigSerializerOptions)!;
+        }
+
+        private static IEnumerable<T> ExamplesOf<T>(Func<IEnumerable<T>> provider, Type type, List<string> failures)
+        {
+            try {
+                return provider().ToList();
+            }
+            catch (Exception ex) {
+                failures.Add($"{type.Name}: GetExamples threw {ex.GetType().Name}: {ex.Message}");
+
+                return Enumerable.Empty<T>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bumps YamlDotNet 13.7.1 to 18.0.0 and rewrites the rule file read path on it.

The reader used to bridge YamlDotNet to a dictionary to System.Text.Json, losing positions, so a bad rule file had no line number. It now deserializes straight into the typed model, and errors carry the YAML line and column on RuleConfigReaderError.Line/Column/Path (the message still includes the position).

RuleNodeDeserializer resolves the typeKind discriminator and constructor-binds the Filter/Action hierarchy and immutable types like Tag. Type discovery still uses the shared assembly scan, so adding an action or filter needs no registration. The write path and archive serialization are unchanged.

New tests round-trip every action and filter, check parity with the old reader, and assert error line numbers. UnitTests.Rules is green (456 tests).
