### PR TITLE
Add host bypass list to UpStreamProxyAction

### DIFF
--- a/src/Fluxzy.Core/Rules/Actions/UpStreamProxyAction.cs
+++ b/src/Fluxzy.Core/Rules/Actions/UpStreamProxyAction.cs
@@ -58,9 +58,9 @@ namespace Fluxzy.Rules.Actions
         ///     True when <paramref name="hostName" /> matches any entry of <paramref name="byPassHosts" />.
         ///     See <see cref="ByPassHosts" /> for the matching rules.
         /// </summary>
-        internal static bool IsByPassed(IReadOnlyCollection<string> byPassHosts, string? hostName)
+        internal static bool IsByPassed(IReadOnlyCollection<string>? byPassHosts, string? hostName)
         {
-            if (hostName == null || byPassHosts.Count == 0)
+            if (hostName == null || byPassHosts == null || byPassHosts.Count == 0)
                 return false;
 
             foreach (var rawEntry in byPassHosts) {

--- a/src/Fluxzy.Core/Rules/Actions/UpStreamProxyAction.cs
+++ b/src/Fluxzy.Core/Rules/Actions/UpStreamProxyAction.cs
@@ -1,5 +1,6 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
@@ -29,18 +30,69 @@ namespace Fluxzy.Rules.Actions
         [ActionDistinctive]
         public string? ProxyAuthorizationHeader { get; set; }
 
+        /// <summary>
+        ///     Hosts that must bypass the upstream proxy and connect directly. Each entry matches the
+        ///     request hostname (port excluded) as follows: <c>*</c> bypasses every host, a bare entry
+        ///     such as <c>example.com</c> matches that host and any of its subdomains, and an explicit
+        ///     <c>*.example.com</c> (or <c>.example.com</c>) matches the domain and its subdomains.
+        ///     Matching is case-insensitive.
+        /// </summary>
+        [ActionDistinctive(Description = "Hosts that bypass the upstream proxy and connect directly")]
+        public List<string> ByPassHosts { get; set; } = new();
+
         public override FilterScope ActionScope => FilterScope.OnAuthorityReceived;
 
-        public override string DefaultDescription => $"Upstream proxy to {Host}:{Port}"; 
+        public override string DefaultDescription => $"Upstream proxy to {Host}:{Port}";
 
         public override ValueTask InternalAlter(
             ExchangeContext context, Exchange? exchange, Connection? connection, FilterScope scope,
             BreakPointManager breakPointManager)
         {
-            if (Host != null! && Port != 0)
+            if (Host != null! && Port != 0 && !IsByPassed(ByPassHosts, context.Authority?.HostName))
                 context.ProxyConfiguration = new ProxyConfiguration(Host, Port, ProxyAuthorizationHeader);
 
             return default;
+        }
+
+        /// <summary>
+        ///     True when <paramref name="hostName" /> matches any entry of <paramref name="byPassHosts" />.
+        ///     See <see cref="ByPassHosts" /> for the matching rules.
+        /// </summary>
+        internal static bool IsByPassed(IReadOnlyCollection<string> byPassHosts, string? hostName)
+        {
+            if (hostName == null || byPassHosts.Count == 0)
+                return false;
+
+            foreach (var rawEntry in byPassHosts) {
+                if (string.IsNullOrWhiteSpace(rawEntry))
+                    continue;
+
+                var entry = rawEntry.Trim();
+
+                if (entry == "*")
+                    return true;
+
+                // Normalize the wildcard form "*.example.com" to a suffix ".example.com".
+                if (entry.StartsWith("*.", StringComparison.Ordinal))
+                    entry = entry.Substring(1);
+
+                if (entry.StartsWith(".", StringComparison.Ordinal)) {
+                    var bare = entry.Substring(1);
+
+                    if (string.Equals(hostName, bare, StringComparison.OrdinalIgnoreCase)
+                        || hostName.EndsWith(entry, StringComparison.OrdinalIgnoreCase))
+                        return true;
+
+                    continue;
+                }
+
+                // Bare host or domain: matches the host itself or any of its subdomains.
+                if (string.Equals(hostName, entry, StringComparison.OrdinalIgnoreCase)
+                    || hostName.EndsWith("." + entry, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
         }
 
         public override IEnumerable<ActionExample> GetExamples()
@@ -52,6 +104,12 @@ namespace Fluxzy.Rules.Actions
                                            " login: leeloo , password: multipass",
                 new UpStreamProxyAction("192.168.1.9", 8080) {
                     ProxyAuthorizationHeader = "Basic bGVlbG9vOm11bHRpcGFzcw=="
+                });
+
+            yield return new ActionExample("Use an upstream proxy to 192.168.1.9 on port 8080 but connect" +
+                                           " directly to localhost and any *.internal.lan host",
+                new UpStreamProxyAction("192.168.1.9", 8080) {
+                    ByPassHosts = { "localhost", "*.internal.lan" }
                 });
         }
     }

--- a/test/Fluxzy.Tests/UnitTests/Rules/UpStreamProxyActionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Rules/UpStreamProxyActionTests.cs
@@ -1,0 +1,141 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Linq;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Rules;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Rules.Filters;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Rules
+{
+    public class UpStreamProxyActionTests
+    {
+        [Theory]
+        // exact host
+        [InlineData("example.com", "example.com", true)]
+        [InlineData("Example.COM", "example.com", true)]
+        [InlineData("other.com", "example.com", false)]
+        // bare domain matches subdomains
+        [InlineData("api.example.com", "example.com", true)]
+        [InlineData("a.b.example.com", "example.com", true)]
+        // no false suffix match
+        [InlineData("notexample.com", "example.com", false)]
+        [InlineData("evil-example.com", "example.com", false)]
+        // explicit wildcard
+        [InlineData("api.internal.lan", "*.internal.lan", true)]
+        [InlineData("internal.lan", "*.internal.lan", true)]
+        [InlineData("internal.lan", ".internal.lan", true)]
+        [InlineData("somethingelse.lan", "*.internal.lan", false)]
+        // catch all
+        [InlineData("anything.at.all", "*", true)]
+        // empty / blank entries are ignored
+        [InlineData("example.com", "  ", false)]
+        public void IsByPassed_Matches_Expected(string hostName, string entry, bool expected)
+        {
+            var result = UpStreamProxyAction.IsByPassed(new[] { entry }, hostName);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void IsByPassed_Empty_List_Never_Matches()
+        {
+            Assert.False(UpStreamProxyAction.IsByPassed(System.Array.Empty<string>(), "example.com"));
+        }
+
+        [Fact]
+        public async Task InternalAlter_Sets_Proxy_When_Host_Not_Bypassed()
+        {
+            var action = new UpStreamProxyAction("192.168.1.9", 8080) {
+                ByPassHosts = { "localhost", "*.internal.lan" }
+            };
+
+            var context = CreateContext("www.example.com");
+
+            await action.InternalAlter(context, null, null, FilterScope.OnAuthorityReceived, null!);
+
+            Assert.NotNull(context.ProxyConfiguration);
+            Assert.Equal("192.168.1.9", context.ProxyConfiguration!.Host);
+            Assert.Equal(8080, context.ProxyConfiguration.Port);
+        }
+
+        [Theory]
+        [InlineData("localhost")]
+        [InlineData("api.internal.lan")]
+        public async Task InternalAlter_Leaves_Direct_When_Host_Bypassed(string hostName)
+        {
+            var action = new UpStreamProxyAction("192.168.1.9", 8080) {
+                ByPassHosts = { "localhost", "*.internal.lan" }
+            };
+
+            var context = CreateContext(hostName);
+
+            await action.InternalAlter(context, null, null, FilterScope.OnAuthorityReceived, null!);
+
+            Assert.Null(context.ProxyConfiguration);
+        }
+
+        [Fact]
+        public void Serialization_Roundtrip_Preserves_ByPassHosts()
+        {
+            var parser = new RuleConfigParser();
+
+            var action = new UpStreamProxyAction("192.168.1.9", 8080) {
+                ProxyAuthorizationHeader = "Basic bGVlbG9vOm11bHRpcGFzcw==",
+                ByPassHosts = { "localhost", "*.internal.lan" }
+            };
+
+            var rule = new Rule(action, new AnyFilter());
+
+            var yaml = parser.GetYamlFromRule(rule);
+
+            var outputRule = parser.TryGetRuleFromYaml(yaml, out var errors)!;
+
+            Assert.True(errors == null || errors.Count == 0);
+
+            var outputAction = (UpStreamProxyAction) outputRule.GetAllActions().Single();
+
+            Assert.Equal("192.168.1.9", outputAction.Host);
+            Assert.Equal(8080, outputAction.Port);
+            Assert.Equal("Basic bGVlbG9vOm11bHRpcGFzcw==", outputAction.ProxyAuthorizationHeader);
+            Assert.Equal(new[] { "localhost", "*.internal.lan" }, outputAction.ByPassHosts);
+        }
+
+        [Fact]
+        public void Reading_Legacy_Config_Without_ByPassHosts_Yields_Empty_List()
+        {
+            var parser = new RuleConfigParser();
+
+            // Pre-existing rule files do not carry the byPassHosts key.
+            var yaml = """
+                filter:
+                  typeKind: AnyFilter
+                action:
+                  typeKind: UpStreamProxyAction
+                  host: 192.168.1.9
+                  port: 8080
+                """;
+
+            var rule = parser.TryGetRuleFromYaml(yaml, out var errors)!;
+
+            Assert.True(errors == null || errors.Count == 0);
+
+            var action = (UpStreamProxyAction) rule.GetAllActions().Single();
+
+            Assert.Equal("192.168.1.9", action.Host);
+            Assert.Equal(8080, action.Port);
+            Assert.NotNull(action.ByPassHosts);
+            Assert.Empty(action.ByPassHosts);
+        }
+
+        private static ExchangeContext CreateContext(string hostName)
+        {
+            var authority = new Authority(hostName, 443, true);
+
+            return new ExchangeContext(authority, new VariableContext(), null,
+                new SetUserAgentActionMapping(null));
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Rules/UpStreamProxyActionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Rules/UpStreamProxyActionTests.cs
@@ -46,6 +46,29 @@ namespace Fluxzy.Tests.UnitTests.Rules
         }
 
         [Fact]
+        public void IsByPassed_Null_List_Never_Matches()
+        {
+            Assert.False(UpStreamProxyAction.IsByPassed(null, "example.com"));
+        }
+
+        [Fact]
+        public async Task InternalAlter_Sets_Proxy_When_ByPassHosts_Is_Null()
+        {
+            // ByPassHosts has a public setter and can be reset to null by a caller or by a
+            // rule file carrying an empty byPassHosts scalar. This must not throw.
+            var action = new UpStreamProxyAction("192.168.1.9", 8080) {
+                ByPassHosts = null!
+            };
+
+            var context = CreateContext("www.example.com");
+
+            await action.InternalAlter(context, null, null, FilterScope.OnAuthorityReceived, null!);
+
+            Assert.NotNull(context.ProxyConfiguration);
+            Assert.Equal("192.168.1.9", context.ProxyConfiguration!.Host);
+        }
+
+        [Fact]
         public async Task InternalAlter_Sets_Proxy_When_Host_Not_Bypassed()
         {
             var action = new UpStreamProxyAction("192.168.1.9", 8080) {


### PR DESCRIPTION
Adds a `ByPassHosts` list to `UpStreamProxyAction` so an upstream proxy rule can connect directly to selected hosts instead of routing them through the proxy.

The match runs at `OnAuthorityReceived`. When the request host matches an entry, the action leaves `ProxyConfiguration` unset, so the exchange falls back to a direct connection, with no downstream change in `PoolBuilder` or the connection pools. Matching is case-insensitive and supports `*` for all hosts, a bare domain such as `example.com` that also covers its subdomains (no false suffix match, so `notexample.com` is not bypassed), and `*.example.com` wildcards.

```yaml
action:
  typeKind: UpStreamProxyAction
  host: 192.168.1.9
  port: 8080
  byPassHosts:
  - localhost
  - '*.internal.lan'
```

`ByPassHosts` defaults to an empty list via an inline field initializer, so existing configurations without the key parse fine and behave exactly as before. The property round-trips through both the YAML and JSON readers.

New `UpStreamProxyActionTests` covers the `IsByPassed` matching matrix, `InternalAlter` behavior for bypassed and non-bypassed hosts, a serialization round-trip, and a legacy config without the key. The full `UnitTests.Rules` suite (502 tests) passes, including the cross-serializer parity test.
