### PR TITLE
Add an upstream socket configuration hook

### DIFF
--- a/examples/Samples.No024.BindUpstreamSocket/Program.cs
+++ b/examples/Samples.No024.BindUpstreamSocket/Program.cs
@@ -35,17 +35,25 @@ namespace Samples.No024.BindUpstreamSocket
 
             socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
-            // Pin the egress interface to a physical NIC. Requires the right interface index and,
+            // Pin the egress interface to a physical NIC. Needs the interface index (or name) and,
             // on Linux, elevated privilege. Branch on the family because the option differs.
             //
-            // const int interfaceIndex = 12;
+            // const int interfaceIndex = 12; // NetworkInterface.GetIPProperties().Get*Properties().Index
+            //
+            // Windows IP_UNICAST_IF (IPv4 index in network order, IPv6 index in host order):
             // if (socket.AddressFamily == AddressFamily.InterNetwork)
             //     socket.SetSocketOption(SocketOptionLevel.IP, (SocketOptionName) 31,
-            //         IPAddress.HostToNetworkOrder(interfaceIndex));            // IPv4, network order
+            //         IPAddress.HostToNetworkOrder(interfaceIndex));
             // else
-            //     socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName) 31, interfaceIndex); // IPv6, host order
+            //     socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName) 31, interfaceIndex);
             //
-            // Linux SO_BINDTODEVICE:
+            // macOS IP_BOUND_IF (25) / IPV6_BOUND_IF (125), interface index, no privilege:
+            // if (socket.AddressFamily == AddressFamily.InterNetwork)
+            //     socket.SetRawSocketOption(0, 25, BitConverter.GetBytes(interfaceIndex));
+            // else
+            //     socket.SetRawSocketOption(41, 125, BitConverter.GetBytes(interfaceIndex));
+            //
+            // Linux SO_BINDTODEVICE (interface name, needs CAP_NET_RAW/root):
             // socket.SetRawSocketOption(1, 25, System.Text.Encoding.ASCII.GetBytes("eth0"));
 
             Console.WriteLine(

--- a/examples/Samples.No024.BindUpstreamSocket/Program.cs
+++ b/examples/Samples.No024.BindUpstreamSocket/Program.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Sockets;
+using Fluxzy;
+using Fluxzy.Core;
+
+namespace Samples.No024.BindUpstreamSocket
+{
+    internal class Program
+    {
+        /// <summary>
+        /// Shows how to configure every upstream socket before it connects. Typical uses are pinning the
+        /// egress interface (IP_UNICAST_IF on Windows, SO_BINDTODEVICE on Linux), a source bind, or
+        /// keep-alive tuning. The callback runs once per upstream socket, before connect, and the socket
+        /// family matches context.RemoteEndPoint.
+        /// </summary>
+        static async Task Main()
+        {
+            var fluxzySetting = FluxzySetting.CreateDefault(IPAddress.Loopback, 44344);
+
+            await using var proxy = new Proxy(fluxzySetting, configureUpstreamSocket: ConfigureSocket);
+            var endpoints = proxy.Run();
+
+            using var httpClient = new HttpClient(new HttpClientHandler {
+                Proxy = new WebProxy($"http://127.0.0.1:{endpoints.First().Port}"),
+                UseProxy = true
+            });
+
+            using var response = await httpClient.GetAsync("https://www.example.com/");
+            Console.WriteLine($"status {(int) response.StatusCode}");
+        }
+
+        static void ConfigureSocket(UpstreamSocketContext context)
+        {
+            var socket = context.Socket;
+
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+
+            // Pin the egress interface to a physical NIC. Requires the right interface index and,
+            // on Linux, elevated privilege. Branch on the family because the option differs.
+            //
+            // const int interfaceIndex = 12;
+            // if (socket.AddressFamily == AddressFamily.InterNetwork)
+            //     socket.SetSocketOption(SocketOptionLevel.IP, (SocketOptionName) 31,
+            //         IPAddress.HostToNetworkOrder(interfaceIndex));            // IPv4, network order
+            // else
+            //     socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName) 31, interfaceIndex); // IPv6, host order
+            //
+            // Linux SO_BINDTODEVICE:
+            // socket.SetRawSocketOption(1, 25, System.Text.Encoding.ASCII.GetBytes("eth0"));
+
+            Console.WriteLine(
+                $"upstream {context.RequestedHost}:{context.RequestedPort} via {context.RemoteEndPoint} ({socket.AddressFamily})");
+        }
+    }
+}

--- a/examples/Samples.No024.BindUpstreamSocket/Samples.No024.BindUpstreamSocket.csproj
+++ b/examples/Samples.No024.BindUpstreamSocket/Samples.No024.BindUpstreamSocket.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/fluxzy.core.slnx
+++ b/fluxzy.core.slnx
@@ -39,6 +39,7 @@
     <Project Path="examples/Samples.No021.SessionCaptureAndReplay/Samples.No021.SessionCaptureAndReplay.csproj" />
     <Project Path="examples/Samples.No022.RejectRequests/Samples.No022.RejectRequests.csproj" />
     <Project Path="examples/Samples.No023.GrpcThroughProxy/Samples.No023.GrpcThroughProxy.csproj" />
+    <Project Path="examples/Samples.No024.BindUpstreamSocket/Samples.No024.BindUpstreamSocket.csproj" />
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj" />

--- a/src/Fluxzy.Core.Pcap/CapturableConnection.cs
+++ b/src/Fluxzy.Core.Pcap/CapturableConnection.cs
@@ -32,7 +32,7 @@ namespace Fluxzy.Core.Pcap
 
     internal class CapturableTcpConnection : ITcpConnection
     {
-        private readonly TcpClient _innerTcpClient;
+        private TcpClient? _innerTcpClient;
         private readonly ICaptureContext _captureContext;
         private readonly string _outTraceFileName;
 
@@ -44,15 +44,28 @@ namespace Fluxzy.Core.Pcap
         {
             _captureContext = captureContext;
             _outTraceFileName = outTraceFileName;
-            _innerTcpClient = new TcpClient();
         }
 
-        public async Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress remoteAddress, int remotePort)
+        public Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress remoteAddress, int remotePort)
+            => ConnectAsync(remoteAddress, remotePort, UpstreamConnectOptions.None);
+
+        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+            IPAddress remoteAddress, int remotePort, UpstreamConnectOptions options)
         {
             if (_stream != null)
                 throw new InvalidOperationException("A previous connect attempt was already made");
 
             var connectError = false;
+
+            _innerTcpClient = new TcpClient(remoteAddress.AddressFamily);
+
+            try {
+                options.Apply(_innerTcpClient.Client, new IPEndPoint(remoteAddress, remotePort));
+            }
+            catch {
+                _innerTcpClient.Dispose();
+                throw;
+            }
 
             _captureContext.Include(remoteAddress, remotePort);
 

--- a/src/Fluxzy.Core.Pcap/CapturedTcpConnectionProvider.cs
+++ b/src/Fluxzy.Core.Pcap/CapturedTcpConnectionProvider.cs
@@ -30,6 +30,8 @@ namespace Fluxzy.Core.Pcap
             _activeContext.Flush();
         }
 
+        public bool RequiresArchiveWriter => true;
+
         public async ValueTask DisposeAsync()
         {
             if (_ownedCaptureContext != null)

--- a/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
+++ b/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
@@ -68,9 +68,12 @@ namespace Fluxzy.Clients
                                            ? setting.ArchiveWriter.GetDumpfilePath(exchange.Connection.Id)!
                                            : string.Empty);
             
+            var connectOptions = new UpstreamConnectOptions(
+                exchange.Authority.HostName, exchange.Authority.Port, setting.ConfigureUpstreamSocket);
+
             var connectResult = await tcpConnection.ConnectAsync(
                 resolutionResult.EndPoint.Address,
-                resolutionResult.EndPoint.Port).ConfigureAwait(false);
+                resolutionResult.EndPoint.Port, connectOptions).ConfigureAwait(false);
 
             exchange.Connection.TcpConnectionOpened = _timeProvider.Instant();
             exchange.Connection.LocalPort = connectResult.Stream.LocalEndPoint.Port;

--- a/src/Fluxzy.Core/Core/ExchangeSourceProviderHelper.cs
+++ b/src/Fluxzy.Core/Core/ExchangeSourceProviderHelper.cs
@@ -7,14 +7,15 @@ namespace Fluxzy.Core
     internal static class ExchangeSourceProviderHelper
     {
         public static ExchangeSourceProvider GetSourceProvider(FluxzySetting setting,
-            SecureConnectionUpdater secureConnectionUpdater, 
-            IIdProvider idProvider, ICertificateProvider certificateProvider, 
-            ProxyAuthenticationMethod proxyAuthenticationMethod, IExchangeContextBuilder contextBuilder)
+            SecureConnectionUpdater secureConnectionUpdater,
+            IIdProvider idProvider, ICertificateProvider certificateProvider,
+            ProxyAuthenticationMethod proxyAuthenticationMethod, IExchangeContextBuilder contextBuilder,
+            IDnsSolver dnsSolver)
         {
             if (!setting.ReverseMode)
                 return new ProtocolDetectingSourceProvider(
                     secureConnectionUpdater, idProvider,
-                    proxyAuthenticationMethod, contextBuilder);
+                    proxyAuthenticationMethod, contextBuilder, dnsSolver);
             
             if (setting.ReverseModePlainHttp)
                 return new ReverseProxyPlainExchangeSourceProvider(idProvider, setting.ReverseModeForcedPort, contextBuilder);

--- a/src/Fluxzy.Core/Core/ITcpConnection.cs
+++ b/src/Fluxzy.Core/Core/ITcpConnection.cs
@@ -8,9 +8,12 @@ using Fluxzy.Misc.Streams;
 
 namespace Fluxzy.Core
 {
-    public interface ITcpConnection : IAsyncDisposable 
+    public interface ITcpConnection : IAsyncDisposable
     {
         Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port);
+
+        Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port, UpstreamConnectOptions options)
+            => ConnectAsync(address, port);
     }
 
     public interface ITcpConnectionConnectResult

--- a/src/Fluxzy.Core/Core/ITcpConnectionProvider.cs
+++ b/src/Fluxzy.Core/Core/ITcpConnectionProvider.cs
@@ -10,6 +10,12 @@ namespace Fluxzy.Core
 
         ITcpConnection Create(string dumpFileName);
 
-        void TryFlush(); 
+        void TryFlush();
+
+        /// <summary>
+        ///     When true, this provider cannot function without a writable archive and may be ignored
+        ///     when the archiving policy is None. Custom providers return false and are always honored.
+        /// </summary>
+        bool RequiresArchiveWriter => false;
     }
 }

--- a/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
+++ b/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
@@ -25,16 +25,28 @@ namespace Fluxzy.Core
 
     internal class DefaultTcpConnection : ITcpConnection
     {
-        public async Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port)
+        public Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port)
+            => ConnectAsync(address, port, UpstreamConnectOptions.None);
+
+        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+            IPAddress address, int port, UpstreamConnectOptions options)
         {
+            TcpClient? client = null;
+
             try {
-                var client = new TcpClient();
+                client = new TcpClient(address.AddressFamily);
                 client.NoDelay = true;
+                options.Apply(client.Client, new IPEndPoint(address, port));
                 await client.ConnectAsync(address, port).ConfigureAwait(false);
                 var stream = new DisposeEventNotifierStream(client, null);
                 return new DefaultTcpConnectionConnectResult(stream);
             }
             catch (Exception ex) {
+                client?.Dispose();
+
+                if (ex is ClientErrorException)
+                    throw;
+
                 if (ex is AggregateException aggregateException && aggregateException.InnerExceptions.Any()) {
                     throw aggregateException.InnerExceptions.First();
                 }

--- a/src/Fluxzy.Core/Core/NetworkErrorCodes.cs
+++ b/src/Fluxzy.Core/Core/NetworkErrorCodes.cs
@@ -34,6 +34,7 @@ namespace Fluxzy.Core
         // Other
         public const string ProtocolError = "protocol_error";
         public const string RuleFailure = "rule_failure";
+        public const string UpstreamConfigurationFailed = "upstream_configuration_failed";
         public const string Unknown = "unknown";
     }
 }

--- a/src/Fluxzy.Core/Core/ProtocolDetectingSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/ProtocolDetectingSourceProvider.cs
@@ -26,7 +26,8 @@ namespace Fluxzy.Core
             SecureConnectionUpdater secureConnectionUpdater,
             IIdProvider idProvider,
             ProxyAuthenticationMethod proxyAuthenticationMethod,
-            IExchangeContextBuilder contextBuilder)
+            IExchangeContextBuilder contextBuilder,
+            IDnsSolver dnsSolver)
             : base(idProvider)
         {
             _httpProvider = new FromProxyConnectSourceProvider(
@@ -39,7 +40,8 @@ namespace Fluxzy.Core
                 secureConnectionUpdater,
                 idProvider,
                 proxyAuthenticationMethod,
-                contextBuilder);
+                contextBuilder,
+                dnsSolver);
         }
 
         public override async ValueTask<ExchangeSourceInitResult?> InitClientConnection(

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -77,6 +77,11 @@ namespace Fluxzy.Core
         public RemoteCertificateValidationCallback CertificateValidationCallback { get; set; }
 
         /// <summary>
+        ///     Optional callback applied to every upstream socket before it connects.
+        /// </summary>
+        public ConfigureUpstreamSocket? ConfigureUpstreamSocket { get; set; }
+
+        /// <summary>
         /// </summary>
         public int ConcurrentConnection { get; set; } = 16;
 

--- a/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
+++ b/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
@@ -20,18 +20,21 @@ namespace Fluxzy.Core.Socks5
         private readonly IIdProvider _idProvider;
         private readonly Socks5AuthenticationAdapter _authAdapter;
         private readonly IExchangeContextBuilder _contextBuilder;
+        private readonly IDnsSolver _dnsSolver;
 
         public Socks5SourceProvider(
             SecureConnectionUpdater secureConnectionUpdater,
             IIdProvider idProvider,
             ProxyAuthenticationMethod proxyAuthenticationMethod,
-            IExchangeContextBuilder contextBuilder)
+            IExchangeContextBuilder contextBuilder,
+            IDnsSolver dnsSolver)
             : base(idProvider)
         {
             _secureConnectionUpdater = secureConnectionUpdater;
             _idProvider = idProvider;
             _authAdapter = new Socks5AuthenticationAdapter(proxyAuthenticationMethod);
             _contextBuilder = contextBuilder;
+            _dnsSolver = dnsSolver;
         }
 
         public override async ValueTask<ExchangeSourceInitResult?> InitClientConnection(
@@ -114,19 +117,15 @@ namespace Fluxzy.Core.Socks5
 
             if (request.AddressType == Socks5Constants.AddrTypeDomain)
             {
-                var addresses = await Dns.GetHostAddressesAsync(request.DestinationAddress, token)
-                    .ConfigureAwait(false);
-
-                if (addresses.Length > 0)
-                {
-                    var resolvedAddress = addresses[0];
+                try {
+                    var resolvedAddress = await _dnsSolver.SolveDns(request.DestinationAddress).ConfigureAwait(false);
                     replyRawAddress = resolvedAddress.GetAddressBytes();
                     replyAddressType = resolvedAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
                         ? Socks5Constants.AddrTypeIPv6
                         : Socks5Constants.AddrTypeIPv4;
                 }
-                else {
-                    // If resolution fails, fall back to IPv4 with zero address
+                catch {
+                    // Resolution is only needed for the reply BND.ADDR, fall back to IPv4 zero
                     replyRawAddress = ZeroIPv4Address;
                     replyAddressType = Socks5Constants.AddrTypeIPv4;
                 }

--- a/src/Fluxzy.Core/Core/UpstreamSocketContext.cs
+++ b/src/Fluxzy.Core/Core/UpstreamSocketContext.cs
@@ -1,0 +1,86 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Fluxzy.Core
+{
+    /// <summary>
+    ///     Invoked once per upstream socket, after the socket is created and before it connects.
+    /// </summary>
+    public delegate void ConfigureUpstreamSocket(UpstreamSocketContext context);
+
+    /// <summary>
+    ///     Context handed to a <see cref="ConfigureUpstreamSocket"/> callback.
+    /// </summary>
+    public sealed class UpstreamSocketContext
+    {
+        public UpstreamSocketContext(Socket socket, string requestedHost, int requestedPort, IPEndPoint remoteEndPoint)
+        {
+            Socket = socket;
+            RequestedHost = requestedHost;
+            RequestedPort = requestedPort;
+            RemoteEndPoint = remoteEndPoint;
+        }
+
+        /// <summary>
+        ///     The upstream socket, not yet connected. Safe to set options or bind.
+        /// </summary>
+        public Socket Socket { get; }
+
+        /// <summary>
+        ///     Host (domain or IP literal) as requested by the client.
+        /// </summary>
+        public string RequestedHost { get; }
+
+        /// <summary>
+        ///     Port as requested by the client.
+        /// </summary>
+        public int RequestedPort { get; }
+
+        /// <summary>
+        ///     The endpoint fluxzy will connect to. The upstream proxy when chaining, otherwise the destination.
+        /// </summary>
+        public IPEndPoint RemoteEndPoint { get; }
+    }
+
+    /// <summary>
+    ///     Carries the requested authority and the optional socket configuration callback down to the
+    ///     connection implementation.
+    /// </summary>
+    public sealed class UpstreamConnectOptions
+    {
+        public static readonly UpstreamConnectOptions None = new(string.Empty, 0, null);
+
+        public UpstreamConnectOptions(string requestedHost, int requestedPort, ConfigureUpstreamSocket? configure)
+        {
+            RequestedHost = requestedHost;
+            RequestedPort = requestedPort;
+            Configure = configure;
+        }
+
+        public string RequestedHost { get; }
+
+        public int RequestedPort { get; }
+
+        public ConfigureUpstreamSocket? Configure { get; }
+
+        public void Apply(Socket socket, IPEndPoint remoteEndPoint)
+        {
+            if (Configure == null)
+                return;
+
+            try {
+                Configure(new UpstreamSocketContext(socket, RequestedHost, RequestedPort, remoteEndPoint));
+            }
+            catch (ClientErrorException) {
+                throw;
+            }
+            catch (Exception ex) {
+                throw new ClientErrorException(-1, "Upstream socket configuration callback failed",
+                    innerException: ex, networkErrorCode: NetworkErrorCodes.UpstreamConfigurationFailed);
+            }
+        }
+    }
+}

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -132,10 +132,12 @@ namespace Fluxzy
                 ? (ISslConnectionBuilder) new BouncyCastleConnectionBuilder()
                 : new SChannelConnectionBuilder();
 
+            var dnsSolver1 = dnsSolver ?? new DefaultDnsResolver();
+
             var poolBuilder = new PoolBuilder(
                 new RemoteConnectionBuilder(ITimingProvider.Default, sslConnectionBuilder),
                 ITimingProvider.Default,
-                Writer, dnsSolver ?? new DefaultDnsResolver(),
+                Writer, dnsSolver1,
                 loggerFactory);
             
             ExecutionContext = new ProxyExecutionContext(startupSetting);
@@ -155,7 +157,8 @@ namespace Fluxzy
                 _runTimeSetting,
                 ExchangeSourceProviderHelper.GetSourceProvider(
                     startupSetting, secureConnectionManager,
-                    IdProvider, certificateProvider, proxyAuthenticationMethod, exchangeContextBuilder),
+                    IdProvider, certificateProvider, proxyAuthenticationMethod, exchangeContextBuilder,
+                    dnsSolver1),
                 poolBuilder);
 
             if (!StartupSetting.AlterationRules.Any(t => t.Action is SkipSslTunnelingAction &&

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -118,7 +118,11 @@ namespace Fluxzy
                     StartupSetting.SaveFilter, StartupSetting);
             }
 
-            if (StartupSetting.ArchivingPolicy.Type == ArchivingPolicyType.None) {
+            if (tcpConnectionProvider1.RequiresArchiveWriter
+                && StartupSetting.ArchivingPolicy.Type == ArchivingPolicyType.None) {
+                (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<Proxy>()
+                    .LogWarning("Ignoring capture-aware connection provider because ArchivingPolicy is None.");
+
                 tcpConnectionProvider1 = ITcpConnectionProvider.Default;
             }
 

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -57,14 +57,17 @@ namespace Fluxzy
         /// <param name="tcpConnectionProvider">The tcp connection provider, if null the default is used</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         public Proxy(
             FluxzySetting startupSetting,
             ITcpConnectionProvider? tcpConnectionProvider = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null)
+            ILoggerFactory? loggerFactory = null,
+            ConfigureUpstreamSocket? configureUpstreamSocket = null)
             : this(startupSetting,
                 new CertificateProvider(startupSetting.CaCertificate, new InMemoryCertificateCache()),
                 new DefaultCertificateAuthorityManager(), tcpConnectionProvider,
+                configureUpstreamSocket: configureUpstreamSocket,
                 proxyAuthenticationMethod: proxyAuthenticationMethod,
                 loggerFactory: loggerFactory)
         {
@@ -81,10 +84,10 @@ namespace Fluxzy
         /// <param name="userAgentProvider">An user Agent provider</param>
         /// <param name="idProvider">An id provider</param>
         /// <param name="dnsSolver">Add a custom DNS solver</param>
-        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         /// <param name="externalCancellationSource">An external cancellation token</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         /// <exception cref="ArgumentNullException"></exception>
         public Proxy(
             FluxzySetting startupSetting,
@@ -94,10 +97,10 @@ namespace Fluxzy
             IUserAgentInfoProvider? userAgentProvider = null,
             FromIndexIdProvider? idProvider = null,
             IDnsSolver? dnsSolver = null,
-            ConfigureUpstreamSocket? configureUpstreamSocket = null,
             CancellationTokenSource? externalCancellationSource = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null)
+            ILoggerFactory? loggerFactory = null,
+            ConfigureUpstreamSocket? configureUpstreamSocket = null)
         {
             _certificateProvider = certificateProvider;
             _externalCancellationSource = externalCancellationSource;

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -57,20 +57,37 @@ namespace Fluxzy
         /// <param name="tcpConnectionProvider">The tcp connection provider, if null the default is used</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
-        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         public Proxy(
             FluxzySetting startupSetting,
             ITcpConnectionProvider? tcpConnectionProvider = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null,
-            ConfigureUpstreamSocket? configureUpstreamSocket = null)
+            ILoggerFactory? loggerFactory = null)
             : this(startupSetting,
                 new CertificateProvider(startupSetting.CaCertificate, new InMemoryCertificateCache()),
                 new DefaultCertificateAuthorityManager(), tcpConnectionProvider,
-                configureUpstreamSocket: configureUpstreamSocket,
                 proxyAuthenticationMethod: proxyAuthenticationMethod,
                 loggerFactory: loggerFactory)
         {
+        }
+
+        /// <summary>
+        ///     Create a new instance of Proxy with an upstream socket configuration callback.
+        ///     An InMemoryCertificateCache will be used as the certificate cache.
+        /// </summary>
+        /// <param name="startupSetting">The startup Setting</param>
+        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
+        /// <param name="tcpConnectionProvider">The tcp connection provider, if null the default is used</param>
+        /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
+        /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        public Proxy(
+            FluxzySetting startupSetting,
+            ConfigureUpstreamSocket configureUpstreamSocket,
+            ITcpConnectionProvider? tcpConnectionProvider = null,
+            ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
+            ILoggerFactory? loggerFactory = null)
+            : this(startupSetting, tcpConnectionProvider, proxyAuthenticationMethod, loggerFactory)
+        {
+            _runTimeSetting.ConfigureUpstreamSocket = configureUpstreamSocket;
         }
 
         /// <summary>
@@ -87,7 +104,6 @@ namespace Fluxzy
         /// <param name="externalCancellationSource">An external cancellation token</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
-        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         /// <exception cref="ArgumentNullException"></exception>
         public Proxy(
             FluxzySetting startupSetting,
@@ -99,8 +115,7 @@ namespace Fluxzy
             IDnsSolver? dnsSolver = null,
             CancellationTokenSource? externalCancellationSource = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null,
-            ConfigureUpstreamSocket? configureUpstreamSocket = null)
+            ILoggerFactory? loggerFactory = null)
         {
             _certificateProvider = certificateProvider;
             _externalCancellationSource = externalCancellationSource;
@@ -146,9 +161,7 @@ namespace Fluxzy
             ExecutionContext = new ProxyExecutionContext(startupSetting);
 
             _runTimeSetting = new ProxyRuntimeSetting(startupSetting, ExecutionContext, tcpConnectionProvider1,
-                Writer, IdProvider, userAgentProvider, loggerFactory, InstanceId) {
-                ConfigureUpstreamSocket = configureUpstreamSocket
-            };
+                Writer, IdProvider, userAgentProvider, loggerFactory, InstanceId);
 
             _logger = _runTimeSetting.GetLogger<Proxy>();
 
@@ -172,6 +185,40 @@ namespace Fluxzy
             }
 
             ThreadPoolUtility.AutoAdjustThreadPoolSize(StartupSetting.ConnectionPerHost);
+        }
+
+        /// <summary>
+        ///     Create a new instance with specific providers and an upstream socket configuration callback.
+        ///     If a provider is not provided the default will be used.
+        /// </summary>
+        /// <param name="startupSetting">The startup Setting</param>
+        /// <param name="certificateProvider">A certificate provider</param>
+        /// <param name="certificateAuthorityManager">A certificate authority manager</param>
+        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
+        /// <param name="tcpConnectionProvider">A tcp connection Provider</param>
+        /// <param name="userAgentProvider">An user Agent provider</param>
+        /// <param name="idProvider">An id provider</param>
+        /// <param name="dnsSolver">Add a custom DNS solver</param>
+        /// <param name="externalCancellationSource">An external cancellation token</param>
+        /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
+        /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        public Proxy(
+            FluxzySetting startupSetting,
+            ICertificateProvider certificateProvider,
+            CertificateAuthorityManager certificateAuthorityManager,
+            ConfigureUpstreamSocket configureUpstreamSocket,
+            ITcpConnectionProvider? tcpConnectionProvider = null,
+            IUserAgentInfoProvider? userAgentProvider = null,
+            FromIndexIdProvider? idProvider = null,
+            IDnsSolver? dnsSolver = null,
+            CancellationTokenSource? externalCancellationSource = null,
+            ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
+            ILoggerFactory? loggerFactory = null)
+            : this(startupSetting, certificateProvider, certificateAuthorityManager, tcpConnectionProvider,
+                userAgentProvider, idProvider, dnsSolver, externalCancellationSource,
+                proxyAuthenticationMethod, loggerFactory)
+        {
+            _runTimeSetting.ConfigureUpstreamSocket = configureUpstreamSocket;
         }
 
         internal ProxyExecutionContext ExecutionContext { get; }

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -81,6 +81,7 @@ namespace Fluxzy
         /// <param name="userAgentProvider">An user Agent provider</param>
         /// <param name="idProvider">An id provider</param>
         /// <param name="dnsSolver">Add a custom DNS solver</param>
+        /// <param name="configureUpstreamSocket">Callback applied to every upstream socket before it connects</param>
         /// <param name="externalCancellationSource">An external cancellation token</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
@@ -93,6 +94,7 @@ namespace Fluxzy
             IUserAgentInfoProvider? userAgentProvider = null,
             FromIndexIdProvider? idProvider = null,
             IDnsSolver? dnsSolver = null,
+            ConfigureUpstreamSocket? configureUpstreamSocket = null,
             CancellationTokenSource? externalCancellationSource = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
             ILoggerFactory? loggerFactory = null)
@@ -139,7 +141,9 @@ namespace Fluxzy
             ExecutionContext = new ProxyExecutionContext(startupSetting);
 
             _runTimeSetting = new ProxyRuntimeSetting(startupSetting, ExecutionContext, tcpConnectionProvider1,
-                Writer, IdProvider, userAgentProvider, loggerFactory, InstanceId);
+                Writer, IdProvider, userAgentProvider, loggerFactory, InstanceId) {
+                ConfigureUpstreamSocket = configureUpstreamSocket
+            };
 
             _logger = _runTimeSetting.GetLogger<Proxy>();
 

--- a/test/Fluxzy.Tests/UnitTests/Core/UpstreamSocketConfigurationTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/UpstreamSocketConfigurationTests.cs
@@ -1,9 +1,16 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Fluxzy;
+using Fluxzy.Certificates;
 using Fluxzy.Core;
 using Xunit;
 
@@ -55,6 +62,176 @@ namespace Fluxzy.Tests.UnitTests.Core
                 () => connection.ConnectAsync(IPAddress.Loopback, 65000, options));
 
             Assert.Equal(NetworkErrorCodes.UpstreamConfigurationFailed, error.ClientError.NetworkErrorCode);
+        }
+
+        [Fact]
+        public async Task Proxy_Invokes_Callback_On_Upstream_Connect()
+        {
+            await using var origin = new LocalHttpOrigin();
+
+            UpstreamSocketContext? captured = null;
+            var connectedAtCallback = true;
+            var count = 0;
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            await using var proxy = new Proxy(setting, ctx => {
+                Interlocked.Increment(ref count);
+                captured = ctx;
+                connectedAtCallback = ctx.Socket.Connected;
+            });
+
+            var endpoints = proxy.Run();
+
+            using var httpClient = CreateProxiedClient(endpoints);
+            using var response = await httpClient.GetAsync($"http://127.0.0.1:{origin.Port}/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("OK", body);
+            Assert.Equal(1, count);
+            Assert.NotNull(captured);
+            Assert.False(connectedAtCallback);
+            Assert.Equal("127.0.0.1", captured!.RequestedHost);
+            Assert.Equal(origin.Port, captured.RequestedPort);
+            Assert.Equal(origin.Port, captured.RemoteEndPoint.Port);
+            Assert.Equal(IPAddress.Loopback, captured.RemoteEndPoint.Address);
+        }
+
+        [Fact]
+        public async Task Proxy_Surfaces_Throwing_Callback_As_528()
+        {
+            await using var origin = new LocalHttpOrigin();
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            await using var proxy = new Proxy(setting,
+                _ => throw new InvalidOperationException("boom"));
+
+            var endpoints = proxy.Run();
+
+            using var httpClient = CreateProxiedClient(endpoints);
+            using var response = await httpClient.GetAsync($"http://127.0.0.1:{origin.Port}/");
+            _ = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(528, (int) response.StatusCode);
+            Assert.True(response.Headers.TryGetValues("x-fluxzy-network-error", out var values));
+            Assert.Equal(NetworkErrorCodes.UpstreamConfigurationFailed, values!.Single(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task Full_Constructor_Overload_Invokes_Callback()
+        {
+            await using var origin = new LocalHttpOrigin();
+
+            var count = 0;
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            await using var proxy = new Proxy(setting,
+                new CertificateProvider(setting.CaCertificate, new InMemoryCertificateCache()),
+                new DefaultCertificateAuthorityManager(),
+                _ => Interlocked.Increment(ref count));
+
+            var endpoints = proxy.Run();
+
+            using var httpClient = CreateProxiedClient(endpoints);
+            using var response = await httpClient.GetAsync($"http://127.0.0.1:{origin.Port}/");
+            _ = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(1, count);
+        }
+
+        private static HttpClient CreateProxiedClient(IReadOnlyCollection<IPEndPoint> endpoints)
+        {
+            return new HttpClient(new HttpClientHandler {
+                Proxy = new WebProxy($"http://127.0.0.1:{endpoints.First().Port}"),
+                UseProxy = true
+            });
+        }
+
+        private sealed class LocalHttpOrigin : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly Task _loop;
+
+            public LocalHttpOrigin()
+            {
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _loop = AcceptLoop();
+            }
+
+            public int Port { get; }
+
+            private async Task AcceptLoop()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                        _ = Serve(client);
+                    }
+                }
+                catch {
+                    // shutting down
+                }
+            }
+
+            private static async Task Serve(TcpClient client)
+            {
+                try {
+                    using (client) {
+                        var stream = client.GetStream();
+                        var buffer = new byte[4096];
+                        var received = new StringBuilder();
+
+                        while (true) {
+                            var read = await stream.ReadAsync(buffer).ConfigureAwait(false);
+
+                            if (read == 0)
+                                return;
+
+                            received.Append(Encoding.ASCII.GetString(buffer, 0, read));
+
+                            while (received.ToString().Contains("\r\n\r\n")) {
+                                var payload = Encoding.ASCII.GetBytes("OK");
+                                var header = Encoding.ASCII.GetBytes(
+                                    $"HTTP/1.1 200 OK\r\nContent-Length: {payload.Length}\r\n\r\n");
+
+                                await stream.WriteAsync(header).ConfigureAwait(false);
+                                await stream.WriteAsync(payload).ConfigureAwait(false);
+                                await stream.FlushAsync().ConfigureAwait(false);
+
+                                var text = received.ToString();
+                                var idx = text.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                                received.Clear();
+                                received.Append(text.Substring(idx + 4));
+                            }
+                        }
+                    }
+                }
+                catch {
+                    // client gone
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+
+                try {
+                    await _loop.ConfigureAwait(false);
+                }
+                catch {
+                    // ignore
+                }
+
+                _cts.Dispose();
+            }
         }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/Core/UpstreamSocketConfigurationTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/UpstreamSocketConfigurationTests.cs
@@ -1,0 +1,60 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    public class UpstreamSocketConfigurationTests
+    {
+        [Fact]
+        public async Task Callback_Receives_Unconnected_Socket_And_Resolved_Endpoint()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+            var acceptTask = listener.AcceptTcpClientAsync();
+
+            UpstreamSocketContext? captured = null;
+            var connectedAtCallback = true;
+
+            var options = new UpstreamConnectOptions("example.com", port, ctx => {
+                captured = ctx;
+                connectedAtCallback = ctx.Socket.Connected;
+            });
+
+            await using var connection = ITcpConnectionProvider.Default.Create(string.Empty);
+            var result = await connection.ConnectAsync(IPAddress.Loopback, port, options);
+
+            Assert.NotNull(captured);
+            Assert.False(connectedAtCallback);
+            Assert.Equal("example.com", captured!.RequestedHost);
+            Assert.Equal(port, captured.RequestedPort);
+            Assert.Equal(port, captured.RemoteEndPoint.Port);
+            Assert.Equal(IPAddress.Loopback, captured.RemoteEndPoint.Address);
+            Assert.Equal(AddressFamily.InterNetwork, captured.Socket.AddressFamily);
+
+            await result.Stream.DisposeAsync();
+            (await acceptTask).Dispose();
+            listener.Stop();
+        }
+
+        [Fact]
+        public async Task Throwing_Callback_Surfaces_As_ClientError()
+        {
+            var options = new UpstreamConnectOptions("example.com", 443,
+                _ => throw new InvalidOperationException("boom"));
+
+            await using var connection = ITcpConnectionProvider.Default.Create(string.Empty);
+
+            var error = await Assert.ThrowsAsync<ClientErrorException>(
+                () => connection.ConnectAsync(IPAddress.Loopback, 65000, options));
+
+            Assert.Equal(NetworkErrorCodes.UpstreamConfigurationFailed, error.ClientError.NetworkErrorCode);
+        }
+    }
+}


### PR DESCRIPTION
Adds a first-class hook to configure the upstream socket before it connects, plus two related fixes from the same use case (a managed tun2socks tunneling to a Fluxzy SOCKS5 ingress, which needs the proxy's own upstream sockets to bypass the tunnel).

A `ConfigureUpstreamSocket` callback runs once per upstream socket, after creation and before connect, exposing the unconnected `Socket`, the requested authority, and the resolved endpoint. It is reachable from both `Proxy` constructors via new overloads and applies to the default and capture paths. The default socket is now opened family-specific (it was IPv6 dual-mode) so callers can reliably set `IP_UNICAST_IF` (Windows), `IP_BOUND_IF` (macOS), or `SO_BINDTODEVICE` (Linux). A throwing callback surfaces as a 528 with the `upstream_configuration_failed` token, and the socket is disposed on failure.

It also stops `ArchivingPolicy.None` from silently discarding an injected `ITcpConnectionProvider` (it now only swaps a provider that reports it needs an archive writer, and logs a warning), and routes the SOCKS5 reply address through the injected `IDnsSolver` instead of the OS resolver.

Source and binary compatible: interface additions are default interface methods, the constructor changes are new overloads, the rest is additive. Five tests cover it without elevation or network (loopback only), two at the connection level and three end-to-end through a real `Proxy`. Adds `examples/Samples.No024.BindUpstreamSocket`. Not machine-tested: that the egress interface actually changes, which needs a multi-NIC host.
