### PR TITLE
Add pluggable process resolver for downstream connections

### DIFF
--- a/examples/Samples.No026.ResolveProcessInfo/Program.cs
+++ b/examples/Samples.No026.ResolveProcessInfo/Program.cs
@@ -1,0 +1,66 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using Fluxzy;
+using Fluxzy.Certificates;
+using Fluxzy.Core;
+using Fluxzy.Utils.ProcessTracking;
+using Fluxzy.Writers;
+
+namespace Samples.No026.ResolveProcessInfo
+{
+    internal class Program
+    {
+        /// <summary>
+        /// Shows how to supply process information yourself instead of relying on the built-in OS TCP
+        /// table lookup. This is the seam to use when a transparent tunnel such as tun2socks fronts the
+        /// proxy over SOCKS5: the socket the proxy accepts belongs to the tunnel, not the real client,
+        /// so only your code can map a connection back to the originating process. Implement
+        /// IProcessInfoResolver, pass it to the Proxy constructor, and keep process tracking enabled.
+        /// The resolver is called once per downstream connection and its result lands on every exchange.
+        /// </summary>
+        static async Task Main()
+        {
+            var fluxzySetting = FluxzySetting
+                                .CreateDefault(System.Net.IPAddress.Loopback, 44344)
+                                .SetEnableProcessTracking(true);
+
+            await using var proxy = new Proxy(fluxzySetting,
+                new CertificateProvider(fluxzySetting.CaCertificate, new InMemoryCertificateCache()),
+                new DefaultCertificateAuthorityManager(),
+                processInfoResolver: new Tun2SocksProcessResolver());
+
+            proxy.Writer.ExchangeUpdated += (_, e) => {
+                var processInfo = e.Original.ProcessInfo;
+
+                if (e.UpdateType == ArchiveUpdateType.AfterResponseHeader && processInfo != null)
+                    Console.WriteLine($"{e.Original.KnownAuthority} -> pid {processInfo.ProcessId} {processInfo.ProcessPath}");
+            };
+
+            var endpoints = proxy.Run();
+
+            using var httpClient = new HttpClient(new HttpClientHandler {
+                Proxy = new System.Net.WebProxy($"http://127.0.0.1:{endpoints.First().Port}"),
+                UseProxy = true
+            });
+
+            using var response = await httpClient.GetAsync("https://www.example.com/");
+            Console.WriteLine($"status {(int) response.StatusCode}");
+        }
+    }
+
+    internal class Tun2SocksProcessResolver : IProcessInfoResolver
+    {
+        public ValueTask<ProcessInfo?> ResolveAsync(ProcessResolutionContext context, CancellationToken token)
+        {
+            // A real integration looks this connection up in the tunnel flow table, keyed by the source
+            // port (context.RemoteEndPoint.Port) or the requested destination (context.RequestedAuthority),
+            // and returns the originating process. Returning null leaves the exchange without process info.
+            //
+            // Here we just report the current process to keep the sample self contained.
+            var processInfo = new ProcessInfo(
+                Environment.ProcessId, Environment.ProcessPath, processArguments: null);
+
+            return new ValueTask<ProcessInfo?>(processInfo);
+        }
+    }
+}

--- a/examples/Samples.No026.ResolveProcessInfo/Samples.No026.ResolveProcessInfo.csproj
+++ b/examples/Samples.No026.ResolveProcessInfo/Samples.No026.ResolveProcessInfo.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fluxzy.Core\Fluxzy.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/fluxzy.core.slnx
+++ b/fluxzy.core.slnx
@@ -40,6 +40,7 @@
     <Project Path="examples/Samples.No022.RejectRequests/Samples.No022.RejectRequests.csproj" />
     <Project Path="examples/Samples.No023.GrpcThroughProxy/Samples.No023.GrpcThroughProxy.csproj" />
     <Project Path="examples/Samples.No024.BindUpstreamSocket/Samples.No024.BindUpstreamSocket.csproj" />
+    <Project Path="examples/Samples.No026.ResolveProcessInfo/Samples.No026.ResolveProcessInfo.csproj" />
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj" />

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -110,13 +110,17 @@ namespace Fluxzy.Core
                 downStreamPipe = exchangeSourceInitResult.DownStreamPipe;
                 var provisionalExchange = exchangeSourceInitResult.ProvisionalExchange;
 
+                // Resolve the originating process once per connection; every exchange shares it.
+                var processInfo = await ResolveProcessInfo(
+                    provisionalExchange, remoteEndPoint, localEndPoint, token);
+
                 if (downStreamPipe.SupportsMultiplexing) {
                     await OperateMultiplexed(
                         buffer, closeImmediately, token,
                         provisionalExchange, downStreamPipe,
                         remoteEndPoint, downStreamClientAddress,
                         localEndPoint, localEndPointsAddress,
-                        callerTokenSource);
+                        callerTokenSource, processInfo);
                 }
                 else {
                     await OperateSequential(
@@ -124,7 +128,7 @@ namespace Fluxzy.Core
                         provisionalExchange, downStreamPipe,
                         remoteEndPoint, downStreamClientAddress,
                         localEndPoint, localEndPointsAddress,
-                        callerTokenSource, client, lastExchangeHolder);
+                        callerTokenSource, client, lastExchangeHolder, processInfo);
                 }
             }
             catch (Exception ex)
@@ -155,7 +159,7 @@ namespace Fluxzy.Core
             IPEndPoint remoteEndPoint, string downStreamClientAddress,
             IPEndPoint localEndPoint, string localEndPointsAddress,
             CancellationTokenSource callerTokenSource, TcpClient client,
-            ExchangeHolder lastExchangeHolder)
+            ExchangeHolder lastExchangeHolder, ProcessInfo? processInfo)
         {
             var processedProvisional = false;
 
@@ -203,7 +207,7 @@ namespace Fluxzy.Core
                     buffer, closeImmediately, token, exchange,
                     remoteEndPoint, downStreamClientAddress,
                     localEndPoint, localEndPointsAddress,
-                    downStreamPipe, callerTokenSource);
+                    downStreamPipe, callerTokenSource, processInfo);
 
                 if (shouldCloseDownStreamConnection)
                 {
@@ -217,7 +221,7 @@ namespace Fluxzy.Core
             Exchange? provisionalExchange, IDownStreamPipe downStreamPipe,
             IPEndPoint remoteEndPoint, string downStreamClientAddress,
             IPEndPoint localEndPoint, string localEndPointsAddress,
-            CancellationTokenSource callerTokenSource)
+            CancellationTokenSource callerTokenSource, ProcessInfo? processInfo)
         {
             var tracker = new ActiveExchangeTracker();
             var processedProvisional = false;
@@ -275,7 +279,7 @@ namespace Fluxzy.Core
                     remoteEndPoint, downStreamClientAddress,
                     localEndPoint, localEndPointsAddress,
                     downStreamPipe, callerTokenSource,
-                    tracker);
+                    tracker, processInfo);
             }
 
             // Wait for all in-flight exchanges to complete
@@ -288,7 +292,7 @@ namespace Fluxzy.Core
             IPEndPoint remoteEndPoint, string downStreamClientAddress,
             IPEndPoint localEndPoint, string localEndPointsAddress,
             IDownStreamPipe downStreamPipe, CancellationTokenSource callerTokenSource,
-            ActiveExchangeTracker tracker)
+            ActiveExchangeTracker tracker, ProcessInfo? processInfo)
         {
             using var exchangeBuffer = RsBuffer.Allocate(FluxzySharedSetting.RequestProcessingBuffer);
 
@@ -298,7 +302,7 @@ namespace Fluxzy.Core
                     exchangeBuffer, closeImmediately, token, exchange,
                     remoteEndPoint, downStreamClientAddress,
                     localEndPoint, localEndPointsAddress,
-                    downStreamPipe, callerTokenSource);
+                    downStreamPipe, callerTokenSource, processInfo);
             }
             catch (Exception ex)
             {
@@ -329,7 +333,7 @@ namespace Fluxzy.Core
             RsBuffer buffer, bool closeImmediately, CancellationToken token, Exchange exchange, IPEndPoint remoteEndPoint,
             string downStreamClientAddress,
             IPEndPoint localEndPoint, string localEndPointsAddress, IDownStreamPipe downStreamPipe,
-            CancellationTokenSource callerTokenSource)
+            CancellationTokenSource callerTokenSource, ProcessInfo? processInfo)
         {
             UpdateExchangeMetrics(exchange, remoteEndPoint, downStreamClientAddress, localEndPoint,
                 localEndPointsAddress);
@@ -345,12 +349,7 @@ namespace Fluxzy.Core
                     _proxyRuntimeSetting.UserAgentProvider);
             }
 
-            // Collect process info if enabled and connection is from localhost
-            if (_proxyRuntimeSetting.StartupSetting.EnableProcessTracking
-                && IPAddress.IsLoopback(remoteEndPoint.Address))
-            {
-                exchange.ProcessInfo = ProcessTracker.Instance.GetProcessInfo(remoteEndPoint.Port);
-            }
+            exchange.ProcessInfo = processInfo;
 
             if (!exchange.Unprocessed)
             {
@@ -363,6 +362,20 @@ namespace Fluxzy.Core
                 downStreamPipe, buffer, closeImmediately, callerTokenSource, token);
 
             return shouldCloseDownStreamConnection;
+        }
+
+        private async ValueTask<ProcessInfo?> ResolveProcessInfo(
+            Exchange provisionalExchange, IPEndPoint remoteEndPoint, IPEndPoint localEndPoint, CancellationToken token)
+        {
+            if (!_proxyRuntimeSetting.StartupSetting.EnableProcessTracking)
+                return null;
+
+            var context = new ProcessResolutionContext(
+                remoteEndPoint, localEndPoint, provisionalExchange.Authority);
+
+            return await _proxyRuntimeSetting.ProcessInfoResolver
+                                             .ResolveAsync(context, token)
+                                             .ConfigureAwait(false);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -11,6 +11,7 @@ using Fluxzy.Clients;
 using Fluxzy.Rules;
 using Fluxzy.Rules.Actions;
 using Fluxzy.Rules.Filters;
+using Fluxzy.Utils.ProcessTracking;
 using Fluxzy.Writers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -80,6 +81,12 @@ namespace Fluxzy.Core
         ///     Optional callback applied to every upstream socket before it connects.
         /// </summary>
         public ConfigureUpstreamSocket? ConfigureUpstreamSocket { get; set; }
+
+        /// <summary>
+        ///     Resolves the originating process for a downstream connection when process tracking is enabled.
+        ///     Defaults to a local OS TCP table lookup.
+        /// </summary>
+        public IProcessInfoResolver ProcessInfoResolver { get; set; } = new LocalTcpTableProcessResolver();
 
         /// <summary>
         /// </summary>

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -22,6 +22,7 @@ using Fluxzy.Misc.ResizableBuffers;
 using Fluxzy.Rules;
 using Fluxzy.Rules.Actions;
 using Fluxzy.Rules.Filters;
+using Fluxzy.Utils.ProcessTracking;
 using Fluxzy.Writers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -104,6 +105,7 @@ namespace Fluxzy
         /// <param name="externalCancellationSource">An external cancellation token</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        /// <param name="processInfoResolver">Resolves the originating process for a downstream connection. Defaults to a local OS TCP table lookup.</param>
         /// <exception cref="ArgumentNullException"></exception>
         public Proxy(
             FluxzySetting startupSetting,
@@ -115,7 +117,8 @@ namespace Fluxzy
             IDnsSolver? dnsSolver = null,
             CancellationTokenSource? externalCancellationSource = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null)
+            ILoggerFactory? loggerFactory = null,
+            IProcessInfoResolver? processInfoResolver = null)
         {
             _certificateProvider = certificateProvider;
             _externalCancellationSource = externalCancellationSource;
@@ -163,6 +166,9 @@ namespace Fluxzy
             _runTimeSetting = new ProxyRuntimeSetting(startupSetting, ExecutionContext, tcpConnectionProvider1,
                 Writer, IdProvider, userAgentProvider, loggerFactory, InstanceId);
 
+            if (processInfoResolver != null)
+                _runTimeSetting.ProcessInfoResolver = processInfoResolver;
+
             _logger = _runTimeSetting.GetLogger<Proxy>();
 
             proxyAuthenticationMethod ??= ProxyAuthenticationMethodBuilder.Create(startupSetting.ProxyAuthentication);
@@ -202,6 +208,7 @@ namespace Fluxzy
         /// <param name="externalCancellationSource">An external cancellation token</param>
         /// <param name="proxyAuthenticationMethod">Use this authentication method instead of the one provided in FluxzySetting</param>
         /// <param name="loggerFactory">Optional logger factory. When null, no logs are emitted.</param>
+        /// <param name="processInfoResolver">Resolves the originating process for a downstream connection. Defaults to a local OS TCP table lookup.</param>
         public Proxy(
             FluxzySetting startupSetting,
             ICertificateProvider certificateProvider,
@@ -213,10 +220,11 @@ namespace Fluxzy
             IDnsSolver? dnsSolver = null,
             CancellationTokenSource? externalCancellationSource = null,
             ProxyAuthenticationMethod? proxyAuthenticationMethod = null,
-            ILoggerFactory? loggerFactory = null)
+            ILoggerFactory? loggerFactory = null,
+            IProcessInfoResolver? processInfoResolver = null)
             : this(startupSetting, certificateProvider, certificateAuthorityManager, tcpConnectionProvider,
                 userAgentProvider, idProvider, dnsSolver, externalCancellationSource,
-                proxyAuthenticationMethod, loggerFactory)
+                proxyAuthenticationMethod, loggerFactory, processInfoResolver)
         {
             _runTimeSetting.ConfigureUpstreamSocket = configureUpstreamSocket;
         }

--- a/src/Fluxzy.Core/Utils/ProcessTracking/IProcessInfoResolver.cs
+++ b/src/Fluxzy.Core/Utils/ProcessTracking/IProcessInfoResolver.cs
@@ -1,0 +1,21 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Utils.ProcessTracking
+{
+    /// <summary>
+    /// Resolves the process behind a downstream connection. The default implementation reads the
+    /// local OS TCP table. Callers fronting the proxy with a transparent tunnel (for example
+    /// tun2socks over SOCKS5) can provide their own to map a connection back to the real process.
+    /// </summary>
+    public interface IProcessInfoResolver
+    {
+        /// <summary>
+        /// Returns the process owning <paramref name="context"/>, or null when it cannot be determined.
+        /// Called once per downstream connection when process tracking is enabled.
+        /// </summary>
+        ValueTask<ProcessInfo?> ResolveAsync(ProcessResolutionContext context, CancellationToken token);
+    }
+}

--- a/src/Fluxzy.Core/Utils/ProcessTracking/LocalTcpTableProcessResolver.cs
+++ b/src/Fluxzy.Core/Utils/ProcessTracking/LocalTcpTableProcessResolver.cs
@@ -1,0 +1,30 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Utils.ProcessTracking
+{
+    /// <summary>
+    /// Default resolver. Looks the process up in the local OS TCP table by connection source port.
+    /// Only loopback connections are resolvable this way.
+    /// </summary>
+    public sealed class LocalTcpTableProcessResolver : IProcessInfoResolver
+    {
+        private readonly IProcessTracker _processTracker;
+
+        public LocalTcpTableProcessResolver(IProcessTracker? processTracker = null)
+        {
+            _processTracker = processTracker ?? ProcessTracker.Instance;
+        }
+
+        public ValueTask<ProcessInfo?> ResolveAsync(ProcessResolutionContext context, CancellationToken token)
+        {
+            if (!IPAddress.IsLoopback(context.RemoteEndPoint.Address))
+                return new ValueTask<ProcessInfo?>((ProcessInfo?) null);
+
+            return new ValueTask<ProcessInfo?>(_processTracker.GetProcessInfo(context.RemoteEndPoint.Port));
+        }
+    }
+}

--- a/src/Fluxzy.Core/Utils/ProcessTracking/ProcessResolutionContext.cs
+++ b/src/Fluxzy.Core/Utils/ProcessTracking/ProcessResolutionContext.cs
@@ -1,0 +1,38 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Net;
+using Fluxzy.Core;
+
+namespace Fluxzy.Utils.ProcessTracking
+{
+    /// <summary>
+    /// Describes a downstream client connection passed to an <see cref="IProcessInfoResolver"/>
+    /// so the originating process can be resolved.
+    /// </summary>
+    public sealed class ProcessResolutionContext
+    {
+        public ProcessResolutionContext(
+            IPEndPoint remoteEndPoint, IPEndPoint localEndPoint, Authority requestedAuthority)
+        {
+            RemoteEndPoint = remoteEndPoint;
+            LocalEndPoint = localEndPoint;
+            RequestedAuthority = requestedAuthority;
+        }
+
+        /// <summary>
+        /// The downstream client endpoint seen by the proxy. When a transparent tunnel such as
+        /// tun2socks fronts the proxy, this is the tunnel socket, not the real client.
+        /// </summary>
+        public IPEndPoint RemoteEndPoint { get; }
+
+        /// <summary>
+        /// The proxy endpoint that accepted the connection.
+        /// </summary>
+        public IPEndPoint LocalEndPoint { get; }
+
+        /// <summary>
+        /// The destination requested by the client, that is the CONNECT or SOCKS5 target.
+        /// </summary>
+        public Authority RequestedAuthority { get; }
+    }
+}

--- a/test/Fluxzy.Tests/Cases/CustomProcessResolverTests.cs
+++ b/test/Fluxzy.Tests/Cases/CustomProcessResolverTests.cs
@@ -1,0 +1,97 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Tests._Fixtures;
+using Fluxzy.Utils.ProcessTracking;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    public class CustomProcessResolverTests
+    {
+        private sealed class FixedResolver : IProcessInfoResolver
+        {
+            private readonly ProcessInfo _info;
+
+            public FixedResolver(ProcessInfo info) => _info = info;
+
+            public ProcessResolutionContext? LastContext { get; private set; }
+
+            public ValueTask<ProcessInfo?> ResolveAsync(ProcessResolutionContext context, CancellationToken token)
+            {
+                LastContext = context;
+                return new ValueTask<ProcessInfo?>(_info);
+            }
+        }
+
+        [Fact]
+        public async Task CustomResolver_IsUsed_WhenProcessTrackingEnabled()
+        {
+            var sentinel = new ProcessInfo(424242, "/opt/tun2socks/app", "app --tunnel");
+            var resolver = new FixedResolver(sentinel);
+
+            await using var proxy = new AddHocProxy(
+                expectedRequestCount: 1,
+                timeoutSeconds: 30,
+                configureSetting: setting => setting.SetEnableProcessTracking(true),
+                processInfoResolver: resolver);
+
+            using var clientHandler = new HttpClientHandler
+            {
+                Proxy = new WebProxy($"http://{proxy.BindHost}:{proxy.BindPort}")
+            };
+
+            using var httpClient = new HttpClient(clientHandler);
+
+            var response = await httpClient.GetAsync(TestConstants.Http11Host);
+            response.EnsureSuccessStatusCode();
+
+            await proxy.WaitUntilDone();
+
+            var exchange = proxy.CapturedExchanges.FirstOrDefault();
+            Assert.NotNull(exchange);
+            Assert.NotNull(exchange.ProcessInfo);
+            Assert.Equal(sentinel.ProcessId, exchange.ProcessInfo!.ProcessId);
+            Assert.Equal(sentinel.ProcessPath, exchange.ProcessInfo.ProcessPath);
+
+            // The resolver receives the connection identity, including the requested destination.
+            Assert.NotNull(resolver.LastContext);
+            Assert.Equal(proxy.BindPort, resolver.LastContext!.LocalEndPoint.Port);
+            Assert.True(IPAddress.IsLoopback(resolver.LastContext.RemoteEndPoint.Address));
+            Assert.Equal("sandbox.fluxzy.io", resolver.LastContext.RequestedAuthority.HostName);
+            Assert.Equal(443, resolver.LastContext.RequestedAuthority.Port);
+        }
+
+        [Fact]
+        public async Task CustomResolver_NotConsulted_WhenProcessTrackingDisabled()
+        {
+            var resolver = new FixedResolver(new ProcessInfo(1, "x", null));
+
+            await using var proxy = new AddHocProxy(
+                expectedRequestCount: 1,
+                timeoutSeconds: 30,
+                processInfoResolver: resolver);
+
+            using var clientHandler = new HttpClientHandler
+            {
+                Proxy = new WebProxy($"http://{proxy.BindHost}:{proxy.BindPort}")
+            };
+
+            using var httpClient = new HttpClient(clientHandler);
+
+            var response = await httpClient.GetAsync(TestConstants.Http11Host);
+            response.EnsureSuccessStatusCode();
+
+            await proxy.WaitUntilDone();
+
+            var exchange = proxy.CapturedExchanges.FirstOrDefault();
+            Assert.NotNull(exchange);
+            Assert.Null(exchange.ProcessInfo);
+            Assert.Null(resolver.LastContext);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Util/ProcessResolverTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/ProcessResolverTests.cs
@@ -1,0 +1,78 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Utils.ProcessTracking;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Util
+{
+    public class ProcessResolverTests
+    {
+        private sealed class StubProcessTracker : IProcessTracker
+        {
+            private readonly ProcessInfo? _result;
+
+            public StubProcessTracker(ProcessInfo? result) => _result = result;
+
+            public int? RequestedPort { get; private set; }
+
+            public ProcessInfo? GetProcessInfo(int localPort)
+            {
+                RequestedPort = localPort;
+                return _result;
+            }
+        }
+
+        private static ProcessResolutionContext ContextFrom(IPAddress remote, int remotePort)
+        {
+            return new ProcessResolutionContext(
+                new IPEndPoint(remote, remotePort),
+                new IPEndPoint(IPAddress.Loopback, 44344),
+                new Authority("example.com", 443, true));
+        }
+
+        [Fact]
+        public async Task Loopback_ReturnsTrackerResult_KeyedOnSourcePort()
+        {
+            var expected = new ProcessInfo(1234, "/usr/bin/app", "app --flag");
+            var tracker = new StubProcessTracker(expected);
+            var resolver = new LocalTcpTableProcessResolver(tracker);
+
+            var result = await resolver.ResolveAsync(
+                ContextFrom(IPAddress.Loopback, 54321), CancellationToken.None);
+
+            Assert.Same(expected, result);
+            Assert.Equal(54321, tracker.RequestedPort);
+        }
+
+        [Fact]
+        public async Task IPv6Loopback_IsResolved()
+        {
+            var expected = new ProcessInfo(7, "/bin/x", null);
+            var tracker = new StubProcessTracker(expected);
+            var resolver = new LocalTcpTableProcessResolver(tracker);
+
+            var result = await resolver.ResolveAsync(
+                ContextFrom(IPAddress.IPv6Loopback, 9000), CancellationToken.None);
+
+            Assert.Same(expected, result);
+            Assert.Equal(9000, tracker.RequestedPort);
+        }
+
+        [Fact]
+        public async Task NonLoopback_ReturnsNull_WithoutQueryingTracker()
+        {
+            var tracker = new StubProcessTracker(new ProcessInfo(1, "x", null));
+            var resolver = new LocalTcpTableProcessResolver(tracker);
+
+            var result = await resolver.ResolveAsync(
+                ContextFrom(IPAddress.Parse("10.0.0.5"), 54321), CancellationToken.None);
+
+            Assert.Null(result);
+            Assert.Null(tracker.RequestedPort);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/_Fixtures/AddHocProx.cs
+++ b/test/Fluxzy.Tests/_Fixtures/AddHocProx.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Certificates;
 using Fluxzy.Core;
+using Fluxzy.Utils.ProcessTracking;
 using Fluxzy.Writers;
 
 namespace Fluxzy.Tests._Fixtures
@@ -24,10 +25,11 @@ namespace Fluxzy.Tests._Fixtures
 
         private int _requestCount;
 
-        public AddHocProxy(int expectedRequestCount = 1, int timeoutSeconds = 5, Action<FluxzySetting>? configureSetting = null)
+        public AddHocProxy(int expectedRequestCount = 1, int timeoutSeconds = 5, Action<FluxzySetting>? configureSetting = null,
+            IProcessInfoResolver? processInfoResolver = null)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                timeoutSeconds = timeoutSeconds * 5; 
+                timeoutSeconds = timeoutSeconds * 5;
 
             _expectedRequestCount = expectedRequestCount;
 
@@ -41,7 +43,8 @@ namespace Fluxzy.Tests._Fixtures
 
             _proxy = new Proxy(_startupSetting,
                 new CertificateProvider(_startupSetting.CaCertificate,
-                    new InMemoryCertificateCache()), new DefaultCertificateAuthorityManager());
+                    new InMemoryCertificateCache()), new DefaultCertificateAuthorityManager(),
+                processInfoResolver: processInfoResolver);
 
             _proxy.Writer.ExchangeUpdated += ProxyOnBeforeResponse;
 


### PR DESCRIPTION
The built-in process tracking maps a connection source port to a PID through the OS TCP table. That breaks when a transparent tunnel such as tun2socks fronts the proxy over SOCKS5: the socket the proxy accepts belongs to the tunnel, so the lookup resolves to the tunnel process, not the real application. Only the caller, who runs the tunnel and holds its flow table, can map a connection back to the originating process.

This adds a resolver seam so the caller can provide that mapping.

- New IProcessInfoResolver with a ProcessResolutionContext carrying the remote endpoint, the local endpoint, and the requested authority (the CONNECT or SOCKS5 target). The source port and the requested destination are the natural keys against a tunnel flow table.
- The resolver is injected on the Proxy constructor, next to the user agent provider and the DNS solver. EnableProcessTracking stays the on/off switch.
- The default LocalTcpTableProcessResolver preserves the current behavior and is the only place that applies the loopback restriction, so a custom resolver sees every connection.
- Resolution moved from once per exchange to once per downstream connection, which is correct for keep-alive and HTTP/2 multiplexing.

Callers fronting the proxy with a tunnel implement the interface and key off context.RemoteEndPoint.Port or context.RequestedAuthority.
