### PR TITLE
Remove network-dependent impersonate block test

### DIFF
--- a/test/Fluxzy.Tests/ImpersonateTests.cs
+++ b/test/Fluxzy.Tests/ImpersonateTests.cs
@@ -1,7 +1,5 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
-using System;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Fluxzy.Clients.Ssl;
@@ -75,31 +73,6 @@ namespace Fluxzy.Tests
 
             Assert.NotNull(ja3Response);
             Assert.Equal(expectedJa3, ja3Response.NormalizedFingerPrint);
-        }
-
-        [Theory]
-        [InlineData("Chrome_Windows_latest")]
-        [InlineData("Firefox_Windows_133")]
-        [InlineData("Firefox_Windows_142")]
-        [InlineData("Chrome_Windows_139")]
-        public async Task CheckBlock(string nameOrConfigfile)
-        {
-            string url = Encoding.UTF8.GetString(Convert.FromBase64String("aHR0cHM6Ly93d3cuZ2FsZXJpZXNsYWZheWV0dGUuY29tL25vdGhpbmc="));
-            int notExpectedStatusCode = 403; 
-
-            await using var proxy = new AddHocConfigurableProxy(1, 10,
-                configureSetting: setting => {
-                    setting.UseBouncyCastleSslEngine();
-                    setting.AddAlterationRulesForAny(new ImpersonateAction(nameOrConfigfile));
-                });
-            
-            using var httpClient = proxy.RunAndGetClient();
-            using var response = await httpClient.GetAsync(url);
-            
-            _ = await response.Content.ReadAsStringAsync();
-
-            Assert.NotEqual(notExpectedStatusCode, (int) response.StatusCode);
-            Assert.NotEqual(528, (int)response.StatusCode);
         }
     }
 }


### PR DESCRIPTION
CheckBlock relied on a live third-party endpoint to decide whether an impersonated TLS fingerprint was blocked. Its result depends on that external service and the egress IP, so it fails intermittently in CI without signalling a real regression. This removes the test and the usings it required.