### PR TITLE
Recover host name from the TLS ClientHello SNI when the target is an IP

### DIFF
--- a/src/Fluxzy.Core/Clients/Ssl/TlsClientHelloParser.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/TlsClientHelloParser.cs
@@ -1,0 +1,279 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+
+namespace Fluxzy.Clients.Ssl
+{
+    /// <summary>Recomposed stream (peeked bytes replayed) plus the usable SNI host, if any.</summary>
+    internal readonly struct SniRecovery
+    {
+        public SniRecovery(Stream recomposedStream, string? sniHost)
+        {
+            RecomposedStream = recomposedStream;
+            SniHost = sniHost;
+        }
+
+        public Stream RecomposedStream { get; }
+
+        public string? SniHost { get; }
+    }
+
+    /// <summary><see cref="ConsumedBytes"/> are every byte read and must be replayed into the handshake.</summary>
+    internal readonly struct ClientHelloPeek
+    {
+        public ClientHelloPeek(bool isTlsHandshake, string? sniHost, ReadOnlyMemory<byte> consumedBytes)
+        {
+            IsTlsHandshake = isTlsHandshake;
+            SniHost = sniHost;
+            ConsumedBytes = consumedBytes;
+        }
+
+        public bool IsTlsHandshake { get; }
+
+        public string? SniHost { get; }
+
+        public ReadOnlyMemory<byte> ConsumedBytes { get; }
+    }
+
+    /// <summary>Reads the SNI host from a client's ClientHello. Never throws; malformed input yields null.</summary>
+    internal static class TlsClientHelloParser
+    {
+        private const byte HandshakeContentType = 0x16;
+        private const byte ClientHelloType = 0x01;
+        private const int ServerNameExtensionType = 0x0000;
+        private const byte HostNameType = 0x00;
+
+        // Bounds the wait for a silent client (e.g. a non-TLS blind tunnel) so it forwards instead of stalling.
+        private const int PeekTimeoutMilliseconds = 5000;
+
+        /// <summary>Peek the ClientHello (bounded) and return a replaying stream plus the usable SNI host.</summary>
+        public static async Task<SniRecovery> RecoverAsync(Stream stream, CancellationToken token)
+        {
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+            timeoutSource.CancelAfter(PeekTimeoutMilliseconds);
+
+            var peek = await PeekAsync(stream, timeoutSource.Token).ConfigureAwait(false);
+
+            // Replay peeked bytes on read; keep writes on the socket so the stream stays read/write.
+            var replayed = new CombinedReadonlyStream(false, peek.ConsumedBytes.Span, stream);
+            var recomposed = new RecomposedStream(replayed, stream);
+
+            var host = !string.IsNullOrWhiteSpace(peek.SniHost) && !IPAddress.TryParse(peek.SniHost, out _)
+                ? peek.SniHost
+                : null;
+
+            return new SniRecovery(recomposed, host);
+        }
+
+        /// <summary>Read the leading TLS record and extract its SNI, returning every byte read for replay.</summary>
+        public static async Task<ClientHelloPeek> PeekAsync(Stream stream, CancellationToken token)
+        {
+            // The first byte alone says whether this is TLS, so a non-TLS client only loses that byte.
+            var header = new byte[5];
+            var headerRead = await ReadUpToAsync(stream, header.AsMemory(0, 1), token).ConfigureAwait(false);
+
+            if (headerRead == 0)
+                return new ClientHelloPeek(false, null, ReadOnlyMemory<byte>.Empty);
+
+            if (header[0] != HandshakeContentType)
+                return new ClientHelloPeek(false, null, header.AsMemory(0, 1));
+
+            headerRead += await ReadUpToAsync(stream, header.AsMemory(1, 4), token).ConfigureAwait(false);
+
+            if (headerRead < header.Length)
+                return new ClientHelloPeek(true, null, header.AsMemory(0, headerRead));
+
+            var recordLength = BinaryPrimitives.ReadUInt16BigEndian(header.AsSpan(3, 2));
+
+            // The record buffer doubles as the bytes we replay, so it is sized exactly and read once.
+            // A ClientHello fits in a single record in practice; a fragmented one fails the parse bounds
+            // check below and falls back to the connect authority.
+            var record = new byte[5 + recordLength];
+            header.CopyTo(record, 0);
+
+            var payloadRead = await ReadUpToAsync(stream, record.AsMemory(5, recordLength), token).ConfigureAwait(false);
+
+            var consumed = payloadRead == recordLength ? record : record.AsSpan(0, 5 + payloadRead).ToArray();
+
+            TryReadServerName(consumed, out var host);
+
+            return new ClientHelloPeek(true, host, consumed);
+        }
+
+        /// <summary>Parse the SNI host from a single complete ClientHello record (record header included).</summary>
+        public static bool TryReadServerName(ReadOnlySpan<byte> tlsRecord, out string? hostName)
+        {
+            hostName = null;
+
+            if (tlsRecord.Length < 5 || tlsRecord[0] != HandshakeContentType)
+                return false;
+
+            var recordLength = BinaryPrimitives.ReadUInt16BigEndian(tlsRecord.Slice(3, 2));
+            var payload = tlsRecord.Slice(5);
+
+            if (payload.Length < recordLength)
+                return false;
+
+            return TryReadServerNameFromHandshake(payload.Slice(0, recordLength), out hostName);
+        }
+
+        private static bool TryReadServerNameFromHandshake(ReadOnlySpan<byte> handshake, out string? hostName)
+        {
+            hostName = null;
+
+            if (handshake.Length < 4 || handshake[0] != ClientHelloType)
+                return false;
+
+            var bodyLength = (handshake[1] << 16) | (handshake[2] << 8) | handshake[3];
+            var body = handshake.Slice(4);
+
+            if (body.Length < bodyLength)
+                return false;
+
+            body = body.Slice(0, bodyLength);
+
+            var pos = 0;
+
+            // client_version (2) + random (32)
+            if (!Skip(ref pos, body.Length, 2 + 32))
+                return false;
+
+            // session_id: 1-byte length prefix
+            if (pos >= body.Length)
+                return false;
+
+            if (!Skip(ref pos, body.Length, body[pos] + 1))
+                return false;
+
+            // cipher_suites: 2-byte length prefix
+            if (pos + 2 > body.Length)
+                return false;
+
+            var cipherSuitesLength = BinaryPrimitives.ReadUInt16BigEndian(body.Slice(pos, 2));
+
+            if (!Skip(ref pos, body.Length, cipherSuitesLength + 2))
+                return false;
+
+            // compression_methods: 1-byte length prefix
+            if (pos >= body.Length)
+                return false;
+
+            if (!Skip(ref pos, body.Length, body[pos] + 1))
+                return false;
+
+            // extensions: 2-byte length prefix (absent on very old hellos => no SNI)
+            if (pos + 2 > body.Length)
+                return false;
+
+            var extensionsLength = BinaryPrimitives.ReadUInt16BigEndian(body.Slice(pos, 2));
+            pos += 2;
+
+            if (pos + extensionsLength > body.Length)
+                return false;
+
+            var extensions = body.Slice(pos, extensionsLength);
+            var extPos = 0;
+
+            while (extPos + 4 <= extensions.Length) {
+                var extensionType = BinaryPrimitives.ReadUInt16BigEndian(extensions.Slice(extPos, 2));
+                var extensionLength = BinaryPrimitives.ReadUInt16BigEndian(extensions.Slice(extPos + 2, 2));
+                extPos += 4;
+
+                if (extPos + extensionLength > extensions.Length)
+                    return false;
+
+                var extensionData = extensions.Slice(extPos, extensionLength);
+                extPos += extensionLength;
+
+                if (extensionType != ServerNameExtensionType)
+                    continue;
+
+                return TryReadHostNameEntry(extensionData, out hostName);
+            }
+
+            return false;
+        }
+
+        private static bool TryReadHostNameEntry(ReadOnlySpan<byte> serverNameExtension, out string? hostName)
+        {
+            hostName = null;
+
+            // server_name_list: 2-byte length prefix
+            if (serverNameExtension.Length < 2)
+                return false;
+
+            var listLength = BinaryPrimitives.ReadUInt16BigEndian(serverNameExtension.Slice(0, 2));
+            var list = serverNameExtension.Slice(2);
+
+            if (list.Length < listLength)
+                return false;
+
+            list = list.Slice(0, listLength);
+
+            var pos = 0;
+
+            while (pos + 3 <= list.Length) {
+                var nameType = list[pos];
+                var nameLength = BinaryPrimitives.ReadUInt16BigEndian(list.Slice(pos + 1, 2));
+                pos += 3;
+
+                if (pos + nameLength > list.Length)
+                    return false;
+
+                if (nameType == HostNameType) {
+                    if (nameLength == 0)
+                        return false;
+
+                    // host_name is carried as ASCII (IDNA a-labels) on the wire.
+                    hostName = Encoding.ASCII.GetString(list.Slice(pos, nameLength));
+
+                    return true;
+                }
+
+                pos += nameLength;
+            }
+
+            return false;
+        }
+
+        private static bool Skip(ref int pos, int length, int by)
+        {
+            if (by < 0)
+                return false;
+
+            pos += by;
+
+            return pos <= length;
+        }
+
+        // Reads up to buffer.Length bytes, returning how many were read. EOF, IO error and the peek
+        // timeout all just stop early; whatever was read is still returned for replay.
+        private static async Task<int> ReadUpToAsync(Stream stream, Memory<byte> buffer, CancellationToken token)
+        {
+            var offset = 0;
+
+            try {
+                while (offset < buffer.Length) {
+                    var read = await stream.ReadAsync(buffer.Slice(offset), token).ConfigureAwait(false);
+
+                    if (read == 0)
+                        break;
+
+                    offset += read;
+                }
+            }
+            catch {
+                // Timeout/IO: return what was read so far.
+            }
+
+            return offset;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Core/ExchangeSourceProviderHelper.cs
+++ b/src/Fluxzy.Core/Core/ExchangeSourceProviderHelper.cs
@@ -15,7 +15,8 @@ namespace Fluxzy.Core
             if (!setting.ReverseMode)
                 return new ProtocolDetectingSourceProvider(
                     secureConnectionUpdater, idProvider,
-                    proxyAuthenticationMethod, contextBuilder, dnsSolver);
+                    proxyAuthenticationMethod, contextBuilder, dnsSolver,
+                    setting.RecoverHostNameFromSni);
             
             if (setting.ReverseModePlainHttp)
                 return new ReverseProxyPlainExchangeSourceProvider(idProvider, setting.ReverseModeForcedPort, contextBuilder);

--- a/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
 using Fluxzy.Clients.H11;
+using Fluxzy.Clients.Ssl;
 using Fluxzy.Misc.ResizableBuffers;
 using Fluxzy.Misc.Streams;
 using Fluxzy.Utils;
@@ -100,6 +101,20 @@ namespace Fluxzy.Core
 
                 await stream.WriteAsync(new ReadOnlyMemory<byte>(AcceptTunnelResponse), token);
                 var exchangeContext = await contextBuilder.Create(authority, true).ConfigureAwait(false);
+
+                // See Socks5SourceProvider: recover the host from the TLS SNI when the target is an IP,
+                // pinning the IP so the upstream connection is unchanged.
+                if (exchangeContext.FluxzySetting?.RecoverHostNameFromSni == true
+                    && IPAddress.TryParse(authority.HostName, out var targetIp)) {
+                    var recovery = await TlsClientHelloParser.RecoverAsync(stream, token).ConfigureAwait(false);
+                    stream = recovery.RecomposedStream;
+
+                    if (recovery.SniHost is { } sniHost) {
+                        exchangeContext.RemoteHostIp = targetIp;
+                        authority = new Authority(sniHost, authority.Port, authority.Secure);
+                        exchangeContext.Authority = authority;
+                    }
+                }
 
                 if (exchangeContext.BlindMode) {
 

--- a/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
@@ -29,18 +29,21 @@ namespace Fluxzy.Core
         private readonly ProxyAuthenticationMethod _proxyAuthenticationMethod;
         private readonly IExchangeContextBuilder _contextBuilder;
         private readonly SecureConnectionUpdater _secureConnectionUpdater;
+        private readonly bool _recoverHostNameFromSni;
         private readonly int _attemptCount;
 
         public FromProxyConnectSourceProvider(
             SecureConnectionUpdater secureConnectionUpdater,
             IIdProvider idProvider, ProxyAuthenticationMethod proxyAuthenticationMethod,
-            IExchangeContextBuilder contextBuilder) :
+            IExchangeContextBuilder contextBuilder,
+            bool recoverHostNameFromSni = false) :
             base (idProvider)
         {
             _secureConnectionUpdater = secureConnectionUpdater;
             _idProvider = idProvider;
             _proxyAuthenticationMethod = proxyAuthenticationMethod;
             _contextBuilder = contextBuilder;
+            _recoverHostNameFromSni = recoverHostNameFromSni;
 
             _attemptCount = proxyAuthenticationMethod.AuthenticationType == ProxyAuthenticationType.None ? 
                 1 : FluxzySharedSetting.ProxyAuthenticationMaxAttempt;
@@ -100,21 +103,21 @@ namespace Fluxzy.Core
                 }
 
                 await stream.WriteAsync(new ReadOnlyMemory<byte>(AcceptTunnelResponse), token);
-                var exchangeContext = await contextBuilder.Create(authority, true).ConfigureAwait(false);
 
-                // See Socks5SourceProvider: recover the host from the TLS SNI when the target is an IP,
-                // pinning the IP so the upstream connection is unchanged.
-                if (exchangeContext.FluxzySetting?.RecoverHostNameFromSni == true
-                    && IPAddress.TryParse(authority.HostName, out var targetIp)) {
+                // See Socks5SourceProvider: when the CONNECT target is an IP, recover the host from the
+                // TLS SNI before the exchange context exists, so authority-scope rules see the recovered
+                // host. The original IP is pinned on every context created for this connection.
+                if (_recoverHostNameFromSni && IPAddress.TryParse(authority.HostName, out var targetIp)) {
                     var recovery = await TlsClientHelloParser.RecoverAsync(stream, token).ConfigureAwait(false);
                     stream = recovery.RecomposedStream;
 
                     if (recovery.SniHost is { } sniHost) {
-                        exchangeContext.RemoteHostIp = targetIp;
                         authority = new Authority(sniHost, authority.Port, authority.Secure);
-                        exchangeContext.Authority = authority;
+                        contextBuilder = new PinnedIpExchangeContextBuilder(contextBuilder, targetIp);
                     }
                 }
+
+                var exchangeContext = await contextBuilder.Create(authority, true).ConfigureAwait(false);
 
                 if (exchangeContext.BlindMode) {
 
@@ -129,7 +132,7 @@ namespace Fluxzy.Core
 
                     return
                         new (false, new ExchangeSourceInitResult(
-                            new Http11DownStreamPipe(_idProvider, authority, stream, stream, _contextBuilder), 
+                            new Http11DownStreamPipe(_idProvider, authority, stream, stream, contextBuilder),
                             provisionalExchange));
                 }
 
@@ -155,7 +158,7 @@ namespace Fluxzy.Core
 
                 if (authenticateResult.NegotiatedApplicationProtocol == System.Net.Security.SslApplicationProtocol.Http2) {
                     var h2Pipe = new H2DownStreamPipe(_idProvider, authority,
-                        authenticateResult.InStream, authenticateResult.OutStream, _contextBuilder);
+                        authenticateResult.InStream, authenticateResult.OutStream, contextBuilder);
 
                     using var rsBuffer = RsBuffer.Allocate(1024);
                     await h2Pipe.Init(rsBuffer);
@@ -163,7 +166,7 @@ namespace Fluxzy.Core
                 }
                 else {
                     downStreamPipe = new Http11DownStreamPipe(_idProvider, authority,
-                        authenticateResult.InStream, authenticateResult.OutStream, _contextBuilder);
+                        authenticateResult.InStream, authenticateResult.OutStream, contextBuilder);
                 }
 
                 return new(false, new ExchangeSourceInitResult(downStreamPipe, exchange));

--- a/src/Fluxzy.Core/Core/PinnedIpExchangeContextBuilder.cs
+++ b/src/Fluxzy.Core/Core/PinnedIpExchangeContextBuilder.cs
@@ -1,0 +1,33 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Core
+{
+    /// <summary>
+    ///     Decorates an exchange context builder so every context created for a connection keeps
+    ///     targeting the IP the client originally connected to (SNI host recovery). The pin applies
+    ///     only when no rule already forced a remote IP.
+    /// </summary>
+    internal sealed class PinnedIpExchangeContextBuilder : IExchangeContextBuilder
+    {
+        private readonly IExchangeContextBuilder _inner;
+        private readonly IPAddress _pinnedIp;
+
+        public PinnedIpExchangeContextBuilder(IExchangeContextBuilder inner, IPAddress pinnedIp)
+        {
+            _inner = inner;
+            _pinnedIp = pinnedIp;
+        }
+
+        public async ValueTask<ExchangeContext> Create(Authority authority, bool secure)
+        {
+            var context = await _inner.Create(authority, secure).ConfigureAwait(false);
+
+            context.RemoteHostIp ??= _pinnedIp;
+
+            return context;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Core/ProtocolDetectingSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/ProtocolDetectingSourceProvider.cs
@@ -27,21 +27,24 @@ namespace Fluxzy.Core
             IIdProvider idProvider,
             ProxyAuthenticationMethod proxyAuthenticationMethod,
             IExchangeContextBuilder contextBuilder,
-            IDnsSolver dnsSolver)
+            IDnsSolver dnsSolver,
+            bool recoverHostNameFromSni = false)
             : base(idProvider)
         {
             _httpProvider = new FromProxyConnectSourceProvider(
                 secureConnectionUpdater,
                 idProvider,
                 proxyAuthenticationMethod,
-                contextBuilder);
+                contextBuilder,
+                recoverHostNameFromSni);
 
             _socks5Provider = new Socks5SourceProvider(
                 secureConnectionUpdater,
                 idProvider,
                 proxyAuthenticationMethod,
                 contextBuilder,
-                dnsSolver);
+                dnsSolver,
+                recoverHostNameFromSni);
         }
 
         public override async ValueTask<ExchangeSourceInitResult?> InitClientConnection(

--- a/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
+++ b/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
+using Fluxzy.Clients.Ssl;
 using Fluxzy.Misc.ResizableBuffers;
 
 namespace Fluxzy.Core.Socks5
@@ -142,6 +143,22 @@ namespace Fluxzy.Core.Socks5
 
             // 10. Create synthetic header for the SOCKS5 connection
             var syntheticHeaderText = CreateSyntheticConnectHeader(request);
+
+            // When the SOCKS target is an IP, recover the host from the TLS SNI and pin the IP so the
+            // upstream still targets it. Peeked bytes are replayed, so the handshake/tunnel is intact.
+            if (exchangeContext.FluxzySetting?.RecoverHostNameFromSni == true
+                && IPAddress.TryParse(request.DestinationAddress, out var targetIp))
+            {
+                var recovery = await TlsClientHelloParser.RecoverAsync(stream, token).ConfigureAwait(false);
+                stream = recovery.RecomposedStream;
+
+                if (recovery.SniHost is { } sniHost)
+                {
+                    exchangeContext.RemoteHostIp = targetIp;
+                    authority = new Authority(sniHost, authority.Port, authority.Secure);
+                    exchangeContext.Authority = authority;
+                }
+            }
 
             // 11. Handle blind mode (no decryption)
             if (exchangeContext.BlindMode)

--- a/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
+++ b/src/Fluxzy.Core/Core/Socks5/Socks5SourceProvider.cs
@@ -22,13 +22,15 @@ namespace Fluxzy.Core.Socks5
         private readonly Socks5AuthenticationAdapter _authAdapter;
         private readonly IExchangeContextBuilder _contextBuilder;
         private readonly IDnsSolver _dnsSolver;
+        private readonly bool _recoverHostNameFromSni;
 
         public Socks5SourceProvider(
             SecureConnectionUpdater secureConnectionUpdater,
             IIdProvider idProvider,
             ProxyAuthenticationMethod proxyAuthenticationMethod,
             IExchangeContextBuilder contextBuilder,
-            IDnsSolver dnsSolver)
+            IDnsSolver dnsSolver,
+            bool recoverHostNameFromSni = false)
             : base(idProvider)
         {
             _secureConnectionUpdater = secureConnectionUpdater;
@@ -36,6 +38,7 @@ namespace Fluxzy.Core.Socks5
             _authAdapter = new Socks5AuthenticationAdapter(proxyAuthenticationMethod);
             _contextBuilder = contextBuilder;
             _dnsSolver = dnsSolver;
+            _recoverHostNameFromSni = recoverHostNameFromSni;
         }
 
         public override async ValueTask<ExchangeSourceInitResult?> InitClientConnection(
@@ -108,10 +111,7 @@ namespace Fluxzy.Core.Socks5
             // 7. Create authority from the request
             var authority = new Authority(request.DestinationAddress, request.DestinationPort, true);
 
-            // 8. Create exchange context
-            var exchangeContext = await _contextBuilder.Create(authority, true).ConfigureAwait(false);
-
-            // 9. Send success reply before establishing the tunnel
+            // 8. Send success reply before establishing the tunnel
             // Some SOCKS5 clients don't support domain name replies, so resolve to IP if needed
             var replyAddressType = request.AddressType;
             var replyRawAddress = request.RawAddress;
@@ -141,26 +141,31 @@ namespace Fluxzy.Core.Socks5
                 workBuffer,
                 token).ConfigureAwait(false);
 
-            // 10. Create synthetic header for the SOCKS5 connection
-            var syntheticHeaderText = CreateSyntheticConnectHeader(request);
+            // 9. When the SOCKS target is an IP, recover the host from the TLS SNI before the exchange
+            // context exists, so authority-scope rules see the recovered host. The original IP is pinned
+            // on every context created for this connection (unless a rule forces another one), keeping
+            // the upstream off the resolver. Peeked bytes are replayed, so the handshake/tunnel is intact.
+            var contextBuilder = _contextBuilder;
 
-            // When the SOCKS target is an IP, recover the host from the TLS SNI and pin the IP so the
-            // upstream still targets it. Peeked bytes are replayed, so the handshake/tunnel is intact.
-            if (exchangeContext.FluxzySetting?.RecoverHostNameFromSni == true
-                && IPAddress.TryParse(request.DestinationAddress, out var targetIp))
+            if (_recoverHostNameFromSni && IPAddress.TryParse(request.DestinationAddress, out var targetIp))
             {
                 var recovery = await TlsClientHelloParser.RecoverAsync(stream, token).ConfigureAwait(false);
                 stream = recovery.RecomposedStream;
 
                 if (recovery.SniHost is { } sniHost)
                 {
-                    exchangeContext.RemoteHostIp = targetIp;
                     authority = new Authority(sniHost, authority.Port, authority.Secure);
-                    exchangeContext.Authority = authority;
+                    contextBuilder = new PinnedIpExchangeContextBuilder(_contextBuilder, targetIp);
                 }
             }
 
-            // 11. Handle blind mode (no decryption)
+            // 10. Create exchange context
+            var exchangeContext = await contextBuilder.Create(authority, true).ConfigureAwait(false);
+
+            // 11. Create synthetic header for the SOCKS5 connection
+            var syntheticHeaderText = CreateSyntheticConnectHeader(request);
+
+            // 12. Handle blind mode (no decryption)
             if (exchangeContext.BlindMode)
             {
                 var blindExchange = Exchange.CreateUntrackedExchange(
@@ -178,11 +183,11 @@ namespace Fluxzy.Core.Socks5
                 blindExchange.Unprocessed = false;
 
                 return new ExchangeSourceInitResult(
-                    new Http11DownStreamPipe(_idProvider, authority, stream, stream, _contextBuilder),
+                    new Http11DownStreamPipe(_idProvider, authority, stream, stream, contextBuilder),
                     blindExchange);
             }
 
-            // 12. Perform TLS upgrade if not blind mode
+            // 13. Perform TLS upgrade if not blind mode
             var certStart = ITimingProvider.Default.Instant();
             var authenticateResult = await _secureConnectionUpdater.AuthenticateAsServer(
                 stream, authority.HostName, exchangeContext, token).ConfigureAwait(false);
@@ -210,7 +215,7 @@ namespace Fluxzy.Core.Socks5
             if (authenticateResult.NegotiatedApplicationProtocol == System.Net.Security.SslApplicationProtocol.Http2) {
                 var h2Pipe = new H2DownStreamPipe(
                     _idProvider, authority,
-                    authenticateResult.InStream, authenticateResult.OutStream, _contextBuilder);
+                    authenticateResult.InStream, authenticateResult.OutStream, contextBuilder);
 
                 using var rsBuffer = RsBuffer.Allocate(1024);
                 await h2Pipe.Init(rsBuffer);
@@ -219,7 +224,7 @@ namespace Fluxzy.Core.Socks5
             else {
                 downStreamPipe = new Http11DownStreamPipe(
                     _idProvider, authority,
-                    authenticateResult.InStream, authenticateResult.OutStream, _contextBuilder);
+                    authenticateResult.InStream, authenticateResult.OutStream, contextBuilder);
             }
 
             return new ExchangeSourceInitResult(downStreamPipe, exchange);

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -531,6 +531,18 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Enable reading the host name from the TLS SNI when the connect target is an IP (the IP is
+        ///     pinned for the upstream connection). Default false.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public FluxzySetting SetRecoverHostNameFromSni(bool value)
+        {
+            RecoverHostNameFromSni = value;
+            return this;
+        }
+
+        /// <summary>
         ///     When set to true, the server certificate will be exported as PEM in the SSL connection information.
         ///     This is useful for diagnostics or auditing purposes.
         /// </summary>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -224,6 +224,14 @@ namespace Fluxzy
         public bool ServeH2 { get; internal set; }
 
         /// <summary>
+        ///     When the connection target is an IP, read the host name from the client's TLS SNI and use
+        ///     it for the certificate, the recorded authority and the upstream SNI, pinning the original
+        ///     IP (no extra DNS). Falls back to the IP when no usable SNI is present. Default false.
+        /// </summary>
+        [JsonInclude]
+        public bool RecoverHostNameFromSni { get; internal set; }
+
+        /// <summary>
         ///     When set to true, the server certificate will be exported as PEM in the SSL connection information.
         ///     This is useful for diagnostics or auditing purposes.
         /// </summary>

--- a/src/Fluxzy/Commands/StartCommandBuilder.cs
+++ b/src/Fluxzy/Commands/StartCommandBuilder.cs
@@ -92,6 +92,7 @@ namespace Fluxzy.Cli.Commands
             command.AddOption(StartCommandOptions.CreatePrettyOutputOption());
             command.AddOption(StartCommandOptions.CreatePrettyMaxRowsOption());
             command.AddOption(StartCommandOptions.CreateServeH2Option());
+            command.AddOption(StartCommandOptions.CreateRecoverHostNameFromSniOption());
             command.AddOption(StartCommandOptions.CreateEnableDiscoveryOption());
             command.AddOption(StartCommandOptions.CreateProtoDirectoryOption());
             command.AddOption(StartCommandOptions.CreateTraceOption());
@@ -136,6 +137,7 @@ namespace Fluxzy.Cli.Commands
             var prettyOutput = invocationContext.Value<bool>("pretty");
             var prettyMaxRows = invocationContext.Value<int>("pretty-max-rows");
             var serveH2 = invocationContext.Value<bool>("serve-h2");
+            var recoverHostNameFromSni = invocationContext.Value<bool>("recover-host-from-sni");
             var enableDiscovery = invocationContext.Value<bool>("enable-discovery");
             var protoDirectories = invocationContext.Value<List<string>>("proto-dir");
             var traceMode = invocationContext.Value<TraceMode>("trace");
@@ -294,6 +296,7 @@ namespace Fluxzy.Cli.Commands
             proxyStartUpSetting.SetEnableProcessTracking(enableProcessTracking);
             proxyStartUpSetting.SetIncludeAndroidEmulatorHost(!noAndroidEmulator);
             proxyStartUpSetting.SetServeH2(serveH2);
+            proxyStartUpSetting.SetRecoverHostNameFromSni(recoverHostNameFromSni);
             proxyStartUpSetting.SetEnableDiscoveryService(enableDiscovery);
             proxyStartUpSetting.SetSkipInternalRules(skipInternalRules);
 

--- a/src/Fluxzy/Commands/StartCommandOptions.cs
+++ b/src/Fluxzy/Commands/StartCommandOptions.cs
@@ -476,6 +476,21 @@ namespace Fluxzy.Cli.Commands
             return option;
         }
 
+        public static Option CreateRecoverHostNameFromSniOption()
+        {
+            var option = new Option<bool>(
+                "--recover-host-from-sni",
+                "When the connection target is an IP address (typically full-system or SOCKS5 " +
+                "capture), read the host name from the TLS SNI and use it to name the generated " +
+                "certificate, the recorded host and the upstream SNI. The original IP is kept for " +
+                "the upstream connection, so no extra DNS resolution is performed.");
+
+            option.SetDefaultValue(false);
+            option.Arity = ArgumentArity.Zero;
+
+            return option;
+        }
+
         public static Option CreateProtoDirectoryOption()
         {
             var option = new Option<List<string>>(

--- a/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -21,7 +22,8 @@ namespace Fluxzy.Tests.UnitTests.Core
 {
     /// <summary>
     ///     Provider-level coverage of RecoverHostNameFromSni: authority rewrite + IP pin over SOCKS5,
-    ///     transparent CONNECT and blind tunnel, and that the pinned IP keeps upstream off the resolver.
+    ///     transparent CONNECT and blind tunnel, and that the pinned IP keeps upstream off the resolver
+    ///     for the provisional exchange and every per-request exchange after it.
     /// </summary>
     public class SniHostRecoveryProviderTests
     {
@@ -31,11 +33,11 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Socks5_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
         {
-            var (result, _) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: true, blindMode: false,
                 target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
 
             Assert.Equal("example.com", exchange.Authority.HostName);
             Assert.Equal(TargetPort, exchange.Authority.Port);
@@ -46,11 +48,11 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Socks5_IpTarget_WithoutUsableSni_KeepsIpAuthorityAndDoesNotPin()
         {
-            var (result, _) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: true, blindMode: false,
                 target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake(TargetIp.ToString()));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
 
             Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
             Assert.Null(exchange.Context.RemoteHostIp);
@@ -59,11 +61,11 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Socks5_HostnameTarget_IsNeverRewritten()
         {
-            var (result, _) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: true, blindMode: false,
                 target: DomainConnectRequest("example.org", TargetPort), TlsHandshake("example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
 
             Assert.Equal("example.org", exchange.Authority.HostName);
             Assert.Null(exchange.Context.RemoteHostIp);
@@ -72,11 +74,11 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Connect_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
         {
-            var (result, _) = await RunConnect(
+            var run = await RunConnect(
                 recoverHostNameFromSni: true, connectTarget: $"{TargetIp}:{TargetPort}",
                 TlsHandshake("example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
 
             Assert.Equal("example.com", exchange.Authority.HostName);
             Assert.Equal(TargetPort, exchange.Authority.Port);
@@ -88,11 +90,11 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Socks5_BlindMode_IpTarget_RecordsHostnameAndPinsIp()
         {
-            var (result, _) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: true, blindMode: true,
                 target: Ipv4ConnectRequest(TargetIp, TargetPort), RawClientHello("blind.example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
 
             Assert.Equal("blind.example.com", exchange.Authority.HostName);
             Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
@@ -101,38 +103,90 @@ namespace Fluxzy.Tests.UnitTests.Core
         [Fact]
         public async Task Recovery_PinnedIp_KeepsUpstreamOffTheDnsResolver()
         {
-            var (result, dns) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: true, blindMode: false,
                 target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
             Assert.Equal("example.com", exchange.Authority.HostName);
             Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
 
             var resolution = await DnsUtility.ComputeDnsUpdateExchange(
-                exchange, ITimingProvider.Default, dns, null);
+                exchange, ITimingProvider.Default, run.Dns, null);
 
             Assert.Equal(TargetIp, resolution.EndPoint.Address);
             Assert.Equal(TargetPort, resolution.EndPoint.Port);
-            Assert.Empty(dns.Queries);
+            Assert.Empty(run.Dns.Queries);
         }
 
         [Fact]
         public async Task WithoutRecovery_UpstreamGoesThroughTheDnsResolver()
         {
-            var (result, dns) = await RunSocks5(
+            var run = await RunSocks5(
                 recoverHostNameFromSni: false, blindMode: false,
                 target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
 
-            var exchange = AssertResult(result);
+            var exchange = AssertResult(run.Result);
             Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
             Assert.Null(exchange.Context.RemoteHostIp);
 
             var resolution = await DnsUtility.ComputeDnsUpdateExchange(
-                exchange, ITimingProvider.Default, dns, null);
+                exchange, ITimingProvider.Default, run.Dns, null);
 
-            Assert.Equal(dns.Answer, resolution.EndPoint.Address);
-            Assert.Contains(TargetIp.ToString(), dns.Queries);
+            Assert.Equal(run.Dns.Answer, resolution.EndPoint.Address);
+            Assert.Contains(TargetIp.ToString(), run.Dns.Queries);
+        }
+
+        // The provisional CONNECT exchange never drives an upstream connection; the pin matters on the
+        // per-request exchanges produced by the downstream pipe after the TLS upgrade.
+        [Fact]
+        public async Task Socks5_PerRequestExchange_KeepsRecoveredHostAndIpPin()
+        {
+            var run = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort),
+                TlsHandshakeThenRequest("example.com"),
+                readNextExchange: true);
+
+            Assert.NotNull(run.NextExchange);
+            Assert.Equal("example.com", run.NextExchange!.Authority.HostName);
+            Assert.Equal(TargetIp, run.NextExchange.Context.RemoteHostIp);
+
+            var resolution = await DnsUtility.ComputeDnsUpdateExchange(
+                run.NextExchange, ITimingProvider.Default, run.Dns, null);
+
+            Assert.Equal(TargetIp, resolution.EndPoint.Address);
+            Assert.Empty(run.Dns.Queries);
+        }
+
+        // The exchange context must be built with the recovered authority, so rules evaluated at
+        // OnAuthorityReceived scope (blind mode, skip decryption...) match the host, not the IP.
+        [Fact]
+        public async Task Recovery_AuthorityScopeRules_SeeTheRecoveredHost()
+        {
+            var run = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
+
+            var authority = Assert.Single(run.ContextBuilder.SeenAuthorities);
+            Assert.Equal("example.com", authority.HostName);
+        }
+
+        // A rule that forces a remote IP at authority scope (e.g. SpoofDnsAction) wins over the pin.
+        [Fact]
+        public async Task Recovery_RuleForcedRemoteIp_IsNotOverriddenByThePin()
+        {
+            var ruleIp = IPAddress.Parse("5.6.7.8");
+
+            var run = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"),
+                ruleForcedRemoteIp: ruleIp);
+
+            var exchange = AssertResult(run.Result);
+
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(ruleIp, exchange.Context.RemoteHostIp);
         }
 
         private static Exchange AssertResult(ExchangeSourceInitResult? result)
@@ -151,6 +205,21 @@ namespace Fluxzy.Tests.UnitTests.Core
             };
         }
 
+        // Handshake, then send a request so the pipe can produce a per-request exchange.
+        private static Func<Stream, CancellationToken, Task<IDisposable?>> TlsHandshakeThenRequest(string targetHost)
+        {
+            return async (clientStream, token) => {
+                var ssl = new SslStream(clientStream, false, (_, _, _, _) => true);
+                await ssl.AuthenticateAsClientAsync(targetHost);
+
+                var request = Encoding.ASCII.GetBytes($"GET / HTTP/1.1\r\nHost: {targetHost}\r\n\r\n");
+                await ssl.WriteAsync(request, token);
+                await ssl.FlushAsync(token);
+
+                return ssl;
+            };
+        }
+
         // Just emit a ClientHello carrying the SNI (blind path: the proxy only sniffs and tunnels).
         private static Func<Stream, CancellationToken, Task<IDisposable?>> RawClientHello(string serverName)
         {
@@ -160,46 +229,49 @@ namespace Fluxzy.Tests.UnitTests.Core
             };
         }
 
-        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunSocks5(
+        private static async Task<RunResult> RunSocks5(
             bool recoverHostNameFromSni, bool blindMode, byte[] target,
-            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction,
+            bool readNextExchange = false, IPAddress? ruleForcedRemoteIp = null)
         {
             return await RunProvider(recoverHostNameFromSni, blindMode,
                 (updater, idProvider, contextBuilder, dnsSolver) =>
                     new Socks5SourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
-                        contextBuilder, dnsSolver),
+                        contextBuilder, dnsSolver, recoverHostNameFromSni),
                 async (clientStream, token) => {
                     await clientStream.WriteAsync(new byte[] { 0x05, 0x01, 0x00 }, token);
                     await clientStream.ReadExactlyAsync(new byte[2], token); // method selection
                     await clientStream.WriteAsync(target, token);
                     await clientStream.ReadExactlyAsync(new byte[10], token); // IPv4 reply
                 },
-                clientTlsAction);
+                clientTlsAction, readNextExchange, ruleForcedRemoteIp);
         }
 
-        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunConnect(
+        private static async Task<RunResult> RunConnect(
             bool recoverHostNameFromSni, string connectTarget,
-            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction,
+            bool readNextExchange = false, IPAddress? ruleForcedRemoteIp = null)
         {
             return await RunProvider(recoverHostNameFromSni, blindMode: false,
                 (updater, idProvider, contextBuilder, _) =>
                     new FromProxyConnectSourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
-                        contextBuilder),
+                        contextBuilder, recoverHostNameFromSni),
                 async (clientStream, token) => {
                     var connect = Encoding.ASCII.GetBytes(
                         $"CONNECT {connectTarget} HTTP/1.1\r\nHost: {connectTarget}\r\n\r\n");
                     await clientStream.WriteAsync(connect, token);
                     await ReadUntilDoubleCrlf(clientStream, token);
                 },
-                clientTlsAction);
+                clientTlsAction, readNextExchange, ruleForcedRemoteIp);
         }
 
-        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunProvider(
+        private static async Task<RunResult> RunProvider(
             bool recoverHostNameFromSni, bool blindMode,
             Func<SecureConnectionUpdater, IIdProvider, IExchangeContextBuilder, IDnsSolver, ExchangeSourceProvider>
                 providerFactory,
             Func<Stream, CancellationToken, Task> preTlsClientDriver,
-            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction,
+            bool readNextExchange = false, IPAddress? ruleForcedRemoteIp = null)
         {
             var root = Certificate.UseDefault();
             using var certProvider = new CertificateProvider(root, new InMemoryCertificateCache());
@@ -207,8 +279,12 @@ namespace Fluxzy.Tests.UnitTests.Core
 
             var updater = new SecureConnectionUpdater(certProvider, serveH2: false);
             var dns = new SpyDnsSolver(IPAddress.Parse("9.9.9.9"));
-            var provider = providerFactory(updater, new FromIndexIdProvider(0, 0),
-                new TestExchangeContextBuilder(setting, blindMode), dns);
+
+            var contextBuilder = new TestExchangeContextBuilder(setting, blindMode) {
+                RuleForcedRemoteHostIp = ruleForcedRemoteIp
+            };
+
+            var provider = providerFactory(updater, new FromIndexIdProvider(0, 0), contextBuilder, dns);
 
             using var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -220,11 +296,22 @@ namespace Fluxzy.Tests.UnitTests.Core
                 using var serverConnection = await listener.AcceptTcpClientAsync(cts.Token);
                 using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(1024 * 8);
 
-                return await provider.InitClientConnection(
+                var initResult = await provider.InitClientConnection(
                     serverConnection.GetStream(), buffer,
                     (IPEndPoint) serverConnection.Client.LocalEndPoint!,
                     (IPEndPoint) serverConnection.Client.RemoteEndPoint!,
                     cts.Token);
+
+                Exchange? nextExchange = null;
+
+                if (readNextExchange && initResult != null) {
+                    using var exchangeScope = new ExchangeScope();
+
+                    nextExchange = await initResult.DownStreamPipe
+                                                   .ReadNextExchange(buffer, exchangeScope, cts.Token);
+                }
+
+                return (InitResult: initResult, NextExchange: nextExchange);
             });
 
             using var client = new TcpClient();
@@ -242,10 +329,10 @@ namespace Fluxzy.Tests.UnitTests.Core
                 clientError = ex;
             }
 
-            ExchangeSourceInitResult? result;
+            (ExchangeSourceInitResult? InitResult, Exchange? NextExchange) serverOutcome;
 
             try {
-                result = await serverTask;
+                serverOutcome = await serverTask;
             }
             catch (Exception serverEx) {
                 throw new Xunit.Sdk.XunitException(
@@ -259,7 +346,7 @@ namespace Fluxzy.Tests.UnitTests.Core
             if (clientError != null)
                 throw clientError;
 
-            return (result, dns);
+            return new RunResult(serverOutcome.InitResult, dns, contextBuilder, serverOutcome.NextExchange);
         }
 
         private static byte[] Ipv4ConnectRequest(IPAddress ip, int port)
@@ -300,6 +387,12 @@ namespace Fluxzy.Tests.UnitTests.Core
             }
         }
 
+        private sealed record RunResult(
+            ExchangeSourceInitResult? Result,
+            SpyDnsSolver Dns,
+            TestExchangeContextBuilder ContextBuilder,
+            Exchange? NextExchange);
+
         private sealed class TestExchangeContextBuilder : IExchangeContextBuilder
         {
             private readonly FluxzySetting _setting;
@@ -312,12 +405,21 @@ namespace Fluxzy.Tests.UnitTests.Core
                 _blindMode = blindMode;
             }
 
+            /// <summary>Authorities passed to Create, i.e. what authority-scope rules would see.</summary>
+            public List<Authority> SeenAuthorities { get; } = new();
+
+            /// <summary>Simulates a rule forcing a remote IP at OnAuthorityReceived scope.</summary>
+            public IPAddress? RuleForcedRemoteHostIp { get; init; }
+
             public ValueTask<ExchangeContext> Create(Authority authority, bool secure)
             {
+                SeenAuthorities.Add(authority);
+
                 return new ValueTask<ExchangeContext>(
                     new ExchangeContext(authority, _variableContext, _setting, null!) {
                         Secure = secure,
-                        BlindMode = _blindMode
+                        BlindMode = _blindMode,
+                        RemoteHostIp = RuleForcedRemoteHostIp
                     });
             }
         }
@@ -331,7 +433,7 @@ namespace Fluxzy.Tests.UnitTests.Core
 
             public IPAddress Answer { get; }
 
-            public System.Collections.Generic.List<string> Queries { get; } = new();
+            public List<string> Queries { get; } = new();
 
             public Task<IPAddress> SolveDns(string hostName)
             {

--- a/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/SniHostRecoveryProviderTests.cs
@@ -1,0 +1,343 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Certificates;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Core.Socks5;
+using Fluxzy.Rules;
+using Fluxzy.Tests.UnitTests.Ssl;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    /// <summary>
+    ///     Provider-level coverage of RecoverHostNameFromSni: authority rewrite + IP pin over SOCKS5,
+    ///     transparent CONNECT and blind tunnel, and that the pinned IP keeps upstream off the resolver.
+    /// </summary>
+    public class SniHostRecoveryProviderTests
+    {
+        private static readonly IPAddress TargetIp = IPAddress.Parse("1.2.3.4");
+        private const int TargetPort = 443;
+
+        [Fact]
+        public async Task Socks5_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetPort, exchange.Authority.Port);
+            Assert.True(exchange.Authority.Secure);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+        }
+
+        [Fact]
+        public async Task Socks5_IpTarget_WithoutUsableSni_KeepsIpAuthorityAndDoesNotPin()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake(TargetIp.ToString()));
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+        }
+
+        [Fact]
+        public async Task Socks5_HostnameTarget_IsNeverRewritten()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: DomainConnectRequest("example.org", TargetPort), TlsHandshake("example.com"));
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.org", exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+        }
+
+        [Fact]
+        public async Task Connect_IpTarget_WithHostnameSni_RewritesAuthorityAndPinsIp()
+        {
+            var (result, _) = await RunConnect(
+                recoverHostNameFromSni: true, connectTarget: $"{TargetIp}:{TargetPort}",
+                TlsHandshake("example.com"));
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetPort, exchange.Authority.Port);
+            Assert.True(exchange.Authority.Secure);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+        }
+
+        // Blind tunnel: never decrypted, but the sniffed SNI still names the authority and pins the IP.
+        [Fact]
+        public async Task Socks5_BlindMode_IpTarget_RecordsHostnameAndPinsIp()
+        {
+            var (result, _) = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: true,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), RawClientHello("blind.example.com"));
+
+            var exchange = AssertResult(result);
+
+            Assert.Equal("blind.example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+        }
+
+        [Fact]
+        public async Task Recovery_PinnedIp_KeepsUpstreamOffTheDnsResolver()
+        {
+            var (result, dns) = await RunSocks5(
+                recoverHostNameFromSni: true, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
+
+            var exchange = AssertResult(result);
+            Assert.Equal("example.com", exchange.Authority.HostName);
+            Assert.Equal(TargetIp, exchange.Context.RemoteHostIp);
+
+            var resolution = await DnsUtility.ComputeDnsUpdateExchange(
+                exchange, ITimingProvider.Default, dns, null);
+
+            Assert.Equal(TargetIp, resolution.EndPoint.Address);
+            Assert.Equal(TargetPort, resolution.EndPoint.Port);
+            Assert.Empty(dns.Queries);
+        }
+
+        [Fact]
+        public async Task WithoutRecovery_UpstreamGoesThroughTheDnsResolver()
+        {
+            var (result, dns) = await RunSocks5(
+                recoverHostNameFromSni: false, blindMode: false,
+                target: Ipv4ConnectRequest(TargetIp, TargetPort), TlsHandshake("example.com"));
+
+            var exchange = AssertResult(result);
+            Assert.Equal(TargetIp.ToString(), exchange.Authority.HostName);
+            Assert.Null(exchange.Context.RemoteHostIp);
+
+            var resolution = await DnsUtility.ComputeDnsUpdateExchange(
+                exchange, ITimingProvider.Default, dns, null);
+
+            Assert.Equal(dns.Answer, resolution.EndPoint.Address);
+            Assert.Contains(TargetIp.ToString(), dns.Queries);
+        }
+
+        private static Exchange AssertResult(ExchangeSourceInitResult? result)
+        {
+            Assert.NotNull(result);
+            return result!.ProvisionalExchange;
+        }
+
+        // Complete a real TLS handshake against the proxy with the given SNI.
+        private static Func<Stream, CancellationToken, Task<IDisposable?>> TlsHandshake(string targetHost)
+        {
+            return async (clientStream, _) => {
+                var ssl = new SslStream(clientStream, false, (_, _, _, _) => true);
+                await ssl.AuthenticateAsClientAsync(targetHost);
+                return ssl; // kept alive until the server side produced its result
+            };
+        }
+
+        // Just emit a ClientHello carrying the SNI (blind path: the proxy only sniffs and tunnels).
+        private static Func<Stream, CancellationToken, Task<IDisposable?>> RawClientHello(string serverName)
+        {
+            return async (clientStream, token) => {
+                await clientStream.WriteAsync(TlsClientHelloParserTests.BuildClientHello(serverName), token);
+                return null;
+            };
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunSocks5(
+            bool recoverHostNameFromSni, bool blindMode, byte[] target,
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+        {
+            return await RunProvider(recoverHostNameFromSni, blindMode,
+                (updater, idProvider, contextBuilder, dnsSolver) =>
+                    new Socks5SourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
+                        contextBuilder, dnsSolver),
+                async (clientStream, token) => {
+                    await clientStream.WriteAsync(new byte[] { 0x05, 0x01, 0x00 }, token);
+                    await clientStream.ReadExactlyAsync(new byte[2], token); // method selection
+                    await clientStream.WriteAsync(target, token);
+                    await clientStream.ReadExactlyAsync(new byte[10], token); // IPv4 reply
+                },
+                clientTlsAction);
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunConnect(
+            bool recoverHostNameFromSni, string connectTarget,
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+        {
+            return await RunProvider(recoverHostNameFromSni, blindMode: false,
+                (updater, idProvider, contextBuilder, _) =>
+                    new FromProxyConnectSourceProvider(updater, idProvider, NoAuthenticationMethod.Instance,
+                        contextBuilder),
+                async (clientStream, token) => {
+                    var connect = Encoding.ASCII.GetBytes(
+                        $"CONNECT {connectTarget} HTTP/1.1\r\nHost: {connectTarget}\r\n\r\n");
+                    await clientStream.WriteAsync(connect, token);
+                    await ReadUntilDoubleCrlf(clientStream, token);
+                },
+                clientTlsAction);
+        }
+
+        private static async Task<(ExchangeSourceInitResult? Result, SpyDnsSolver Dns)> RunProvider(
+            bool recoverHostNameFromSni, bool blindMode,
+            Func<SecureConnectionUpdater, IIdProvider, IExchangeContextBuilder, IDnsSolver, ExchangeSourceProvider>
+                providerFactory,
+            Func<Stream, CancellationToken, Task> preTlsClientDriver,
+            Func<Stream, CancellationToken, Task<IDisposable?>> clientTlsAction)
+        {
+            var root = Certificate.UseDefault();
+            using var certProvider = new CertificateProvider(root, new InMemoryCertificateCache());
+            var setting = FluxzySetting.CreateLocalRandomPort().SetRecoverHostNameFromSni(recoverHostNameFromSni);
+
+            var updater = new SecureConnectionUpdater(certProvider, serveH2: false);
+            var dns = new SpyDnsSolver(IPAddress.Parse("9.9.9.9"));
+            var provider = providerFactory(updater, new FromIndexIdProvider(0, 0),
+                new TestExchangeContextBuilder(setting, blindMode), dns);
+
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            var serverTask = Task.Run(async () => {
+                using var serverConnection = await listener.AcceptTcpClientAsync(cts.Token);
+                using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(1024 * 8);
+
+                return await provider.InitClientConnection(
+                    serverConnection.GetStream(), buffer,
+                    (IPEndPoint) serverConnection.Client.LocalEndPoint!,
+                    (IPEndPoint) serverConnection.Client.RemoteEndPoint!,
+                    cts.Token);
+            });
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, port);
+            var clientStream = client.GetStream();
+
+            IDisposable? keepAlive = null;
+            Exception? clientError = null;
+
+            try {
+                await preTlsClientDriver(clientStream, cts.Token);
+                keepAlive = await clientTlsAction(clientStream, cts.Token);
+            }
+            catch (Exception ex) {
+                clientError = ex;
+            }
+
+            ExchangeSourceInitResult? result;
+
+            try {
+                result = await serverTask;
+            }
+            catch (Exception serverEx) {
+                throw new Xunit.Sdk.XunitException(
+                    $"Server provider failed (client error: {clientError?.Message ?? "none"}): {serverEx}");
+            }
+            finally {
+                keepAlive?.Dispose();
+                listener.Stop();
+            }
+
+            if (clientError != null)
+                throw clientError;
+
+            return (result, dns);
+        }
+
+        private static byte[] Ipv4ConnectRequest(IPAddress ip, int port)
+        {
+            var request = new byte[] { 0x05, 0x01, 0x00, 0x01, 0, 0, 0, 0, 0, 0 };
+            ip.GetAddressBytes().CopyTo(request, 4);
+            BinaryPrimitives.WriteUInt16BigEndian(request.AsSpan(8), (ushort) port);
+            return request;
+        }
+
+        private static byte[] DomainConnectRequest(string domain, int port)
+        {
+            var domainBytes = Encoding.ASCII.GetBytes(domain);
+            var request = new byte[4 + 1 + domainBytes.Length + 2];
+            request[0] = 0x05;
+            request[1] = 0x01;
+            request[2] = 0x00;
+            request[3] = 0x03;
+            request[4] = (byte) domainBytes.Length;
+            domainBytes.CopyTo(request, 5);
+            BinaryPrimitives.WriteUInt16BigEndian(request.AsSpan(5 + domainBytes.Length), (ushort) port);
+            return request;
+        }
+
+        private static async Task ReadUntilDoubleCrlf(Stream stream, CancellationToken token)
+        {
+            var single = new byte[1];
+            var matched = 0;
+
+            while (matched < 4) {
+                var read = await stream.ReadAsync(single, token);
+
+                if (read == 0)
+                    throw new EndOfStreamException();
+
+                var expected = matched % 2 == 0 ? (byte) '\r' : (byte) '\n';
+                matched = single[0] == expected ? matched + 1 : single[0] == '\r' ? 1 : 0;
+            }
+        }
+
+        private sealed class TestExchangeContextBuilder : IExchangeContextBuilder
+        {
+            private readonly FluxzySetting _setting;
+            private readonly bool _blindMode;
+            private readonly VariableContext _variableContext = new();
+
+            public TestExchangeContextBuilder(FluxzySetting setting, bool blindMode)
+            {
+                _setting = setting;
+                _blindMode = blindMode;
+            }
+
+            public ValueTask<ExchangeContext> Create(Authority authority, bool secure)
+            {
+                return new ValueTask<ExchangeContext>(
+                    new ExchangeContext(authority, _variableContext, _setting, null!) {
+                        Secure = secure,
+                        BlindMode = _blindMode
+                    });
+            }
+        }
+
+        private sealed class SpyDnsSolver : IDnsSolver
+        {
+            public SpyDnsSolver(IPAddress answer)
+            {
+                Answer = answer;
+            }
+
+            public IPAddress Answer { get; }
+
+            public System.Collections.Generic.List<string> Queries { get; } = new();
+
+            public Task<IPAddress> SolveDns(string hostName)
+            {
+                Queries.Add(hostName);
+                return Task.FromResult(Answer);
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Ssl/TlsClientHelloParserTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Ssl/TlsClientHelloParserTests.cs
@@ -1,0 +1,370 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients.Ssl;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Ssl
+{
+    public class TlsClientHelloParserTests
+    {
+        // ----- TryReadServerName (pure record parsing) -----
+
+        [Fact]
+        public void TryReadServerName_WithSni_ReturnsHost()
+        {
+            Assert.True(TlsClientHelloParser.TryReadServerName(BuildClientHello("example.com"), out var host));
+            Assert.Equal("example.com", host);
+        }
+
+        [Fact]
+        public void TryReadServerName_NoSniExtension_ReturnsFalse()
+        {
+            Assert.False(TlsClientHelloParser.TryReadServerName(BuildClientHello(), out var host));
+            Assert.Null(host);
+        }
+
+        [Fact]
+        public void TryReadServerName_FirstHostNameEntryWins_WithMultipleNames()
+        {
+            Assert.True(TlsClientHelloParser.TryReadServerName(
+                BuildClientHello("first.example.com", "second.example.com"), out var host));
+            Assert.Equal("first.example.com", host);
+        }
+
+        [Fact]
+        public void TryReadServerName_SniAmongOtherExtensions_ReturnsHost()
+        {
+            // SNI is rarely the first extension on a real ClientHello.
+            var extensions = Concat(
+                Extension(0x002b, new byte[] { 0x02, 0x03, 0x04 }), // supported_versions (dummy payload)
+                SniExtension(HostNameEntry("late.example.com")),
+                Extension(0x000d, new byte[] { 0x01, 0x02 }));      // signature_algorithms (dummy payload)
+
+            var record = Record(0x01, ClientHelloBody(extensions));
+
+            Assert.True(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Equal("late.example.com", host);
+        }
+
+        [Fact]
+        public void TryReadServerName_NonHostNameEntrySkipped_ReturnsHostName()
+        {
+            var list = Concat(NameEntry(0x01, "ignored"), NameEntry(0x00, "real.example.com"));
+            var record = Record(0x01, ClientHelloBody(SniExtension(list)));
+
+            Assert.True(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Equal("real.example.com", host);
+        }
+
+        [Fact]
+        public void TryReadServerName_OnlyNonHostNameEntry_ReturnsFalse()
+        {
+            var record = Record(0x01, ClientHelloBody(SniExtension(NameEntry(0x01, "not-a-host"))));
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Null(host);
+        }
+
+        [Fact]
+        public void TryReadServerName_EmptyHostName_ReturnsFalse()
+        {
+            var record = Record(0x01, ClientHelloBody(SniExtension(NameEntry(0x00, ""))));
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Null(host);
+        }
+
+        [Fact]
+        public void TryReadServerName_ServerHelloMessageType_ReturnsFalse()
+        {
+            // 0x02 = ServerHello, not a ClientHello.
+            var record = Record(0x02, ClientHelloBody(SniExtension(HostNameEntry("example.com"))));
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Null(host);
+        }
+
+        [Fact]
+        public void TryReadServerName_IpLiteralSni_IsReturnedVerbatim()
+        {
+            // The parser does not judge the value; RecoverAsync is what discards IP literals.
+            Assert.True(TlsClientHelloParser.TryReadServerName(BuildClientHello("203.0.113.5"), out var host));
+            Assert.Equal("203.0.113.5", host);
+        }
+
+        [Fact]
+        public void TryReadServerName_CorruptServerNameListLength_ReturnsFalse()
+        {
+            // server_name_list claims 200 bytes but carries only one short entry.
+            var record = Record(0x01, ClientHelloBody(SniExtension(HostNameEntry("x.example.com"), declaredListLength: 200)));
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(record, out var host));
+            Assert.Null(host);
+        }
+
+        [Theory]
+        [InlineData(5)]
+        [InlineData(20)]
+        [InlineData(40)]
+        public void TryReadServerName_Truncated_ReturnsFalseWithoutThrowing(int keep)
+        {
+            var truncated = BuildClientHello("example.com").AsSpan(0, keep).ToArray();
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(truncated, out var host));
+            Assert.Null(host);
+        }
+
+        [Fact]
+        public void TryReadServerName_NotAHandshakeRecord_ReturnsFalse()
+        {
+            var applicationData = new byte[] { 0x17, 0x03, 0x03, 0x00, 0x05, 1, 2, 3, 4, 5 };
+
+            Assert.False(TlsClientHelloParser.TryReadServerName(applicationData, out var host));
+            Assert.Null(host);
+        }
+
+        // ----- PeekAsync (stream read + replay) -----
+
+        [Fact]
+        public async Task PeekAsync_ReplaysEveryByteAndExtractsSni()
+        {
+            var record = BuildClientHello("sni.example.com");
+            using var stream = new MemoryStream(record);
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, CancellationToken.None);
+
+            Assert.True(peek.IsTlsHandshake);
+            Assert.Equal("sni.example.com", peek.SniHost);
+            Assert.Equal(record, peek.ConsumedBytes.ToArray());
+        }
+
+        [Fact]
+        public async Task PeekAsync_NonTlsFirstByte_StopsImmediately()
+        {
+            using var stream = new MemoryStream(Encoding.ASCII.GetBytes("GET / HTTP/1.1\r\n\r\n"));
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, CancellationToken.None);
+
+            Assert.False(peek.IsTlsHandshake);
+            Assert.Null(peek.SniHost);
+            Assert.Equal(new[] { (byte) 'G' }, peek.ConsumedBytes.ToArray());
+        }
+
+        [Fact]
+        public async Task PeekAsync_EmptyStream_ReturnsNotTls()
+        {
+            using var stream = new MemoryStream(Array.Empty<byte>());
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, CancellationToken.None);
+
+            Assert.False(peek.IsTlsHandshake);
+            Assert.Null(peek.SniHost);
+            Assert.Empty(peek.ConsumedBytes.ToArray());
+        }
+
+        [Fact]
+        public async Task PeekAsync_CanceledToken_ReturnsGracefully()
+        {
+            using var stream = new MemoryStream(BuildClientHello("example.com"));
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, new CancellationToken(true));
+
+            Assert.Null(peek.SniHost);
+        }
+
+        [Fact]
+        public async Task PeekAsync_TruncatedPayload_ReplaysBytesReadWithoutSni()
+        {
+            // Keep the 5-byte header (with its full record length) but only a slice of the payload.
+            var record = BuildClientHello("example.com");
+            var truncated = record.AsSpan(0, 15).ToArray();
+            using var stream = new MemoryStream(truncated);
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, CancellationToken.None);
+
+            Assert.True(peek.IsTlsHandshake);
+            Assert.Null(peek.SniHost);
+            Assert.Equal(truncated, peek.ConsumedBytes.ToArray());
+        }
+
+        [Fact]
+        public async Task PeekAsync_ChunkedDelivery_ExtractsSni()
+        {
+            var record = BuildClientHello("chunked.example.com");
+            using var stream = new OneByteAtATimeStream(record);
+
+            var peek = await TlsClientHelloParser.PeekAsync(stream, CancellationToken.None);
+
+            Assert.Equal("chunked.example.com", peek.SniHost);
+            Assert.Equal(record, peek.ConsumedBytes.ToArray());
+        }
+
+        // ----- RecoverAsync (timeout + replay stream + IP-literal filter) -----
+
+        [Fact]
+        public async Task RecoverAsync_HostnameSni_ReturnsHostAndReplaysLosslessly()
+        {
+            var record = BuildClientHello("recover.example.com");
+            using var stream = new MemoryStream(record);
+
+            var recovery = await TlsClientHelloParser.RecoverAsync(stream, CancellationToken.None);
+
+            Assert.Equal("recover.example.com", recovery.SniHost);
+            Assert.Equal(record, await DrainAsync(recovery.RecomposedStream));
+        }
+
+        [Fact]
+        public async Task RecoverAsync_IpLiteralSni_ReturnsNullHostButStillReplays()
+        {
+            var record = BuildClientHello("198.51.100.7");
+            using var stream = new MemoryStream(record);
+
+            var recovery = await TlsClientHelloParser.RecoverAsync(stream, CancellationToken.None);
+
+            Assert.Null(recovery.SniHost);
+            Assert.Equal(record, await DrainAsync(recovery.RecomposedStream));
+        }
+
+        [Fact]
+        public async Task RecoverAsync_NoSni_ReturnsNullHost()
+        {
+            using var stream = new MemoryStream(BuildClientHello());
+
+            var recovery = await TlsClientHelloParser.RecoverAsync(stream, CancellationToken.None);
+
+            Assert.Null(recovery.SniHost);
+        }
+
+        // ----- builders -----
+
+        internal static byte[] BuildClientHello(params string?[] serverNames)
+        {
+            var hasSni = serverNames is { Length: > 0 } && serverNames[0] != null;
+
+            if (!hasSni)
+                return Record(0x01, ClientHelloBody(Array.Empty<byte>()));
+
+            var list = Concat(serverNames.Select(n => HostNameEntry(n!)).ToArray());
+
+            return Record(0x01, ClientHelloBody(SniExtension(list)));
+        }
+
+        private static byte[] Record(byte messageType, byte[] handshakeBody)
+        {
+            var handshake = new List<byte> { messageType };
+            handshake.AddRange(UInt24(handshakeBody.Length));
+            handshake.AddRange(handshakeBody);
+
+            var record = new List<byte> { 0x16, 0x03, 0x01 };
+            record.AddRange(UInt16(handshake.Count));
+            record.AddRange(handshake);
+
+            return record.ToArray();
+        }
+
+        private static byte[] ClientHelloBody(byte[] extensions)
+        {
+            var body = new List<byte>();
+            body.AddRange(new byte[] { 0x03, 0x03 });     // client_version
+            body.AddRange(new byte[32]);                  // random
+            body.Add(0x00);                               // session_id length
+            body.AddRange(UInt16(2));                     // cipher_suites length
+            body.AddRange(new byte[] { 0x13, 0x01 });     // one cipher suite
+            body.Add(0x01);                               // compression_methods length
+            body.Add(0x00);                               // null compression
+            body.AddRange(UInt16(extensions.Length));     // extensions length
+            body.AddRange(extensions);
+
+            return body.ToArray();
+        }
+
+        private static byte[] Extension(int type, byte[] data)
+        {
+            var extension = new List<byte>();
+            extension.AddRange(UInt16(type));
+            extension.AddRange(UInt16(data.Length));
+            extension.AddRange(data);
+
+            return extension.ToArray();
+        }
+
+        private static byte[] SniExtension(byte[] serverNameList, int? declaredListLength = null)
+        {
+            var data = new List<byte>();
+            data.AddRange(UInt16(declaredListLength ?? serverNameList.Length));
+            data.AddRange(serverNameList);
+
+            return Extension(0x0000, data.ToArray());
+        }
+
+        private static byte[] HostNameEntry(string name) => NameEntry(0x00, name);
+
+        private static byte[] NameEntry(byte nameType, string name)
+        {
+            var nameBytes = Encoding.ASCII.GetBytes(name);
+            var entry = new List<byte> { nameType };
+            entry.AddRange(UInt16(nameBytes.Length));
+            entry.AddRange(nameBytes);
+
+            return entry.ToArray();
+        }
+
+        private static byte[] Concat(params byte[][] parts) => parts.SelectMany(p => p).ToArray();
+
+        private static byte[] UInt16(int value) => new[] { (byte) (value >> 8), (byte) value };
+
+        private static byte[] UInt24(int value) => new[] { (byte) (value >> 16), (byte) (value >> 8), (byte) value };
+
+        private static async Task<byte[]> DrainAsync(Stream stream)
+        {
+            using var sink = new MemoryStream();
+            await stream.CopyToAsync(sink);
+            return sink.ToArray();
+        }
+
+        // Returns at most one byte per read to exercise the partial-read reassembly loop.
+        private sealed class OneByteAtATimeStream : Stream
+        {
+            private readonly byte[] _data;
+            private int _position;
+
+            public OneByteAtATimeStream(byte[] data) => _data = data;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => _position; set => throw new NotSupportedException(); }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (_position >= _data.Length || count == 0)
+                    return 0;
+
+                buffer[offset] = _data[_position++];
+                return 1;
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                if (_position >= _data.Length || buffer.Length == 0)
+                    return new ValueTask<int>(0);
+
+                buffer.Span[0] = _data[_position++];
+                return new ValueTask<int>(1);
+            }
+
+            public override void Flush() { }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
Under full-system / SOCKS5 capture the connect authority is often a raw IP: the certificate gets an IP CN and the recorded host is the IP, while the real name sits in the client's TLS ClientHello SNI.

With the opt-in `RecoverHostNameFromSni` setting (CLI `--recover-host-from-sni`, default off), both ingress providers (SOCKS5 and transparent CONNECT) peek the ClientHello when the target is an IP and adopt the SNI for the recorded authority, the certificate and the upstream SNI. The peek runs before the exchange context is built, so authority-scope rules match the host name, and the original IP is pinned on every exchange context of the connection, so upstream targets the same IP with no extra DNS (a rule-forced remote IP wins over the pin). Peeked bytes are replayed, keeping the handshake or blind tunnel byte-for-byte intact, and the parser never throws: no SNI, ECH or malformed input falls back to the IP authority. With the flag off the paths are unchanged.

Covered by `TlsClientHelloParserTests` and `SniHostRecoveryProviderTests` (parsing edge cases, replay integrity, rewrite + pin across providers, per-request exchanges and blind tunnels, rule precedence).
