### PR TITLE
Report real OS trust result on Linux certificate install

### DIFF
--- a/src/Fluxzy.Core/Certificates/DefaultCertificateAuthorityManager.cs
+++ b/src/Fluxzy.Core/Certificates/DefaultCertificateAuthorityManager.cs
@@ -27,20 +27,26 @@ namespace Fluxzy.Certificates
                 return ExtendedMacOsCertificateInstaller.IsCertificateInstalled(certificate, AttemptAskElevation);
             }
 
-            // TODO implementation for Linux should be here 
-            
-            using var store = new X509Store(StoreName.Root);
+            using var store = new X509Store(StoreName.Root, ResolveRootStoreLocation(RuntimeInformation.IsOSPlatform));
             store.Open(OpenFlags.ReadOnly);
             var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, certificate.Thumbprint, false);
             return certificates.Count > 0;
+        }
+
+        // On Linux CurrentUser\Root is private to .NET and invisible to the OS; the system bundle is LocalMachine\Root
+        internal static StoreLocation ResolveRootStoreLocation(Func<OSPlatform, bool> isOsPlatform)
+        {
+            return isOsPlatform(OSPlatform.Linux)
+                ? StoreLocation.LocalMachine
+                : StoreLocation.CurrentUser;
         }
 
         public override ValueTask<bool> RemoveCertificate(string thumbPrint)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                ExtendedLinuxCertificateInstaller.Uninstall(thumbPrint, AttemptAskElevation);
-                return new ValueTask<bool>(true); 
+                var removed = ExtendedLinuxCertificateInstaller.Uninstall(thumbPrint, AttemptAskElevation);
+                return new ValueTask<bool>(removed);
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
@@ -73,12 +79,13 @@ namespace Fluxzy.Certificates
         public override ValueTask<bool> InstallCertificate(X509Certificate2 certificate)
         {
             try {
+                // The per-user X509Store below is not the OS trust scope on Linux, so the system installer is authoritative
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                    ExtendedLinuxCertificateInstaller.Install(certificate, AttemptAskElevation);
+                    return new ValueTask<bool>(ExtendedLinuxCertificateInstaller.Install(certificate, AttemptAskElevation));
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     ExtendedMacOsCertificateInstaller.Install(certificate, AttemptAskElevation);
-                
+
                 using var newCertificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
                 using var store = new X509Store(StoreName.Root);
 
@@ -88,10 +95,10 @@ namespace Fluxzy.Certificates
                 }
                 catch (Exception) {
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                        throw; 
-                    // we ignore errors for macos and linux
+                        throw;
+                    // we ignore errors for macos
                 }
-                
+
                 return new ValueTask<bool>(true);
             }
             catch (Exception ex) {

--- a/src/Fluxzy.Core/Certificates/ExtendedLinuxCertificateInstaller.cs
+++ b/src/Fluxzy.Core/Certificates/ExtendedLinuxCertificateInstaller.cs
@@ -88,33 +88,51 @@ namespace Fluxzy.Certificates
         /// </summary>
         /// <param name="x509Certificate2"></param>
         /// <param name="askElevation"></param>
-        public static void Uninstall(X509Certificate2 x509Certificate2, bool askElevation)
+        public static bool Uninstall(X509Certificate2 x509Certificate2, bool askElevation)
         {
-            Uninstall(x509Certificate2.Thumbprint, askElevation);
+            return Uninstall(x509Certificate2.Thumbprint, askElevation);
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="thumbPrint"></param>
         /// <param name="askElevation"></param>
-        public static void Uninstall(string thumbPrint, bool askElevation)
+        public static bool Uninstall(string thumbPrint, bool askElevation)
         {
+            var anyDirectory = false;
+            var success = true;
+
             foreach (var installableCertificate in InstallableCertificates) {
+                if (!Directory.Exists(installableCertificate.Directory))
+                    continue;
+
+                anyDirectory = true;
+
                 var filePath = Path.Combine(installableCertificate.Directory,
                     $"fluxzy-{thumbPrint}.crt");
 
                 if (askElevation) {
-                    // run RM command 
+                    var rmResult = ProcessUtils.RunElevated("rm", new[] { "-f", $"{filePath}" }, false, "");
 
-                    ProcessUtils.RunElevated("rm", new[] {$"{filePath}"}, false, "");
-                    return;
+                    if (rmResult == null) {
+                        success = false;
+                        continue;
+                    }
+
+                    rmResult.WaitForExit();
+
+                    if (rmResult.ExitCode != 0)
+                        success = false;
+
+                    continue;
                 }
-
 
                 if (File.Exists(filePath))
                     File.Delete(filePath);
             }
+
+            return anyDirectory && success;
         }
     }
 }

--- a/src/Fluxzy/Commands/CertificateCommandBuilder.cs
+++ b/src/Fluxzy/Commands/CertificateCommandBuilder.cs
@@ -94,7 +94,12 @@ namespace Fluxzy.Cli.Commands
                     certificate = new X509Certificate2(await File.ReadAllBytesAsync(fileInfo.FullName));
                 }
 
-                await certificateManager.InstallCertificate(certificate);
+                var installed = await certificateManager.InstallCertificate(certificate);
+
+                if (!installed) {
+                    throw new Exception($"Failed to trust {certificate.SubjectName.Name}. The system trust store " +
+                                        "was not updated (insufficient privileges or cancelled elevation).");
+                }
             }, argumentFileInfo);
 
             return exportCommand;

--- a/test/Fluxzy.Tests/UnitTests/Certificates/CertificateManager.cs
+++ b/test/Fluxzy.Tests/UnitTests/Certificates/CertificateManager.cs
@@ -1,5 +1,6 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Fluxzy.Certificates;
@@ -27,6 +28,44 @@ namespace Fluxzy.Tests.UnitTests.Certificates
             var outOfProcCertManager = new OutOfProcAuthorityManager();
             Assert.False(_manager.IsCertificateInstalled(_certificate));
             Assert.False(outOfProcCertManager.IsCertificateInstalled(_certificate));
+        }
+
+        [Fact]
+        public void ResolveRootStoreLocation_UsesSystemBundleOnLinux()
+        {
+            Assert.Equal(StoreLocation.LocalMachine,
+                DefaultCertificateAuthorityManager.ResolveRootStoreLocation(p => p == OSPlatform.Linux));
+        }
+
+        [Fact]
+        public void ResolveRootStoreLocation_UsesCurrentUserOffLinux()
+        {
+            Assert.Equal(StoreLocation.CurrentUser,
+                DefaultCertificateAuthorityManager.ResolveRootStoreLocation(p => p == OSPlatform.Windows));
+
+            Assert.Equal(StoreLocation.CurrentUser,
+                DefaultCertificateAuthorityManager.ResolveRootStoreLocation(p => p == OSPlatform.OSX));
+        }
+
+        [Fact]
+        public void PerUserRootStore_IsNotReportedAsInstalled_OnLinux()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return;
+
+            using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadWrite);
+
+            using var publicCert = new X509Certificate2(_certificate.Export(X509ContentType.Cert));
+            store.Add(publicCert);
+
+            try {
+                // The per-user store is invisible to the OS, so trust must be read from LocalMachine\Root only
+                Assert.False(_manager.IsCertificateInstalled(_certificate));
+            }
+            finally {
+                store.Remove(publicCert);
+            }
         }
     }
 }


### PR DESCRIPTION
On Linux the cert install always reported success and trust checks read a per-user .NET store the OS ignores, so a CA looked trusted while real clients failed. Now install honors the system installer result and trust is read from the OS bundle. Adds no-root tests for the per-user store and the platform mapping.