### PR TITLE
Fix macOS system proxy detection and restore

### DIFF
--- a/src/Fluxzy.Core/Misc/ProcessUtils.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtils.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -41,11 +42,9 @@ namespace Fluxzy.Misc
             return process.ExitCode == 0 ? stringBuilder.ToString() : null;
         }
 
-        public static async Task<ProcessRunResult> QuickRunAsync(
+        public static Task<ProcessRunResult> QuickRunAsync(
             string commandName, string args, Stream? stdinStream = null, bool throwOnFail = false)
         {
-            // Run process and return process run result 
-
             var processStartInfo = new ProcessStartInfo(commandName, args) {
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
@@ -54,10 +53,36 @@ namespace Fluxzy.Misc
                 CreateNoWindow = true
             };
 
+            return RunAsync(processStartInfo, stdinStream, throwOnFail);
+        }
+
+        /// <summary>
+        /// Passes each argument verbatim via <see cref="ProcessStartInfo.ArgumentList"/>, so spaces and
+        /// empty values survive without any shell/quoting layer.
+        /// </summary>
+        public static Task<ProcessRunResult> QuickRunAsync(
+            string commandName, IEnumerable<string> args, bool throwOnFail = false)
+        {
+            var processStartInfo = new ProcessStartInfo(commandName) {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            foreach (var arg in args)
+                processStartInfo.ArgumentList.Add(arg);
+
+            return RunAsync(processStartInfo, null, throwOnFail);
+        }
+
+        private static async Task<ProcessRunResult> RunAsync(
+            ProcessStartInfo processStartInfo, Stream? stdinStream, bool throwOnFail)
+        {
             var process = Process.Start(processStartInfo);
 
             if (process == null) {
-                throw new InvalidOperationException("Unable to start process " + commandName + " " + args);
+                throw new InvalidOperationException("Unable to start process " + processStartInfo.FileName);
             }
 
             Task? copyTask = null;
@@ -84,7 +109,7 @@ namespace Fluxzy.Misc
 
             if (process.ExitCode != 0 && throwOnFail) {
                 throw new InvalidOperationException(
-                    $"Process {commandName} {args} exited" +
+                    $"Process {processStartInfo.FileName} exited" +
                     $" with code {process.ExitCode} {standardOutput} {standardError}");
             }
 

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsHelper.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsHelper.cs
@@ -11,72 +11,71 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
 {
     internal class MacOsHelper
     {
-        // Adding root certificate on macos s
-
-        public static async Task<IEnumerable<NetworkInterface>> GetEnabledInterfaces()
+        public static async Task<IReadOnlyList<NetworkInterface>> GetEnabledInterfaces()
         {
-            var runResult = await ProcessUtils.QuickRunAsync("networksetup", "-listnetworkserviceorder");
+            var runResult = await ProcessUtils.QuickRunAsync("networksetup", new[] { "-listnetworkserviceorder" });
 
             if (runResult.ExitCode != 0 || runResult.StandardOutputMessage == null)
                 throw new InvalidOperationException("Failed to get interfaces");
 
-            var commandResponse = runResult.StandardOutputMessage;
-
-            return ParseInterfaces(commandResponse);
+            return ParseInterfaces(runResult.StandardOutputMessage);
         }
 
-        public static IEnumerable<NetworkInterface> ParseInterfaces(string commandResponse)
+        public static IReadOnlyList<NetworkInterface> ParseInterfaces(string commandResponse)
         {
-            var networkInterfaces = System.Net.NetworkInformation.NetworkInterface
-                                          .GetAllNetworkInterfaces()
-                                          .Where(n => n.NetworkInterfaceType != NetworkInterfaceType.Loopback)
-                                          .Where(n => n.NetworkInterfaceType != NetworkInterfaceType.Unknown)
-                                          .Where(n => n.OperationalStatus == OperationalStatus.Up)
-                                          .Where(n => n.GetIPProperties().UnicastAddresses.Any())
-                                          .ToList();
-            
-            var hardwarePorMapping = NetworkInterface.ParseHardwarePortMapping(
+            var services = NetworkInterface.ParseNetworkServices(
                 commandResponse.Split(new[] { "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries));
 
-            return networkInterfaces.Select(s => !hardwarePorMapping.TryGetValue(s.Name, out var hardwarePort) ?
-                null : 
-                new NetworkInterface(s.Name, s.Name, hardwarePort))
-                                    .OfType<NetworkInterface>();
+            var activeDevices = System.Net.NetworkInformation.NetworkInterface
+                                       .GetAllNetworkInterfaces()
+                                       .Where(n => n.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+                                       .Where(n => n.NetworkInterfaceType != NetworkInterfaceType.Unknown)
+                                       .Where(n => n.OperationalStatus == OperationalStatus.Up)
+                                       .Where(n => n.GetIPProperties().UnicastAddresses.Any())
+                                       .Select(n => n.Name)
+                                       .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            return services.Where(s => activeDevices.Contains(s.DeviceName)).ToList();
         }
 
-        public static async Task<Dictionary<string, NetworkInterfaceProxySetting?>> ReadProxySettings(IEnumerable<string> interfaceNames)
+        /// <summary>
+        /// Fills <see cref="NetworkInterface.ProxySetting"/> for each interface by querying
+        /// <c>networksetup</c> by service name. Read failures leave the setting null.
+        /// </summary>
+        public static async Task PopulateProxySettings(IEnumerable<NetworkInterface> interfaces)
         {
-            var result = new Dictionary<string, NetworkInterfaceProxySetting?>();
+            foreach (var iface in interfaces) {
 
-            foreach (var interfaceName in interfaceNames) {
+                var proxyResult = await ProcessUtils.QuickRunAsync(
+                    "networksetup", new[] { "-getsecurewebproxy", iface.ServiceName });
 
-                var getwebProxyResult = await ProcessUtils.QuickRunAsync("networksetup", $"-getsecurewebproxy \"{interfaceName}\"");
-
-                if (getwebProxyResult.ExitCode != 0 || getwebProxyResult.StandardOutputMessage == null)
+                if (proxyResult.ExitCode != 0 || proxyResult.StandardOutputMessage == null)
                     continue;
 
-                var commandResponse = getwebProxyResult.StandardOutputMessage;
+                var proxySetting = NetworkInterfaceProxySetting.ParseFromCommandLineResult(proxyResult.StandardOutputMessage);
 
-                var proxySetting = NetworkInterfaceProxySetting.ParseFromCommandLineResult(commandResponse);
+                if (proxySetting == null)
+                    continue;
 
-                result[interfaceName] = proxySetting;
+                var byPassResult = await ProcessUtils.QuickRunAsync(
+                    "networksetup", new[] { "-getproxybypassdomains", iface.ServiceName });
 
-                if (proxySetting != null) {
-                    // Proxy settigns is available we try to set bypass domains
+                if (byPassResult.ExitCode == 0 && byPassResult.StandardOutputMessage != null)
+                    proxySetting.ByPassDomains = ParseByPassDomains(byPassResult.StandardOutputMessage);
 
-                    var byPassDomainsRunResult = await ProcessUtils.QuickRunAsync("networksetup", $"-getproxybypassdomains \"{interfaceName}\"");
-
-                    if (byPassDomainsRunResult.ExitCode != 0 || byPassDomainsRunResult.StandardOutputMessage == null)
-                        continue;
-
-                    var byPassDomains = byPassDomainsRunResult.StandardOutputMessage.Split(new[] { "\r", "\n" },
-                        StringSplitOptions.RemoveEmptyEntries).Distinct().ToArray();
-
-                    proxySetting.ByPassDomains = byPassDomains;
-                }
+                iface.ProxySetting = proxySetting;
             }
+        }
 
-            return result;
+        public static string[] ParseByPassDomains(string commandResponse)
+        {
+            // When the list is empty, networksetup prints "There aren't any bypass domains set on <service>."
+            return commandResponse.Split(new[] { "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                                  .Select(l => l.Trim())
+                                  .Where(l => l.Length > 0)
+                                  .Where(l => !l.Contains("aren't any bypass", StringComparison.OrdinalIgnoreCase))
+                                  .Distinct()
+                                  .ToArray();
         }
     }
 }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsHelper.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsHelper.cs
@@ -11,9 +11,11 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
 {
     internal class MacOsHelper
     {
+        private static string NetworkSetup => MacOsProxyConfiguration.NetworkSetupCommand;
+
         public static async Task<IReadOnlyList<NetworkInterface>> GetEnabledInterfaces()
         {
-            var runResult = await ProcessUtils.QuickRunAsync("networksetup", new[] { "-listnetworkserviceorder" });
+            var runResult = await ProcessUtils.QuickRunAsync(NetworkSetup, new[] { "-listnetworkserviceorder" });
 
             if (runResult.ExitCode != 0 || runResult.StandardOutputMessage == null)
                 throw new InvalidOperationException("Failed to get interfaces");
@@ -47,7 +49,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
             foreach (var iface in interfaces) {
 
                 var proxyResult = await ProcessUtils.QuickRunAsync(
-                    "networksetup", new[] { "-getsecurewebproxy", iface.ServiceName });
+                    NetworkSetup, new[] { "-getsecurewebproxy", iface.ServiceName });
 
                 if (proxyResult.ExitCode != 0 || proxyResult.StandardOutputMessage == null)
                     continue;
@@ -58,7 +60,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
                     continue;
 
                 var byPassResult = await ProcessUtils.QuickRunAsync(
-                    "networksetup", new[] { "-getproxybypassdomains", iface.ServiceName });
+                    NetworkSetup, new[] { "-getproxybypassdomains", iface.ServiceName });
 
                 if (byPassResult.ExitCode == 0 && byPassResult.StandardOutputMessage != null)
                     proxySetting.ByPassDomains = ParseByPassDomains(byPassResult.StandardOutputMessage);

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxyConfiguration.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxyConfiguration.cs
@@ -1,0 +1,53 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+
+namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
+{
+    /// <summary>
+    /// macOS proxy values that are otherwise hardcoded, each overridable through an environment variable.
+    /// Values are read once at startup.
+    /// </summary>
+    internal static class MacOsProxyConfiguration
+    {
+        /// <summary>
+        /// Path or name of the networksetup binary (FLUXZY_MACOS_NETWORKSETUP_PATH),
+        /// e.g. <c>/usr/sbin/networksetup</c> or a custom wrapper. Defaults to <c>networksetup</c>.
+        /// </summary>
+        public static string NetworkSetupCommand { get; } =
+            GetNonEmpty("FLUXZY_MACOS_NETWORKSETUP_PATH") ?? "networksetup";
+
+        /// <summary>
+        /// Network services preferred when deciding which one represents the active system proxy
+        /// (FLUXZY_MACOS_PROXY_PRIORITY_SERVICES, comma separated). Defaults to Wi-Fi then Ethernet.
+        /// </summary>
+        public static IReadOnlyCollection<string> PriorityServices { get; } =
+            ParseList(Environment.GetEnvironmentVariable("FLUXZY_MACOS_PROXY_PRIORITY_SERVICES"))
+            ?? new[] { "Wi-Fi", "Ethernet" };
+
+        /// <summary>
+        /// When set, restricts proxy configuration to these services (FLUXZY_MACOS_PROXY_SERVICES,
+        /// comma separated); otherwise every active service is configured.
+        /// </summary>
+        public static IReadOnlyCollection<string>? ServiceAllowList { get; } =
+            ParseList(Environment.GetEnvironmentVariable("FLUXZY_MACOS_PROXY_SERVICES"));
+
+        public static IReadOnlyCollection<string>? ParseList(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            var items = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            return items.Length == 0 ? null : items;
+        }
+
+        private static string? GetNonEmpty(string name)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxySetter.cs
@@ -14,18 +14,20 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
     {
         private const string NativeSettingKey = "nativeSetting";
 
-        private static readonly HashSet<string> PriorityDevices = new(
-            new[] { "Wi-Fi", "Ethernet"}, StringComparer.OrdinalIgnoreCase);
+        private static string NetworkSetup => MacOsProxyConfiguration.NetworkSetupCommand;
+
+        private static readonly HashSet<string> PriorityServices = new(
+            MacOsProxyConfiguration.PriorityServices, StringComparer.OrdinalIgnoreCase);
 
         public async Task<SystemProxySetting> ReadSetting()
         {
-            var interfaces = await MacOsHelper.GetEnabledInterfaces();
+            var interfaces = await GetManagedInterfaces();
 
             await MacOsHelper.PopulateProxySettings(interfaces);
 
             var enabledProxySetting = interfaces
                                       .Where(s => s.ProxySetting != null)
-                                      .OrderByDescending(t => PriorityDevices.Contains(t.HardwarePort))
+                                      .OrderByDescending(IsPriority)
                                       .FirstOrDefault(s => s.ProxySetting!.Enabled)?.ProxySetting;
 
             var proxyEnabled = enabledProxySetting != null;
@@ -56,14 +58,33 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
                 return;
             }
 
-            // Fresh setting: apply the same proxy to every active service.
-            var serviceNames = (await MacOsHelper.GetEnabledInterfaces()).Select(s => s.ServiceName);
+            // Fresh setting: apply the same proxy to every managed service.
+            var serviceNames = (await GetManagedInterfaces()).Select(s => s.ServiceName);
 
             var appliedHost = value.BoundHost == ProxyConstants.NoProxyWord ? string.Empty : value.BoundHost;
             var appliedPort = value.ListenPort <= 0 ? 0 : value.ListenPort;
 
             await Task.WhenAll(serviceNames.Select(
                 s => ApplyToService(s, appliedHost, appliedPort, value.ByPassHosts, value.Enabled, throwOnFail)));
+        }
+
+        private static bool IsPriority(NetworkInterface iface)
+        {
+            return PriorityServices.Contains(iface.ServiceName) || PriorityServices.Contains(iface.HardwarePort);
+        }
+
+        private static async Task<IReadOnlyList<NetworkInterface>> GetManagedInterfaces()
+        {
+            var interfaces = await MacOsHelper.GetEnabledInterfaces();
+
+            var allowList = MacOsProxyConfiguration.ServiceAllowList;
+
+            if (allowList == null)
+                return interfaces;
+
+            var allowed = new HashSet<string>(allowList, StringComparer.OrdinalIgnoreCase);
+
+            return interfaces.Where(i => allowed.Contains(i.ServiceName) || allowed.Contains(i.HardwarePort)).ToList();
         }
 
         private static async Task RestoreInterface(NetworkInterface iface, bool throwOnFail)
@@ -82,10 +103,10 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
         private static async Task ApplyToService(
             string serviceName, string host, int port, IEnumerable<string> byPassHosts, bool enabled, bool throwOnFail)
         {
-            await ProcessUtils.QuickRunAsync("networksetup",
+            await ProcessUtils.QuickRunAsync(NetworkSetup,
                 new[] { "-setwebproxy", serviceName, host, port.ToString() }, throwOnFail);
 
-            await ProcessUtils.QuickRunAsync("networksetup",
+            await ProcessUtils.QuickRunAsync(NetworkSetup,
                 new[] { "-setsecurewebproxy", serviceName, host, port.ToString() }, throwOnFail);
 
             await SetByPassDomains(serviceName, byPassHosts, throwOnFail);
@@ -103,17 +124,17 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
             // would otherwise be stored as a single blank bypass entry.
             args.AddRange(domains.Count == 0 ? new[] { "Empty" } : domains);
 
-            await ProcessUtils.QuickRunAsync("networksetup", args, throwOnFail);
+            await ProcessUtils.QuickRunAsync(NetworkSetup, args, throwOnFail);
         }
 
         private static async Task SetState(string serviceName, bool enabled, bool throwOnFail)
         {
             var onOff = enabled ? "on" : "off";
 
-            await ProcessUtils.QuickRunAsync("networksetup",
+            await ProcessUtils.QuickRunAsync(NetworkSetup,
                 new[] { "-setwebproxystate", serviceName, onOff }, throwOnFail);
 
-            await ProcessUtils.QuickRunAsync("networksetup",
+            await ProcessUtils.QuickRunAsync(NetworkSetup,
                 new[] { "-setsecurewebproxystate", serviceName, onOff }, throwOnFail);
         }
     }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/MacOsProxySetter.cs
@@ -12,88 +12,109 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
 {
     internal class MacOsProxySetter : ISystemProxySetter
     {
+        private const string NativeSettingKey = "nativeSetting";
+
         private static readonly HashSet<string> PriorityDevices = new(
-            new[] { "Wi-Fi", "Ethernet"}, StringComparer.OrdinalIgnoreCase); 
+            new[] { "Wi-Fi", "Ethernet"}, StringComparer.OrdinalIgnoreCase);
 
         public async Task<SystemProxySetting> ReadSetting()
         {
-            // list all interfaces 
-            var interfaces = (await MacOsHelper.GetEnabledInterfaces()).ToList();
+            var interfaces = await MacOsHelper.GetEnabledInterfaces();
 
-            // get proxy settings
-            var proxySettings = await MacOsHelper.ReadProxySettings(interfaces.Select(s => s.Name));
+            await MacOsHelper.PopulateProxySettings(interfaces);
 
-            foreach (var proxySetting in proxySettings) {
-                var iface = interfaces.FirstOrDefault(s => s.Name == proxySetting.Key);
-
-                if (iface == null)
-                    continue;
-
-                iface.ProxySetting = proxySetting.Value;
-            }
-            
-            var activeInterfaces = interfaces.Where(s => s.ProxySetting != null).ToList();
-
-            var enabledProxySetting = activeInterfaces
+            var enabledProxySetting = interfaces
+                                      .Where(s => s.ProxySetting != null)
                                       .OrderByDescending(t => PriorityDevices.Contains(t.HardwarePort))
                                       .FirstOrDefault(s => s.ProxySetting!.Enabled)?.ProxySetting;
 
             var proxyEnabled = enabledProxySetting != null;
-            var proxyHost = enabledProxySetting?.Server ?? ProxyConstants.NoProxyWord; 
+            var proxyHost = enabledProxySetting?.Server ?? ProxyConstants.NoProxyWord;
             var proxyPort = enabledProxySetting?.Port ?? -1;
             var byPassDomains = enabledProxySetting?.ByPassDomains ?? Array.Empty<string>();
 
+            // The per-interface snapshot is what UnRegister replays to restore the exact prior state.
             return new SystemProxySetting(proxyHost, proxyPort, byPassDomains) {
                 Enabled = proxyEnabled,
-                PrivateValues = { ["nativeSetting"] = activeInterfaces } 
+                PrivateValues = { [NativeSettingKey] = interfaces }
             };
         }
 
         public async Task ApplySetting(SystemProxySetting value)
         {
-            // networksetup -setwebproxy Ethernet 127.0.0.1 44344
-            // networksetup -setproxybypassdomains domain1 domain2 
-
-            var activeInterfaceNames = (await MacOsHelper.GetEnabledInterfaces())
-                                                  .Select(s => s.HardwarePort).ToList();
-
-
             var throwOnFail = false;
 
 #if DEBUG
-            throwOnFail = false; 
+            throwOnFail = true;
 #endif
-            await Task.WhenAll(activeInterfaceNames.Select(s => PrepareInterface(value, s, throwOnFail))); 
+
+            // Restoring a previously read setting: replay each interface's captured state verbatim.
+            if (value.PrivateValues.TryGetValue(NativeSettingKey, out var native)
+                && native is IEnumerable<NetworkInterface> snapshot) {
+                await Task.WhenAll(snapshot.Select(s => RestoreInterface(s, throwOnFail)));
+
+                return;
+            }
+
+            // Fresh setting: apply the same proxy to every active service.
+            var serviceNames = (await MacOsHelper.GetEnabledInterfaces()).Select(s => s.ServiceName);
+
+            var appliedHost = value.BoundHost == ProxyConstants.NoProxyWord ? string.Empty : value.BoundHost;
+            var appliedPort = value.ListenPort <= 0 ? 0 : value.ListenPort;
+
+            await Task.WhenAll(serviceNames.Select(
+                s => ApplyToService(s, appliedHost, appliedPort, value.ByPassHosts, value.Enabled, throwOnFail)));
         }
 
-        private static async Task PrepareInterface(SystemProxySetting value, string interfaceName, bool throwOnFail)
+        private static async Task RestoreInterface(NetworkInterface iface, bool throwOnFail)
         {
-            var appliedHost = value.BoundHost == ProxyConstants.NoProxyWord ? "''" : value.BoundHost;
-            var appliedPort = value.ListenPort <= 0 ? "''" : value.ListenPort.ToString();
+            if (iface.ProxySetting is not { } proxy) {
+                // Prior state unknown: just turn the proxy off rather than guessing a host.
+                await SetState(iface.ServiceName, false, throwOnFail);
 
-            await ProcessUtils.QuickRunAsync("networksetup",
-                $"-setwebproxy \"{interfaceName}\" \"{appliedHost}\" {appliedPort}", throwOnFail: throwOnFail);
-
-            await ProcessUtils.QuickRunAsync("networksetup",
-                $"-setsecurewebproxy \"{interfaceName}\" \"{appliedHost}\" {appliedPort}", throwOnFail: throwOnFail);
-
-            if (value.ByPassHosts.Any()) {
-                await ProcessUtils.QuickRunAsync("networksetup",
-                    $"-setproxybypassdomains \"{interfaceName}\" {string.Join(" ", value.ByPassHosts.Select(s => $"\"{s}\""))}",
-                    throwOnFail: throwOnFail);
-            }
-            else {
-                await ProcessUtils.QuickRunAsync("networksetup", $"-setproxybypassdomains \"{interfaceName}\" ''",
-                    throwOnFail: throwOnFail);
+                return;
             }
 
-            var onOff = value.Enabled ? "on" : "off";
+            await ApplyToService(iface.ServiceName, proxy.Server, proxy.Port, proxy.ByPassDomains, proxy.Enabled,
+                throwOnFail);
+        }
 
-            await ProcessUtils.QuickRunAsync("networksetup", $"-setwebproxystate \"{interfaceName}\" {onOff}",
-                throwOnFail: throwOnFail);
+        private static async Task ApplyToService(
+            string serviceName, string host, int port, IEnumerable<string> byPassHosts, bool enabled, bool throwOnFail)
+        {
+            await ProcessUtils.QuickRunAsync("networksetup",
+                new[] { "-setwebproxy", serviceName, host, port.ToString() }, throwOnFail);
 
-            await ProcessUtils.QuickRunAsync("networksetup", $"-setsecurewebproxystate \"{interfaceName}\" {onOff}",
-                throwOnFail: throwOnFail);
+            await ProcessUtils.QuickRunAsync("networksetup",
+                new[] { "-setsecurewebproxy", serviceName, host, port.ToString() }, throwOnFail);
+
+            await SetByPassDomains(serviceName, byPassHosts, throwOnFail);
+
+            await SetState(serviceName, enabled, throwOnFail);
+        }
+
+        private static async Task SetByPassDomains(string serviceName, IEnumerable<string> byPassHosts, bool throwOnFail)
+        {
+            var domains = byPassHosts.Where(h => !string.IsNullOrWhiteSpace(h)).ToList();
+
+            var args = new List<string> { "-setproxybypassdomains", serviceName };
+
+            // networksetup clears the list only via the "Empty" keyword; an empty argument
+            // would otherwise be stored as a single blank bypass entry.
+            args.AddRange(domains.Count == 0 ? new[] { "Empty" } : domains);
+
+            await ProcessUtils.QuickRunAsync("networksetup", args, throwOnFail);
+        }
+
+        private static async Task SetState(string serviceName, bool enabled, bool throwOnFail)
+        {
+            var onOff = enabled ? "on" : "off";
+
+            await ProcessUtils.QuickRunAsync("networksetup",
+                new[] { "-setwebproxystate", serviceName, onOff }, throwOnFail);
+
+            await ProcessUtils.QuickRunAsync("networksetup",
+                new[] { "-setsecurewebproxystate", serviceName, onOff }, throwOnFail);
         }
     }
 }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/NetworkInterface.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/macOs/NetworkInterface.cs
@@ -9,46 +9,65 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
 {
     internal class NetworkInterface
     {
-        public NetworkInterface(string name, string deviceName, string hardwarePort)
+        public NetworkInterface(string deviceName, string serviceName, string hardwarePort)
         {
-            Name = name;
             DeviceName = deviceName;
+            ServiceName = serviceName;
             HardwarePort = hardwarePort;
         }
 
-        public string Name { get;  } 
+        /// <summary>BSD device name (e.g. <c>en0</c>).</summary>
+        public string DeviceName { get; }
 
-        public string DeviceName { get;  }
+        /// <summary>
+        /// Network service name (e.g. <c>Wi-Fi</c>). This is the identifier every
+        /// <c>networksetup</c> proxy sub-command expects - not the device name.
+        /// </summary>
+        public string ServiceName { get; }
 
+        /// <summary>Hardware port (e.g. <c>Wi-Fi</c>), used only as a stable key for priority ordering.</summary>
         public string HardwarePort { get; }
 
         public NetworkInterfaceProxySetting? ProxySetting { get; set; }
 
-        
-        
+        private static readonly Regex ServiceHeaderRegex =
+            new(@"^\((?:\d+|\*)\)\s+(?<service>.+)$");
+
+        private static readonly Regex DeviceLineRegex =
+            new(@"^\(Hardware Port:\s*(?<hardwarePort>.*),\s*Device:\s*(?<deviceName>[a-zA-Z0-9_]+)\)$");
+
         /// <summary>
-        /// Mapping between device name and hardward port 
+        /// Parses <c>networksetup -listnetworkserviceorder</c>, pairing each "(n) ServiceName"
+        /// header with the "(Hardware Port: ..., Device: ...)" line that follows it.
         /// </summary>
-        /// <param name="lines"></param>
-        /// <returns></returns>
-        public static Dictionary<string, string> ParseHardwarePortMapping(string[] lines)
+        public static IReadOnlyList<NetworkInterface> ParseNetworkServices(IEnumerable<string> lines)
         {
-            var regexDeviceName = @"Hardware Port: (?<hardwarePort>.*), Device: (?<deviceName>[a-zA-Z0-9_]+)\)$";
+            var result = new List<NetworkInterface>();
+            string? currentService = null;
 
-            var result = new Dictionary<string, string>();
-            
-            foreach (var line in lines) {
-                var matchResult = Regex.Match(line, regexDeviceName);
+            foreach (var rawLine in lines) {
+                var line = rawLine.Trim();
 
-                if (!matchResult.Success)
-                    continue; 
-                
-                var deviceName = matchResult.Groups["deviceName"].Value;
-                var hardwarePort = matchResult.Groups["hardwarePort"].Value;
-                
-                result[deviceName] = hardwarePort;
+                var header = ServiceHeaderRegex.Match(line);
+
+                if (header.Success) {
+                    currentService = header.Groups["service"].Value.Trim();
+                    continue;
+                }
+
+                var device = DeviceLineRegex.Match(line);
+
+                if (device.Success && currentService != null) {
+                    result.Add(new NetworkInterface(
+                        device.Groups["deviceName"].Value,
+                        currentService,
+                        device.Groups["hardwarePort"].Value.Trim()));
+
+                    currentService = null;
+                }
             }
-            return result; 
+
+            return result;
         }
     }
 
@@ -66,14 +85,12 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
         public string Server { get; }
 
         public int Port { get;  }
-        
-        public string[] ByPassDomains { get; set; } = new string[0];
+
+        public string[] ByPassDomains { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// Parses result of command line "networksetup -getwebproxy {interfaceName}"
+        /// Parses result of command line "networksetup -getsecurewebproxy {serviceName}"
         /// </summary>
-        /// <param name="commandLineResult"></param>
-        /// <returns></returns>
         public static NetworkInterfaceProxySetting? ParseFromCommandLineResult(string commandLineResult)
         {
             var lines = commandLineResult.Split(new[] { "\r", "\n"}, StringSplitOptions.RemoveEmptyEntries)
@@ -93,14 +110,14 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.macOs
                 return null;
 
             if (!dictionaryOfValue.TryGetValue("Server", out var serverValue))
-                return null; 
+                return null;
 
             if (!dictionaryOfValue.TryGetValue("Port", out var portValue))
                 return null;
 
             var enabled = string.Equals(enabledValue.Trim(), "Yes", StringComparison.OrdinalIgnoreCase);
-            var server = serverValue.Trim(); 
-            
+            var server = serverValue.Trim();
+
             if (!int.TryParse(portValue.Trim(), out var port))
                 return null;
 

--- a/test/Fluxzy.Tests/UnitTests/NativeOps/Macos/CliMacosTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/NativeOps/Macos/CliMacosTests.cs
@@ -108,5 +108,23 @@ namespace Fluxzy.Tests.UnitTests.NativeOps.Macos
 
             Assert.Equal(new[] { "*.local", "169.254/16", "example.com" }, domains);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(",, ,")]
+        public void TestParseServiceListEmptyIsNull(string? raw)
+        {
+            Assert.Null(MacOsProxyConfiguration.ParseList(raw));
+        }
+
+        [Fact]
+        public void TestParseServiceListTrimsAndDropsEmpty()
+        {
+            var list = MacOsProxyConfiguration.ParseList(" Wi-Fi , Ethernet ,, USB 10/100/1000 LAN ");
+
+            Assert.Equal(new[] { "Wi-Fi", "Ethernet", "USB 10/100/1000 LAN" }, list);
+        }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/NativeOps/Macos/CliMacosTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/NativeOps/Macos/CliMacosTests.cs
@@ -1,5 +1,6 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System.Linq;
 using Fluxzy.Utils.NativeOps.SystemProxySetup.macOs;
 using Xunit;
 
@@ -51,6 +52,61 @@ namespace Fluxzy.Tests.UnitTests.NativeOps.Macos
                 "\r\nEnabled: yes\r\nEnabled: yes\r\nServer: 127.0.0.1\r\nPort: 44344\r\nAuthenticated Proxy Enabled: 0");
 
             Assert.Null(setting);
+        }
+
+        private const string ServiceOrderResult =
+            "An asterisk (*) denotes that a network service is disabled.\n" +
+            "(1) USB 10/100/1000 LAN\n" +
+            "(Hardware Port: USB 10/100/1000 LAN, Device: en7)\n" +
+            "\n" +
+            "(2) Wi-Fi\n" +
+            "(Hardware Port: Wi-Fi, Device: en0)\n";
+
+        [Fact]
+        public void TestParseNetworkServices()
+        {
+            var services = NetworkInterface.ParseNetworkServices(
+                ServiceOrderResult.Split('\n'));
+
+            Assert.Equal(2, services.Count);
+
+            var wifi = services.Single(s => s.DeviceName == "en0");
+
+            // networksetup is addressed by service name, not by BSD device name.
+            Assert.Equal("Wi-Fi", wifi.ServiceName);
+            Assert.Equal("Wi-Fi", wifi.HardwarePort);
+        }
+
+        [Fact]
+        public void TestParseNetworkServicesKeepsRenamedServiceName()
+        {
+            // A user can rename a service, so the service name no longer matches the hardware port.
+            var services = NetworkInterface.ParseNetworkServices(new[] {
+                "(1) Home Wi-Fi",
+                "(Hardware Port: Wi-Fi, Device: en0)"
+            });
+
+            var iface = Assert.Single(services);
+
+            Assert.Equal("en0", iface.DeviceName);
+            Assert.Equal("Home Wi-Fi", iface.ServiceName);
+            Assert.Equal("Wi-Fi", iface.HardwarePort);
+        }
+
+        [Fact]
+        public void TestParseByPassDomainsEmpty()
+        {
+            var domains = MacOsHelper.ParseByPassDomains("There aren't any bypass domains set on Wi-Fi.");
+
+            Assert.Empty(domains);
+        }
+
+        [Fact]
+        public void TestParseByPassDomains()
+        {
+            var domains = MacOsHelper.ParseByPassDomains("*.local\r\n169.254/16\r\nexample.com");
+
+            Assert.Equal(new[] { "*.local", "169.254/16", "example.com" }, domains);
         }
     }
 }


### PR DESCRIPTION
On macOS, `networksetup` was queried by BSD device name (`en0`) for reads but by service name (`Wi-Fi`) for writes. `networksetup` rejects the device name, so proxy detection always reported "no proxy", `IsRegisteredOn` was always false, and any pre-existing user proxy was lost on unregister. Disabling also wrote a literal `''` bypass entry and wiped the macOS default bypass list.

* Read and write `networksetup` by service name
* Snapshot and restore each interface's prior proxy and bypass on unregister
* Pass args via `ArgumentList` so empty values and names with spaces work without a shell quoting layer; clear the bypass list via the `Empty` keyword
* Report `networksetup` failures in DEBUG builds

Several previously hardcoded macOS values are now overridable through environment variables:

* `FLUXZY_MACOS_NETWORKSETUP_PATH` sets the networksetup binary
* `FLUXZY_MACOS_PROXY_PRIORITY_SERVICES` sets the service priority used to pick the active proxy
* `FLUXZY_MACOS_PROXY_SERVICES` restricts configuration to specific services instead of every active one

