### PR TITLE
Name MITM leaf certificates from TLS SNI when the target is an IP

### DIFF
--- a/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
@@ -124,7 +124,17 @@ namespace Fluxzy.Core
                 var authenticateResult = await _secureConnectionUpdater.AuthenticateAsServer(
                     stream, authority.HostName, exchangeContext, token).ConfigureAwait(false);
 
-                authority = new Authority(authority.HostName, authority.Port, authenticateResult.IsSsl);
+                // See Socks5SourceProvider: when the target was an IP and the client sent a usable
+                // SNI, adopt the hostname for the authority and upstream SNI while pinning the
+                // original IP so the upstream connection is unchanged.
+                if (authenticateResult.SniHost is { } sniHost
+                    && IPAddress.TryParse(authority.HostName, out var pinnedIp)) {
+                    exchangeContext.RemoteHostIp = pinnedIp;
+                    authority = new Authority(sniHost, authority.Port, authenticateResult.IsSsl);
+                }
+                else {
+                    authority = new Authority(authority.HostName, authority.Port, authenticateResult.IsSsl);
+                }
 
                 var exchange = Exchange.CreateUntrackedExchange(_idProvider, exchangeContext,
                     authority, plainHeaderChars, Stream.Null,

--- a/src/Fluxzy.Core/Core/Impl/SecureConnectionUpdater.cs
+++ b/src/Fluxzy.Core/Core/Impl/SecureConnectionUpdater.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -25,13 +26,16 @@ namespace Fluxzy.Core
 
         private readonly ICertificateProvider _certificateProvider;
         private readonly bool _serveH2;
+        private readonly bool _recoverHostNameFromSni;
         private readonly ILogger _logger;
 
         public SecureConnectionUpdater(
-            ICertificateProvider certificateProvider, bool serveH2, ILogger? logger = null)
+            ICertificateProvider certificateProvider, bool serveH2,
+            bool recoverHostNameFromSni = false, ILogger? logger = null)
         {
             _certificateProvider = certificateProvider;
             _serveH2 = serveH2;
+            _recoverHostNameFromSni = recoverHostNameFromSni;
             _logger = logger ?? NullLogger.Instance;
         }
 
@@ -63,15 +67,25 @@ namespace Fluxzy.Core
 
             var secureStream = new SslStream(new RecomposedStream(stream, originalStream), false);
 
-            X509Certificate2 certificate;
+            // When recovery is enabled and the connect authority is an IP literal (full-system /
+            // SOCKS5 capture where the client connected straight to a resolved IP), name the leaf
+            // from the TLS SNI instead. Resolution then happens in the selection callback, where the
+            // SNI is known. The default path keeps eager resolution, so behavior and cost are unchanged.
+            var recoverFromSni = _recoverHostNameFromSni && IPAddress.TryParse(host, out _);
 
-            try {
-                certificate = context.ServerCertificate ?? _certificateProvider.GetCertificate(host);
+            X509Certificate2? prebuiltCertificate = null;
+
+            if (!recoverFromSni) {
+                try {
+                    prebuiltCertificate = context.ServerCertificate ?? _certificateProvider.GetCertificate(host);
+                }
+                catch (Exception e) {
+                    FluxzyLogEvents.CertificateResolutionFailed(_logger, e, host);
+                    throw;
+                }
             }
-            catch (Exception e) {
-                FluxzyLogEvents.CertificateResolutionFailed(_logger, e, host);
-                throw;
-            }
+
+            string? observedSniHost = null;
 
             try {
 
@@ -94,7 +108,30 @@ namespace Fluxzy.Core
                     ClientCertificateRequired = false,
                     CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
                     EncryptionPolicy = EncryptionPolicy.RequireEncryption,
-                    ServerCertificateSelectionCallback = (sender, name) => certificate
+                    ServerCertificateSelectionCallback = (sender, name) =>
+                    {
+                        if (context.ServerCertificate is not null)
+                            return context.ServerCertificate;
+
+                        if (!recoverFromSni)
+                            return prebuiltCertificate!;
+
+                        // Prefer a usable SNI hostname; ignore empty SNI and IP-literal SNI and keep
+                        // the IP fallback (current behavior) in those cases.
+                        var sniUsable = !string.IsNullOrWhiteSpace(name) && !IPAddress.TryParse(name, out _);
+                        var certHost = sniUsable ? name! : host;
+
+                        if (sniUsable)
+                            observedSniHost = name;
+
+                        try {
+                            return _certificateProvider.GetCertificate(certHost);
+                        }
+                        catch (Exception e) {
+                            FluxzyLogEvents.CertificateResolutionFailed(_logger, e, certHost);
+                            throw;
+                        }
+                    }
                 };
 
                 await secureStream
@@ -110,13 +147,15 @@ namespace Fluxzy.Core
                     };
             }
 
-            return new SecureConnectionUpdateResult(true, secureStream, secureStream, secureStream.NegotiatedApplicationProtocol);
+            return new SecureConnectionUpdateResult(true, secureStream, secureStream,
+                secureStream.NegotiatedApplicationProtocol, observedSniHost);
         }
     }
 
     internal record SecureConnectionUpdateResult(
         bool IsSsl, Stream InStream, Stream OutStream,
-        SslApplicationProtocol NegotiatedApplicationProtocol = default)
+        SslApplicationProtocol NegotiatedApplicationProtocol = default,
+        string? SniHost = null)
     {
         public bool IsSsl { get; } = IsSsl;
 
@@ -125,5 +164,11 @@ namespace Fluxzy.Core
         public Stream OutStream { get; } = OutStream;
 
         public SslApplicationProtocol NegotiatedApplicationProtocol { get; } = NegotiatedApplicationProtocol;
+
+        /// <summary>
+        ///     The hostname observed in the TLS SNI when leaf-from-SNI recovery applied (i.e. the
+        ///     connect authority was an IP and the client sent a usable SNI). Null otherwise.
+        /// </summary>
+        public string? SniHost { get; } = SniHost;
     }
 }

--- a/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
+++ b/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
@@ -171,7 +171,17 @@ namespace Fluxzy.Core.Socks5
                 stream, authority.HostName, exchangeContext, token).ConfigureAwait(false);
             var certEnd = ITimingProvider.Default.Instant();
 
-            authority = new Authority(authority.HostName, authority.Port, authenticateResult.IsSsl);
+            // The SOCKS5 target was an IP and the client revealed a hostname through the TLS SNI:
+            // adopt that hostname for the recorded authority and the upstream SNI, but pin the
+            // original IP so the upstream connection still targets it exactly (no DNS, no reroute).
+            if (authenticateResult.SniHost is { } sniHost
+                && IPAddress.TryParse(authority.HostName, out var pinnedIp)) {
+                exchangeContext.RemoteHostIp = pinnedIp;
+                authority = new Authority(sniHost, authority.Port, authenticateResult.IsSsl);
+            }
+            else {
+                authority = new Authority(authority.HostName, authority.Port, authenticateResult.IsSsl);
+            }
 
             var exchange = Exchange.CreateUntrackedExchange(
                 _idProvider,

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -531,6 +531,20 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     When enabled, recover the hostname from the TLS SNI to name leaf certificates (and the
+        ///     recorded authority and upstream SNI) whenever the connect target is an IP address. The
+        ///     original IP is pinned, so the upstream connection still targets it exactly without an
+        ///     extra DNS resolution. Falls back to the IP when no usable SNI is present. Default false.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public FluxzySetting SetRecoverHostNameFromSni(bool value)
+        {
+            RecoverHostNameFromSni = value;
+            return this;
+        }
+
+        /// <summary>
         ///     When set to true, the server certificate will be exported as PEM in the SSL connection information.
         ///     This is useful for diagnostics or auditing purposes.
         /// </summary>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -224,6 +224,19 @@ namespace Fluxzy
         public bool ServeH2 { get; internal set; }
 
         /// <summary>
+        ///     When enabled and the connection target is an IP address (typically full-system or
+        ///     SOCKS5 capture, where the client connected straight to a resolved IP), Fluxzy names
+        ///     the generated leaf certificate, the recorded authority and the upstream SNI from the
+        ///     TLS SNI sent by the client instead of from the IP. The original IP is pinned for the
+        ///     upstream connection, so no extra DNS resolution is performed and traffic still goes to
+        ///     the exact target. Connections to distinct IPs that share the recovered hostname are
+        ///     pooled together. Falls back to the IP when no usable SNI is present (raw-IP TLS, ECH).
+        ///     Default false, which leaves behavior and performance unchanged.
+        /// </summary>
+        [JsonInclude]
+        public bool RecoverHostNameFromSni { get; internal set; }
+
+        /// <summary>
         ///     When set to true, the server certificate will be exported as PEM in the SSL connection information.
         ///     This is useful for diagnostics or auditing purposes.
         /// </summary>

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -128,6 +128,7 @@ namespace Fluxzy
 
             var secureConnectionManager = new SecureConnectionUpdater(
                 certificateProvider, startupSetting.ServeH2,
+                startupSetting.RecoverHostNameFromSni,
                 (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<SecureConnectionUpdater>());
 
             if (StartupSetting.ArchivingPolicy.Type == ArchivingPolicyType.Directory

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -92,6 +92,7 @@ namespace Fluxzy.Cli.Commands
             command.AddOption(StartCommandOptions.CreatePrettyOutputOption());
             command.AddOption(StartCommandOptions.CreatePrettyMaxRowsOption());
             command.AddOption(StartCommandOptions.CreateServeH2Option());
+            command.AddOption(StartCommandOptions.CreateRecoverHostNameFromSniOption());
             command.AddOption(StartCommandOptions.CreateEnableDiscoveryOption());
             command.AddOption(StartCommandOptions.CreateProtoDirectoryOption());
             command.AddOption(StartCommandOptions.CreateTraceOption());
@@ -136,6 +137,7 @@ namespace Fluxzy.Cli.Commands
             var prettyOutput = invocationContext.Value<bool>("pretty");
             var prettyMaxRows = invocationContext.Value<int>("pretty-max-rows");
             var serveH2 = invocationContext.Value<bool>("serve-h2");
+            var recoverHostNameFromSni = invocationContext.Value<bool>("recover-host-from-sni");
             var enableDiscovery = invocationContext.Value<bool>("enable-discovery");
             var protoDirectories = invocationContext.Value<List<string>>("proto-dir");
             var traceMode = invocationContext.Value<TraceMode>("trace");
@@ -294,6 +296,7 @@ namespace Fluxzy.Cli.Commands
             proxyStartUpSetting.SetEnableProcessTracking(enableProcessTracking);
             proxyStartUpSetting.SetIncludeAndroidEmulatorHost(!noAndroidEmulator);
             proxyStartUpSetting.SetServeH2(serveH2);
+            proxyStartUpSetting.SetRecoverHostNameFromSni(recoverHostNameFromSni);
             proxyStartUpSetting.SetEnableDiscoveryService(enableDiscovery);
             proxyStartUpSetting.SetSkipInternalRules(skipInternalRules);
 

--- a/src/Fluxzy/Commands/StartCommandOptions.cs
+++ b/src/Fluxzy/Commands/StartCommandOptions.cs
@@ -476,6 +476,21 @@ namespace Fluxzy.Cli.Commands
             return option;
         }
 
+        public static Option CreateRecoverHostNameFromSniOption()
+        {
+            var option = new Option<bool>(
+                "--recover-host-from-sni",
+                "When the connection target is an IP address (typically full-system or SOCKS5 " +
+                "capture), name the generated certificate, the recorded host and the upstream SNI " +
+                "from the TLS SNI sent by the client. The original IP is kept for the upstream " +
+                "connection, so no extra DNS resolution is performed.");
+
+            option.SetDefaultValue(false);
+            option.Arity = ArgumentArity.Zero;
+
+            return option;
+        }
+
         public static Option CreateProtoDirectoryOption()
         {
             var option = new Option<List<string>>(

--- a/test/Fluxzy.Tests/UnitTests/Core/SecureConnectionUpdaterSniTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SecureConnectionUpdaterSniTests.cs
@@ -1,0 +1,106 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Certificates;
+using Fluxzy.Core;
+using Fluxzy.Rules;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    /// <summary>
+    ///     Covers RecoverHostNameFromSni: when the connect authority is an IP, the leaf certificate
+    ///     is named from the TLS SNI sent by the client, falling back to the IP CN otherwise.
+    /// </summary>
+    public class SecureConnectionUpdaterSniTests
+    {
+        private const string ConnectIp = "93.184.216.34";
+
+        [Fact]
+        public async Task Recover_On_WithHostnameSni_NamesLeafFromSni()
+        {
+            var (served, observedSni) = await RunHandshake(
+                recoverHostNameFromSni: true, connectHost: ConnectIp, clientTargetHost: "example.com");
+
+            Assert.Equal("CN=*.example.com", served.Subject);
+
+            var dnsNames = served.Extensions
+                                 .OfType<X509SubjectAlternativeNameExtension>()
+                                 .Single()
+                                 .EnumerateDnsNames()
+                                 .ToList();
+
+            Assert.Contains("example.com", dnsNames);
+            Assert.Contains("*.example.com", dnsNames);
+            Assert.Equal("example.com", observedSni);
+        }
+
+        [Fact]
+        public async Task Recover_On_WithoutUsableSni_FallsBackToIpCn()
+        {
+            // The client targets the IP itself, so there is no usable hostname SNI: the IP CN is kept.
+            var (served, observedSni) = await RunHandshake(
+                recoverHostNameFromSni: true, connectHost: ConnectIp, clientTargetHost: ConnectIp);
+
+            Assert.Equal($"CN={ConnectIp}", served.Subject);
+            Assert.Null(observedSni);
+        }
+
+        [Fact]
+        public async Task Recover_Off_IgnoresSni_KeepsIpCn()
+        {
+            // Default behavior: even with a hostname SNI, the leaf is named from the IP authority.
+            var (served, observedSni) = await RunHandshake(
+                recoverHostNameFromSni: false, connectHost: ConnectIp, clientTargetHost: "example.com");
+
+            Assert.Equal($"CN={ConnectIp}", served.Subject);
+            Assert.Null(observedSni);
+        }
+
+        private static async Task<(X509Certificate2 Served, string? ObservedSni)> RunHandshake(
+            bool recoverHostNameFromSni, string connectHost, string clientTargetHost)
+        {
+            var root = Certificate.UseDefault();
+            using var provider = new CertificateProvider(root, new InMemoryCertificateCache());
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            var updater = new SecureConnectionUpdater(provider, serveH2: false,
+                recoverHostNameFromSni: recoverHostNameFromSni);
+
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var serverTask = Task.Run(async () => {
+                using var serverConnection = await listener.AcceptTcpClientAsync(cts.Token);
+                var authority = new Authority(connectHost, port, true);
+                var context = new ExchangeContext(authority, new VariableContext(), setting, null!);
+
+                return await updater.AuthenticateAsServer(
+                    serverConnection.GetStream(), connectHost, context, cts.Token);
+            });
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, port);
+
+            using var clientSsl = new SslStream(client.GetStream(), false, (_, _, _, _) => true);
+            await clientSsl.AuthenticateAsClientAsync(clientTargetHost);
+
+            var result = await serverTask;
+            var served = (X509Certificate2) clientSsl.RemoteCertificate!;
+
+            listener.Stop();
+
+            return (served, result.SniHost);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
@@ -1,0 +1,320 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Certificates;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Core.Socks5;
+using Fluxzy.Rules;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    /// <summary>
+    ///     End-to-end coverage of RecoverHostNameFromSni at the ingress-provider level: the authority
+    ///     rewrite + IP pinning in Socks5SourceProvider and FromProxyConnectSourceProvider, and the
+    ///     resulting guarantee that the pinned IP keeps the upstream connection off the DNS resolver.
+    /// </summary>
+    public class SniHostRecoveryProviderTests
+    {
+        private static readonly IPAddress TargetIp = IPAddress.Parse("1.2.3.4");
+        private const int TargetPort = 443;
+
+        // #1 - SOCKS5: IP target + hostname SNI -> authority adopts the hostname, IP is pinned.
+        [Fact]
+        public async Task Socks5_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, target: Ipv4ConnectRequest(TargetIp, TargetPort),
+                clientSniTargetHost: "example.com");
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetPort, exchange.Authority.Port);
+            Assert.True(exchange.Authority.Secure);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+        }
+
+        // #1 - SOCKS5: IP target but no usable SNI (client targets the IP itself) -> IP CN is kept.
+        [Fact]
+        public async Task Socks5_IpTarget_WithoutUsableSni_KeepsIpAuthorityAndDoesNotPin()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, target: Ipv4ConnectRequest(TargetIp, TargetPort),
+                clientSniTargetHost: TargetIp.ToString());
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+        }
+
+        // #1 - SOCKS5: hostname target (ATYP=DOMAIN) is never rewritten, even with the flag on and a
+        // usable SNI. The recovery is gated to IP authorities only.
+        [Fact]
+        public async Task Socks5_HostnameTarget_IsNeverRewritten()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, target: DomainConnectRequest("example.org", TargetPort),
+                clientSniTargetHost: "example.com");
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.org", exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+        }
+
+        // #1 - transparent CONNECT: IP target + hostname SNI -> authority adopts the hostname, IP pinned.
+        [Fact]
+        public async Task Connect_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
+        {
+            var (result, _) = await RunConnect(
+                recoverHostNameFromSni: true, connectTarget: $"{TargetIp}:{TargetPort}",
+                clientSniTargetHost: "example.com");
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetPort, exchange.Authority.Port);
+            Assert.True(exchange.Authority.Secure);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+        }
+
+        // #2 - the pin set during recovery keeps the upstream connection on the exact target IP and the
+        // DNS resolver is never consulted for the recovered hostname.
+        [Fact]
+        public async Task Recovery_PinnedIp_KeepsUpstreamOffTheDnsResolver()
+        {
+            var (result, dns) = await RunSocks5(
+                recoverHostNameFromSni: true, target: Ipv4ConnectRequest(TargetIp, TargetPort),
+                clientSniTargetHost: "example.com");
+
+            var exchange = AssertResult(result);
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+
+            // The upstream resolution honors the pin: it returns the original target IP, not the
+            // (deliberately different) address the resolver would hand back, and never queries it.
+            var resolution = await DnsUtility.ComputeDnsUpdateExchange(
+                exchange, ITimingProvider.Default, dns, null);
+
+            Assert.Equal(TargetIp, resolution.EndPoint.Address);
+            Assert.Equal(TargetPort, resolution.EndPoint.Port);
+            Assert.Empty(dns.Queries);
+        }
+
+        // #2 (contrast) - without recovery the authority stays the IP and is not pinned, so the resolver
+        // IS on the upstream path. This is the reroute risk that pinning removes.
+        [Fact]
+        public async Task WithoutRecovery_UpstreamGoesThroughTheDnsResolver()
+        {
+            var (result, dns) = await RunSocks5(
+                recoverHostNameFromSni: false, target: Ipv4ConnectRequest(TargetIp, TargetPort),
+                clientSniTargetHost: "example.com");
+
+            var exchange = AssertResult(result);
+            Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+
+            var resolution = await DnsUtility.ComputeDnsUpdateExchange(
+                exchange, ITimingProvider.Default, dns, null);
+
+            Assert.Equal(dns.Answer, resolution.EndPoint.Address);
+            Assert.Contains(TargetIp.ToString(), dns.Queries);
+        }
+
+        private static Exchange AssertResult(ExchangeSourceInitResult? result)
+        {
+            Assert.NotNull(result);
+            return result!.ProvisionalExchange;
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunSocks5(
+            bool recoverHostNameFromSni, byte[] target, string clientSniTargetHost)
+        {
+            return await RunProvider(recoverHostNameFromSni,
+                (updater, idProvider, contextBuilder, dnsSolver) =>
+                    new Socks5SourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
+                        contextBuilder, dnsSolver),
+                async (clientStream, token) => {
+                    await clientStream.WriteAsync(new byte[] { 0x05, 0x01, 0x00 }, token);
+                    await clientStream.ReadExactlyAsync(new byte[2], token); // method selection
+                    await clientStream.WriteAsync(target, token);
+                    await clientStream.ReadExactlyAsync(new byte[10], token); // IPv4 reply
+                },
+                clientSniTargetHost);
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunConnect(
+            bool recoverHostNameFromSni, string connectTarget, string clientSniTargetHost)
+        {
+            return await RunProvider(recoverHostNameFromSni,
+                (updater, idProvider, contextBuilder, _) =>
+                    new FromProxyConnectSourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
+                        contextBuilder),
+                async (clientStream, token) => {
+                    var connect = Encoding.ASCII.GetBytes(
+                        $"CONNECT {connectTarget} HTTP/1.1\r\nHost: {connectTarget}\r\n\r\n");
+                    await clientStream.WriteAsync(connect, token);
+                    await ReadUntilDoubleCrlf(clientStream, token); // tunnel accept response
+                },
+                clientSniTargetHost);
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunProvider(
+            bool recoverHostNameFromSni,
+            Func<SecureConnectionUpdater, IIdProvider, IExchangeContextBuilder, IDnsSolver, ExchangeSourceProvider>
+                providerFactory,
+            Func<Stream, CancellationToken, Task> preTlsClientDriver,
+            string clientSniTargetHost)
+        {
+            var root = Certificate.UseDefault();
+            using var certProvider = new CertificateProvider(root, new InMemoryCertificateCache());
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            var updater = new SecureConnectionUpdater(certProvider, serveH2: false,
+                recoverHostNameFromSni: recoverHostNameFromSni);
+
+            var dns = new SpyDnsSolver(IPAddress.Parse("9.9.9.9"));
+            var provider = providerFactory(updater, new FromIndexIdProvider(0, 0),
+                new TestExchangeContextBuilder(setting), dns);
+
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+            var serverTask = Task.Run(async () => {
+                using var serverConnection = await listener.AcceptTcpClientAsync(cts.Token);
+                using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(1024 * 8);
+
+                return await provider.InitClientConnection(
+                    serverConnection.GetStream(), buffer,
+                    (IPEndPoint) serverConnection.Client.LocalEndPoint!,
+                    (IPEndPoint) serverConnection.Client.RemoteEndPoint!,
+                    cts.Token);
+            });
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, port);
+            var clientStream = client.GetStream();
+
+            // Keep the SSL stream alive until the server side has produced its result.
+            SslStream? clientSsl = null;
+            Exception? clientError = null;
+
+            try {
+                await preTlsClientDriver(clientStream, cts.Token);
+
+                clientSsl = new SslStream(clientStream, false, (_, _, _, _) => true);
+                await clientSsl.AuthenticateAsClientAsync(clientSniTargetHost);
+            }
+            catch (Exception ex) {
+                clientError = ex;
+            }
+
+            ExchangeSourceInitResult? result;
+
+            try {
+                result = await serverTask;
+            }
+            catch (Exception serverEx) {
+                throw new Xunit.Sdk.XunitException(
+                    $"Server provider failed (client error: {clientError?.Message ?? "none"}): {serverEx}");
+            }
+            finally {
+                clientSsl?.Dispose();
+                listener.Stop();
+            }
+
+            if (clientError != null)
+                throw clientError;
+
+            return (result, dns);
+        }
+
+        private static byte[] Ipv4ConnectRequest(IPAddress ip, int port)
+        {
+            var request = new byte[] { 0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0 };
+            ip.GetAddressBytes().CopyTo(request, 4);
+            BinaryPrimitives.WriteUInt16BigEndian(request.AsSpan(8), (ushort) port);
+            return request;
+        }
+
+        private static byte[] DomainConnectRequest(string domain, int port)
+        {
+            var domainBytes = Encoding.ASCII.GetBytes(domain);
+            var request = new byte[4 + 1 + domainBytes.Length + 2];
+            request[0] = 0x05;
+            request[1] = 0x01;
+            request[2] = 0x00;
+            request[3] = 0x03;
+            request[4] = (byte) domainBytes.Length;
+            domainBytes.CopyTo(request, 5);
+            BinaryPrimitives.WriteUInt16BigEndian(request.AsSpan(5 + domainBytes.Length), (ushort) port);
+            return request;
+        }
+
+        private static async Task ReadUntilDoubleCrlf(Stream stream, CancellationToken token)
+        {
+            var single = new byte[1];
+            var matched = 0;
+
+            while (matched < 4) {
+                var read = await stream.ReadAsync(single, token);
+
+                if (read == 0)
+                    throw new EndOfStreamException();
+
+                var expected = matched % 2 == 0 ? (byte) '\r' : (byte) '\n';
+                matched = single[0] == expected ? matched + 1 : single[0] == '\r' ? 1 : 0;
+            }
+        }
+
+        private sealed class TestExchangeContextBuilder : IExchangeContextBuilder
+        {
+            private readonly FluxzySetting _setting;
+            private readonly VariableContext _variableContext = new();
+
+            public TestExchangeContextBuilder(FluxzySetting setting)
+            {
+                _setting = setting;
+            }
+
+            public ValueTask<ExchangeContext> Create(Authority authority, bool secure)
+            {
+                return new ValueTask<ExchangeContext>(
+                    new ExchangeContext(authority, _variableContext, _setting, null!) { Secure = secure });
+            }
+        }
+
+        private sealed class SpyDnsSolver : IDnsSolver
+        {
+            public SpyDnsSolver(IPAddress answer)
+            {
+                Answer = answer;
+            }
+
+            public IPAddress Answer { get; }
+
+            public List<string> Queries { get; } = new();
+
+            public Task<IPAddress> SolveDns(string hostName)
+            {
+                Queries.Add(hostName);
+                return Task.FromResult(Answer);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Under full-system / SOCKS5 capture the connect authority is often a raw IP, so the generated leaf certificate gets an IP CN (CN=93.184.x.x) and the recorded host is the IP. The real hostname is present in the TLS ClientHello SNI but was discarded.

This adds an opt-in setting `RecoverHostNameFromSni` (default off, so the default path is unchanged in behavior and performance). When enabled and the connect target is an IP:

- the leaf certificate is named from the SNI in the selection callback (CN=*.example.com instead of the IP),
- both ingress paths (SOCKS5 and transparent CONNECT) adopt the SNI host for the recorded authority and the upstream SNI,
- the original IP is pinned via `ExchangeContext.RemoteHostIp`, so the upstream connection still targets it exactly with no extra DNS resolution and no reroute.

It falls back to the IP CN when no usable SNI is present (raw-IP TLS, ECH). Surfaced on the CLI as `--recover-host-from-sni`.

Why pin the IP rather than re-resolve the hostname: `Authority.HostName` drives the upstream DNS resolution, the connection-pool key and the upstream TLS SNI. Rewriting it to the hostname without pinning would put Fluxzy's resolver on the critical path of every connection and could connect to a different IP than the client targeted. Pinning keeps the proven real-IP path untouched.

