### PR TITLE
Tolerate closed stdin when feeding the sudo password

### DIFF
--- a/src/Fluxzy.Core/Misc/ProcessUtils.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtils.cs
@@ -308,8 +308,15 @@ namespace Fluxzy.Misc
 
             // sudo -S reads the password (up to the first newline) from stdin, then execs
             // the target. Remaining stdin flows to the child, so the caller can keep writing.
-            await process.StandardInput.WriteLineAsync(password).ConfigureAwait(false);
-            await process.StandardInput.FlushAsync().ConfigureAwait(false);
+            try {
+                await process.StandardInput.WriteLineAsync(password).ConfigureAwait(false);
+                await process.StandardInput.FlushAsync().ConfigureAwait(false);
+            }
+            catch (IOException) {
+                // Under NOPASSWD sudo (or any elevated command that ignores stdin and exits
+                // immediately), the pipe can already be closed before we write the password.
+                // That is benign: the command ran without needing it.
+            }
 
             return process;
         }


### PR DESCRIPTION
StartWithSudoPasswordFile writes the password to the elevated process stdin after starting it. Under NOPASSWD sudo, or whenever the elevated command ignores stdin and exits immediately (rm, cp, update-ca-certificates), the pipe can already be closed by the time we write, raising a broken-pipe IOException that fails the call intermittently. The password write is unnecessary in that case, so this swallows the IOException instead of failing.