### PR TITLE
Fix Linux system proxy detection and restore

### DIFF
--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
@@ -32,7 +32,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
 
             Environment.SetEnvironmentVariable("https_proxy", word, EnvironmentVariableTarget.User);
             Environment.SetEnvironmentVariable("http_proxy", word, EnvironmentVariableTarget.User);
-            Environment.SetEnvironmentVariable("no_proxy", word, EnvironmentVariableTarget.User);
+            Environment.SetEnvironmentVariable("no_proxy", noProxy, EnvironmentVariableTarget.User);
 
             return Task.CompletedTask;
         }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
@@ -23,6 +23,8 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
                 Environment.SetEnvironmentVariable("http_proxy", "", EnvironmentVariableTarget.User);
                 Environment.SetEnvironmentVariable("https_proxy", "", EnvironmentVariableTarget.User);
                 Environment.SetEnvironmentVariable("no_proxy", "", EnvironmentVariableTarget.User);
+
+                return Task.CompletedTask;
             }
 
             var word = $"http://{value.BoundHost}:{value.ListenPort}";

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/EnvProxySetter.cs
@@ -55,7 +55,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
             }
 
             if (!string.IsNullOrEmpty(httpsProxySetting)) {
-                var splitTab = httpsProxySetting.Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries);
+                var splitTab = StripScheme(httpsProxySetting).Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (splitTab.Length > 1 && int.TryParse(splitTab.Last(), out var port) && port > 0 && port < 65535) {
                     return Task.FromResult(new SystemProxySetting(string.Join(":", splitTab.SkipLast(1)), port, byPassHosts) {
@@ -65,7 +65,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
             }
 
             if (!string.IsNullOrEmpty(httpProxySetting)) {
-                var splitTab = httpProxySetting.Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries);
+                var splitTab = StripScheme(httpProxySetting).Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (splitTab.Length > 1 && int.TryParse(splitTab.Last(), out var port) && port > 0 && port < 65535) {
                     return Task.FromResult(new SystemProxySetting(string.Join(":", splitTab.SkipLast(1)), port, byPassHosts) {
@@ -77,6 +77,14 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
             return Task.FromResult(new SystemProxySetting("", -1) {
                 Enabled = false
             });
+        }
+
+        // Env values look like "http://host:port"; drop the scheme so it is not kept in the host.
+        private static string StripScheme(string value)
+        {
+            var schemeIndex = value.IndexOf("://", StringComparison.Ordinal);
+
+            return schemeIndex >= 0 ? value.Substring(schemeIndex + 3) : value;
         }
     }
 }

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
@@ -28,33 +28,40 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
 
         public async Task ApplySetting(SystemProxySetting proxySetting)
         {
-            if (ProcessUtils.IsCommandAvailable("gsettings")) {
-                // Gnome based process we set proxy settings via gsettings
+            if (!ProcessUtils.IsCommandAvailable("gsettings")) {
+                // Not a Gnome based environment: keep read and write symmetric by routing
+                // to the same fallback ReadSetting uses.
 
-                if (!proxySetting.Enabled) {
-                    if (proxySetting.PrivateValues.TryGetValue("GSettings.Proxy", out var prev)
-                        && prev is Dictionary<string, object> previousValues) {
-                        // Restore the existing settings
+                await _internalSetter.ApplySetting(proxySetting);
 
-                        foreach (var (key, value) in previousValues) {
-                            SetGSettingValue(key, value);
-                        }
+                return;
+            }
 
-                        return;
+            // Gnome based process we set proxy settings via gsettings
+
+            if (!proxySetting.Enabled) {
+                if (proxySetting.PrivateValues.TryGetValue("GSettings.Proxy", out var prev)
+                    && prev is Dictionary<string, object> previousValues) {
+                    // Restore the existing settings
+
+                    foreach (var (key, value) in previousValues) {
+                        SetGSettingValue(key, value);
                     }
-
-                    // Just disable proxy 
-
-                    await ProcessUtils.QuickRunAsync("gsettings set org.gnome.system.proxy mode 'none'");
 
                     return;
                 }
 
-                SetGSettingValue("org.gnome.system.proxy mode", "manual");
-                SetGSettingValue("org.gnome.system.proxy use-same-proxy", true);
-                SetGSettingValue("org.gnome.system.proxy.http host", proxySetting.BoundHost);
-                SetGSettingValue("org.gnome.system.proxy.http port", proxySetting.ListenPort);
+                // Just disable proxy
+
+                await ProcessUtils.QuickRunAsync("gsettings set org.gnome.system.proxy mode 'none'");
+
+                return;
             }
+
+            SetGSettingValue("org.gnome.system.proxy mode", "manual");
+            SetGSettingValue("org.gnome.system.proxy use-same-proxy", true);
+            SetGSettingValue("org.gnome.system.proxy.http host", proxySetting.BoundHost);
+            SetGSettingValue("org.gnome.system.proxy.http port", proxySetting.ListenPort);
         }
 
         public Task<SystemProxySetting> ReadSetting()

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Fluxzy.Core.Proxy;
@@ -55,7 +56,8 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
             if (!proxySetting.Enabled) {
                 // Just disable proxy
 
-                await ProcessUtils.QuickRunAsync("gsettings set org.gnome.system.proxy mode 'none'");
+                var disableResult = await ProcessUtils.QuickRunAsync("gsettings set org.gnome.system.proxy mode 'none'");
+                LogIfFailed("org.gnome.system.proxy mode", disableResult);
 
                 return;
             }
@@ -123,6 +125,7 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
         private bool SetGSettingValue(string key, string value)
         {
             var result = ProcessUtils.QuickRun($"gsettings set {key}  \"{value}\"");
+            LogIfFailed(key, result);
 
             return result.ExitCode == 0;
         }
@@ -131,8 +134,16 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
         {
             var result = ProcessUtils.QuickRun($"gsettings set {key}  " +
                                                $"\"{JsonSerializer.Serialize(value, value.GetType()).ToGtkJson()}\"");
+            LogIfFailed(key, result);
 
             return result.ExitCode == 0;
+        }
+
+        [Conditional("DEBUG")]
+        private static void LogIfFailed(string key, ProcessRunResult result)
+        {
+            if (result.ExitCode != 0)
+                Debug.WriteLine($"gsettings set {key} failed ({result.ExitCode}): {result.StandardErrorMessage}");
         }
     }
 

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
@@ -39,18 +39,20 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
 
             // Gnome based process we set proxy settings via gsettings
 
-            if (!proxySetting.Enabled) {
-                if (proxySetting.PrivateValues.TryGetValue("GSettings.Proxy", out var prev)
-                    && prev is Dictionary<string, object> previousValues) {
-                    // Restore the existing settings
-
-                    foreach (var (key, value) in previousValues) {
+            // A captured snapshot always wins: replay every key verbatim so the user's prior
+            // configuration is restored exactly, whether or not it had a proxy enabled. Otherwise
+            // a pre-existing manual proxy would be reduced to just mode/host/port.
+            if (proxySetting.PrivateValues.TryGetValue("GSettings.Proxy", out var prev)
+                && prev is Dictionary<string, object?> previousValues) {
+                foreach (var (key, value) in previousValues) {
+                    if (value != null)
                         SetGSettingValue(key, value);
-                    }
-
-                    return;
                 }
 
+                return;
+            }
+
+            if (!proxySetting.Enabled) {
                 // Just disable proxy
 
                 await ProcessUtils.QuickRunAsync("gsettings set org.gnome.system.proxy mode 'none'");

--- a/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
+++ b/src/Fluxzy.Core/Utils/NativeOps/SystemProxySetup/Linux/LinuxProxySetter.cs
@@ -73,15 +73,21 @@ namespace Fluxzy.Utils.NativeOps.SystemProxySetup.Linux
                         previousSettings.Add(key, value);
                 }
 
+                var host = previousSettings["org.gnome.system.proxy.http host"]?.ToString();
+                var port = (int) previousSettings["org.gnome.system.proxy.http port"]!;
+
                 var finalSettings = new SystemProxySetting(
-                    previousSettings["org.gnome.system.proxy.http host"]?.ToString()!,
-                    (int) previousSettings["org.gnome.system.proxy.http port"]!,
+                    host!,
+                    port,
                     previousSettings["org.gnome.system.proxy ignore-hosts"] == null
                         ? Array.Empty<string>()
                         : (string[]) previousSettings["org.gnome.system.proxy ignore-hosts"]!
                 ) {
+                    // gsettings' "http enabled" key is unused (per its own schema): proxying is
+                    // active when mode is manual and a host/port are set.
                     Enabled = previousSettings["org.gnome.system.proxy mode"]?.ToString() == "manual"
-                              && (bool) previousSettings["org.gnome.system.proxy.http enabled"]!,
+                              && !string.IsNullOrEmpty(host)
+                              && port != 0,
                     PrivateValues = {
                         ["GSettings.Proxy"] = previousSettings
                     }


### PR DESCRIPTION
Linux gsettings detection ignored host and port, restore was lossy for an existing manual proxy, and the env fallback had several wrong writes. This fixes detection, restore, and the non-Gnome fallback path.