### PR TITLE
Set version to 1.38-alpha

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.36-alpha",
+  "version": "1.38-alpha",
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"
   ],


### PR DESCRIPTION
v1.36 shipped from release/v1.36 but main's post-release version bump was missed, leaving it at 1.36-alpha. This advances main to the next dev version.

Produced as part of nbgv prepare-release for v1.37. The release/v1.37 branch is cut separately.