### PR TITLE
Fix h2 stream permit leaks and h1 pool idle teardown (#634)

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -32,20 +32,32 @@ namespace Fluxzy.Clients.H11
         private readonly RemoteConnectionBuilder _remoteConnectionBuilder;
         private readonly ITimingProvider _timingProvider;
 
+        // Idle teardown state (the HTTP/1.1 analogue of H2's MonitorIdleAsync).
+        private readonly Action<IHttpConnectionPool>? _onConnectionFaulted;
+        private readonly object _idleGate = new();
+        private volatile bool _complete;
+        private int _activeRequestCount;
+        private DateTime _lastActivity;
+        private PeriodicTimer? _idleTimer;
+        private Task? _idleMonitorTask;
+
         internal Http11ConnectionPool(
             Authority authority,
             RemoteConnectionBuilder remoteConnectionBuilder,
             ITimingProvider timingProvider,
             ProxyRuntimeSetting proxyRuntimeSetting,
             RealtimeArchiveWriter archiveWriter,
-            DnsResolutionResult resolutionResult)
+            DnsResolutionResult resolutionResult,
+            Action<IHttpConnectionPool>? onConnectionFaulted = null)
         {
             _remoteConnectionBuilder = remoteConnectionBuilder;
             _timingProvider = timingProvider;
             _proxyRuntimeSetting = proxyRuntimeSetting;
             _archiveWriter = archiveWriter;
             _resolutionResult = resolutionResult;
+            _onConnectionFaulted = onConnectionFaulted;
             Authority = authority;
+            _lastActivity = timingProvider.Instant();
 
             _pendingConnections = Channel.CreateBounded<Http11ProcessingState>(
                     new BoundedChannelOptions(proxyRuntimeSetting.ConcurrentConnection) {
@@ -58,10 +70,86 @@ namespace Fluxzy.Clients.H11
 
         public Authority Authority { get; }
 
-        public bool Complete => false;
+        /// <summary>
+        ///     True once torn down (idle teardown or disposal), so <see cref="PoolBuilder"/>
+        ///     stops reusing it and evicts it. Was hardcoded <c>false</c>, which left idle
+        ///     HTTP/1.1 pools accumulating one per host (haga-rak/fluxzy.core#634).
+        /// </summary>
+        public bool Complete => _complete;
+
+        /// <summary>Test seam: drive <see cref="TryIdleTeardown"/>'s idle branch without wall-clock waits.</summary>
+        internal DateTime LastActivity {
+            get { lock (_idleGate) { return _lastActivity; } }
+            set { lock (_idleGate) { _lastActivity = value; } }
+        }
 
         public void Init()
         {
+            // Standalone pools (e.g. ConnectionBuilder.CreateH11) pass no callback and keep
+            // their previous never-torn-down behaviour.
+            if (_onConnectionFaulted == null)
+                return;
+
+            var tickSeconds = Math.Clamp(_proxyRuntimeSetting.TimeOutSecondsUnusedConnection, 1, 30);
+            _idleTimer = new PeriodicTimer(TimeSpan.FromSeconds(tickSeconds));
+            _idleMonitorTask = MonitorIdleAsync(_idleTimer);
+        }
+
+        private async Task MonitorIdleAsync(PeriodicTimer timer)
+        {
+            try {
+                while (await timer.WaitForNextTickAsync().ConfigureAwait(false)) {
+                    if (TryIdleTeardown())
+                        return;
+                }
+            }
+            catch (Exception) {
+                // Never propagate from the background loop (cf. haga-rak/fluxzy.core#614).
+            }
+        }
+
+        /// <summary>
+        ///     Tears down the pool when it is idle (no in-flight request, untouched for
+        ///     <c>TimeOutSecondsUnusedConnection</c>): disposes pooled connections and fires
+        ///     the eviction callback. Returns <c>true</c> when the monitor should stop.
+        /// </summary>
+        internal bool TryIdleTeardown()
+        {
+            List<Connection>? idleConnections = null;
+
+            lock (_idleGate) {
+                if (_complete)
+                    return true;
+
+                // Gated against Send's increment so a request that just started cannot have
+                // its pool evicted from under it.
+                if (_activeRequestCount != 0)
+                    return false;
+
+                if (_timingProvider.Instant() - _lastActivity
+                    <= TimeSpan.FromSeconds(_proxyRuntimeSetting.TimeOutSecondsUnusedConnection))
+                    return false;
+
+                _complete = true;
+
+                // Completing the writer makes a late OnExchangeCompleteFunction recycle
+                // (TryWrite) fail, so that connection is freed instead of re-leaking.
+                _pendingConnections.Writer.TryComplete();
+
+                while (_pendingConnections.Reader.TryRead(out var state))
+                    (idleConnections ??= new List<Connection>()).Add(state.Connection);
+            }
+
+            if (idleConnections != null) {
+                foreach (var connection in idleConnections)
+                    FreeConnectionStreams(connection);
+            }
+
+            // Fire-and-forget by contract, so this can't deadlock against DisposeAsync
+            // awaiting the monitor task.
+            _onConnectionFaulted?.Invoke(this);
+
+            return true;
         }
 
         public async ValueTask Send(
@@ -71,6 +159,18 @@ namespace Fluxzy.Clients.H11
             ITimingProvider.Default.Instant();
 
             exchange.HttpVersion = "HTTP/1.1";
+
+            lock (_idleGate) {
+                if (_complete)
+                    // Evicted while idle between PoolBuilder handing it out and this Send.
+                    // Retryable so the orchestrator re-resolves a fresh pool (cf. the
+                    // "Relaunch" path below).
+                    throw new ConnectionCloseException(
+                        "HTTP/1.1 connection pool was evicted after going idle; retry on a fresh pool");
+
+                _activeRequestCount++;
+                _lastActivity = _timingProvider.Instant();
+            }
 
             try {
                 var requestDate = _timingProvider.Instant();
@@ -190,6 +290,11 @@ namespace Fluxzy.Clients.H11
                 }
             }
             finally {
+                lock (_idleGate) {
+                    _activeRequestCount--;
+                    _lastActivity = _timingProvider.Instant();
+                }
+
                 //_semaphoreSlim.Release();
                 ITimingProvider.Default.Instant();
             }
@@ -197,10 +302,10 @@ namespace Fluxzy.Clients.H11
 
         private static void FreeConnectionStreams(Connection connection)
         {
-            connection.ReadStream!.Dispose();
+            connection.ReadStream?.Dispose();
 
             if (connection.ReadStream != connection.WriteStream)
-                connection.WriteStream!.Dispose();
+                connection.WriteStream?.Dispose();
         }
 
         private bool HasConnectionExpired(DateTime instantNow, Http11ProcessingState state)
@@ -222,9 +327,35 @@ namespace Fluxzy.Clients.H11
             return res; 
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            return default;
+            List<Connection>? idleConnections = null;
+
+            // Idempotent with TryIdleTeardown: whichever runs first sets _complete and
+            // drains the channel; the other finds it empty/completed.
+            lock (_idleGate) {
+                _complete = true;
+                _pendingConnections.Writer.TryComplete();
+
+                while (_pendingConnections.Reader.TryRead(out var state))
+                    (idleConnections ??= new List<Connection>()).Add(state.Connection);
+            }
+
+            if (idleConnections != null) {
+                foreach (var connection in idleConnections)
+                    FreeConnectionStreams(connection);
+            }
+
+            _idleTimer?.Dispose();
+
+            if (_idleMonitorTask != null) {
+                try {
+                    await _idleMonitorTask.ConfigureAwait(false);
+                }
+                catch {
+                    // Monitor already swallows; belt-and-braces.
+                }
+            }
         }
 
         public void Dispose()

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -881,6 +881,9 @@ namespace Fluxzy.Clients.H2
                 // orchestrator (ProxyOrchestrator.cs:524) treats it as retryable and
                 // Send() skips the pool-level OnLoopEnd teardown.
                 if (activeStream != null && activeStream.AbandonedByGoAway) {
+                    // Idempotent; covers an abandon that landed before ProcessResponse ran.
+                    _streamPool.NotifyDispose(activeStream);
+
                     throw new ConnectionCloseException(
                         "Stream abandoned after remote GOAWAY; request was not processed",
                         activeStream.AbandonInnerCause);
@@ -893,6 +896,20 @@ namespace Fluxzy.Clients.H2
                     // Send a reset on stream to prevent the remote
                     // from sending further data
                     activeStream.ResetByCaller();
+
+                // Cancellation landed after the stream was registered but before
+                // ProcessResponse could dispose it (e.g. awaiting waitForHeaderSentTask).
+                // NotifyDispose is the sole permit-release path and is idempotent; without
+                // this the permit leaks and ActiveStreamCount stays pinned (#634).
+                if (activeStream != null)
+                    _streamPool.NotifyDispose(activeStream);
+
+                throw;
+            }
+            catch (Exception) when (activeStream != null) {
+                // Same leak via a non-OCE failure (e.g. ProcessResponse's ClientErrorException
+                // on a header wait cancelled without GOAWAY). Idempotent (#634).
+                _streamPool.NotifyDispose(activeStream);
 
                 throw;
             }

--- a/src/Fluxzy.Core/Clients/H2/StreamPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamPool.cs
@@ -99,10 +99,23 @@ namespace Fluxzy.Clients.H2
             if (!_maxConcurrentStreamBarrier.Wait(TimeSpan.Zero))
                 await _maxConcurrentStreamBarrier.WaitAsync(callerCancellationToken).ConfigureAwait(false);
 
-            var res = await CreateActiveStreamAsync(exchange, callerCancellationToken, ongoingStreamInit, resetTokenSource)
-                            .ConfigureAwait(false);
-
-            return res;
+            try {
+                return await CreateActiveStreamAsync(
+                                 exchange, callerCancellationToken, ongoingStreamInit, resetTokenSource)
+                             .ConfigureAwait(false);
+            }
+            catch {
+                // The concurrency permit was acquired above, but stream setup failed before
+                // the StreamWorker was registered in _runningStreams — so NotifyDispose (the
+                // sole release path) will never run for it. Release here; otherwise a setup
+                // cancelled by the caller/pool token (HttpClient timeouts, client aborts, a
+                // GOAWAY flipping the pool to draining) permanently leaks a permit. On a
+                // long-lived pool the permits drain to zero and every new stream stalls,
+                // producing the escalating OperationCanceledException of
+                // haga-rak/fluxzy.core#634.
+                _maxConcurrentStreamBarrier.Release();
+                throw;
+            }
         }
 
         public void NotifyDispose(StreamWorker streamWorker)

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -453,7 +453,12 @@ namespace Fluxzy.Clients.H2
         public async ValueTask ProcessResponse(CancellationToken cancellationToken, H2ConnectionPool cp)
         {
             try {
-                if (!cancellationToken.IsCancellationRequested)
+                // Skip the wait only when the header is already in hand (deliver a response
+                // that raced a late cancellation). Gating on !IsCancellationRequested would
+                // instead let an already-cancelled token fall through with a null
+                // Response.Header and leave this stream registered but undisposed — a silent
+                // permit leak with no exception for the caller to release on (#634).
+                if (!_responseHeadersComplete)
                     await _headerReceivedSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) {

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -178,7 +178,7 @@ namespace Fluxzy.Clients
 
                 var http11ConnectionPool = new Http11ConnectionPool(exchange.Authority,
                     _remoteConnectionBuilder, _timingProvider, proxyRuntimeSetting,
-                    _archiveWriter!, dnsResolutionResult);
+                    _archiveWriter!, dnsResolutionResult, OnConnectionFaulted);
 
                 exchange.HttpVersion = "HTTP/1.1";
 
@@ -224,7 +224,7 @@ namespace Fluxzy.Clients
             if (openingResult.Type == RemoteConnectionResultType.Http11) {
                 var http11ConnectionPool = new Http11ConnectionPool(exchange.Authority,
                     _remoteConnectionBuilder, _timingProvider, proxyRuntimeSetting, _archiveWriter,
-                    dnsResolutionResult);
+                    dnsResolutionResult, OnConnectionFaulted);
 
                 exchange.HttpVersion = exchange.Connection!.HttpVersion = "HTTP/1.1";
 

--- a/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
@@ -1,0 +1,146 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Channels;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H11;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H11Client
+{
+    /// <summary>
+    ///     Reproducer for the HTTP/1.1 pool accumulation confirmed in the heap dump for
+    ///     haga-rak/fluxzy.core#634: an idle <see cref="Http11ConnectionPool"/> was never
+    ///     evicted from PoolBuilder (<c>Complete</c> hardcoded false, H2-only fault callback,
+    ///     no-op dispose), so a proxy hitting many hosts accumulated one immortal pool per
+    ///     host. Drives the new <see cref="Http11ConnectionPool.TryIdleTeardown"/> seam
+    ///     directly (no wall-clock waits).
+    /// </summary>
+    public class Http11ConnectionPoolIdleTeardownTests
+    {
+        [Fact]
+        public void IdlePool_TearsDown_DisposesPooledConnections_AndFiresEviction()
+        {
+            IHttpConnectionPool? evicted = null;
+            var pool = BuildPool(onFaulted: p => evicted = p);
+
+            // An idle recycled connection — what pins a socket + TLS state in the dump.
+            var (connection, readStream, writeStream) = MakePooledConnection();
+            Assert.True(EnqueuePooledConnection(pool, connection),
+                "precondition: pooled connection enqueued");
+
+            pool.LastActivity = DateTime.MinValue; // force the idle clock
+
+            var tornDown = pool.TryIdleTeardown();
+
+            Assert.True(tornDown, "an idle pool must report that it tore down");
+            Assert.True(pool.Complete,
+                "a torn-down pool must be Complete so PoolBuilder evicts it and stops reusing it");
+            Assert.Same(pool, evicted); // eviction callback fired with this pool
+
+            // The pooled connection's transport must be released (the missing reclamation).
+            Assert.True(readStream.Disposed, "pooled connection read stream must be disposed");
+            Assert.True(writeStream.Disposed, "pooled connection write stream must be disposed");
+        }
+
+        [Fact]
+        public void RecentlyUsedPool_IsNotTornDown()
+        {
+            var faulted = 0;
+            var pool = BuildPool(onFaulted: _ => Interlocked.Increment(ref faulted));
+
+            pool.LastActivity = DateTime.UtcNow; // just used
+
+            Assert.False(pool.TryIdleTeardown(), "a recently-used pool must not be torn down");
+            Assert.False(pool.Complete);
+            Assert.Equal(0, faulted);
+        }
+
+        [Fact]
+        public void PoolWithInflightRequest_IsNotTornDown()
+        {
+            var faulted = 0;
+            var pool = BuildPool(onFaulted: _ => Interlocked.Increment(ref faulted));
+
+            SetActiveRequestCount(pool, 1);        // simulate an in-flight Send
+            pool.LastActivity = DateTime.MinValue; // and idle by the wall clock
+
+            Assert.False(pool.TryIdleTeardown(),
+                "a pool with an in-flight request must not be evicted from under it");
+            Assert.False(pool.Complete);
+            Assert.Equal(0, faulted);
+        }
+
+        // ==================================================================
+        // Helpers
+        // ==================================================================
+
+        private static Http11ConnectionPool BuildPool(Action<IHttpConnectionPool> onFaulted)
+        {
+            var authority = new Authority("test.local", 443, true);
+
+            // remoteConnectionBuilder/archiveWriter/DNS are only used by Send, not teardown.
+            // Init() is skipped on purpose so no background timer is left running.
+            return new Http11ConnectionPool(
+                authority,
+                remoteConnectionBuilder: null!,
+                ITimingProvider.Default,
+                ProxyRuntimeSetting.CreateDefault,
+                archiveWriter: null!,
+                resolutionResult: default,
+                onConnectionFaulted: onFaulted);
+        }
+
+        private static (Connection connection, RecordingStream read, RecordingStream write) MakePooledConnection()
+        {
+            var connection = new Connection(new Authority("test.local", 443, true), IIdProvider.FromZero);
+            var read = new RecordingStream();
+            var write = new RecordingStream();
+            connection.ReadStream = read;
+            connection.WriteStream = write;
+            return (connection, read, write);
+        }
+
+        private static bool EnqueuePooledConnection(Http11ConnectionPool pool, Connection connection)
+        {
+            var field = typeof(Http11ConnectionPool).GetField(
+                "_pendingConnections", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var channel = (Channel<Http11ProcessingState>) field!.GetValue(pool)!;
+            return channel.Writer.TryWrite(new Http11ProcessingState(connection, DateTime.UtcNow));
+        }
+
+        private static void SetActiveRequestCount(Http11ConnectionPool pool, int count)
+        {
+            typeof(Http11ConnectionPool)
+                .GetField("_activeRequestCount", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(pool, count);
+        }
+
+        private sealed class RecordingStream : Stream
+        {
+            public bool Disposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                Disposed = true;
+                base.Dispose(disposing);
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => 0;
+            public override long Position { get => 0; set { } }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => 0;
+            public override long Seek(long offset, SeekOrigin origin) => 0;
+            public override void SetLength(long value) { }
+            public override void Write(byte[] buffer, int offset, int count) { }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolStreamCancellationLeakTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2ConnectionPoolStreamCancellationLeakTests.cs
@@ -1,0 +1,118 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients.H2;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    /// <summary>
+    ///     Reproducer for the post-registration permit leak of haga-rak/fluxzy.core#634:
+    ///     when the caller cancels while <see cref="H2ConnectionPool.Send"/> is still setting
+    ///     up a registered stream, the exchange used to unwind without disposing it — leaking
+    ///     a barrier permit and pinning <see cref="StreamPool.ActiveStreamCount"/>. Drives the
+    ///     real Send over a never-answering loopback and asserts a failed exchange leaves zero
+    ///     active streams and all permits restored.
+    /// </summary>
+    public class H2ConnectionPoolStreamCancellationLeakTests
+    {
+        [Fact]
+        public async Task CallerCancellationAfterRegistration_DoesNotLeakPermitOrPinPool()
+        {
+            const int maxConcurrent = 8;
+
+            using var pipe = new DuplexPipe();
+            var baseStream = new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream);
+
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting();
+            setting.Remote.SettingsMaxConcurrentStreams = maxConcurrent;
+
+            var connection = new Connection(authority, new TestIdProvider());
+
+            await using var pool = new H2ConnectionPool(
+                baseStream, setting, authority, connection,
+                onConnectionFaulted: _ => { });
+
+            pool.Init();
+
+            Assert.Equal(maxConcurrent, AvailablePermits(pool));
+
+            // No-body GET: once the header is sent the exchange parks in ProcessResponse
+            // waiting for a response the silent server never sends.
+            var header = "GET / HTTP/2.0\r\nhost: test.local\r\n\r\n".AsMemory();
+            var exchange = new Exchange(new TestIdProvider(), authority, header, "HTTP/2", DateTime.UtcNow);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(0x4000);
+            using var callerCts = new CancellationTokenSource();
+
+            var sendTask = pool.Send(exchange, null!, buffer, null!, callerCts.Token).AsTask();
+
+            // Cancel only once the stream is registered — the window this leak lives in.
+            await WaitForActiveStreamAsync(pool, sendTask);
+
+            Assert.Equal(1, pool.StreamPoolForTests.ActiveStreamCount);
+            Assert.Equal(maxConcurrent - 1, AvailablePermits(pool));
+
+            callerCts.Cancel();
+
+            // Fails with OCE (header-sent wait) or ClientErrorException (ProcessResponse) —
+            // both are the leak's exit paths.
+            await Assert.ThrowsAnyAsync<Exception>(() => WithTimeout(sendTask));
+
+            // Invariant (fails pre-fix): a failed exchange leaves no active stream and
+            // returns every permit it borrowed.
+            Assert.Equal(0, pool.StreamPoolForTests.ActiveStreamCount);
+
+            var leaked = maxConcurrent - AvailablePermits(pool);
+            Assert.True(leaked == 0,
+                $"Leaked {leaked} of {maxConcurrent} concurrency permits after a cancelled " +
+                $"exchange while ActiveStreamCount={pool.StreamPoolForTests.ActiveStreamCount}.");
+        }
+
+        private static async Task WaitForActiveStreamAsync(H2ConnectionPool pool, Task sendTask)
+        {
+            var sw = Stopwatch.StartNew();
+
+            while (pool.StreamPoolForTests.ActiveStreamCount == 0) {
+                if (sendTask.IsCompleted)
+                    // Surfaces the real exception if Send failed before registering a stream.
+                    await sendTask;
+
+                if (sw.Elapsed > TimeSpan.FromSeconds(5))
+                    throw new TimeoutException("Stream was never registered within 5s.");
+
+                await Task.Delay(2);
+            }
+        }
+
+        private static async Task WithTimeout(Task task)
+        {
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var completed = await Task.WhenAny(task, Task.Delay(Timeout.Infinite, timeoutCts.Token));
+
+            if (completed != task)
+                throw new TimeoutException("Send did not complete within 5s after cancellation.");
+
+            timeoutCts.Cancel();
+            await task; // observe / rethrow
+        }
+
+        private static int AvailablePermits(H2ConnectionPool pool)
+        {
+            var field = typeof(StreamPool).GetField(
+                "_maxConcurrentStreamBarrier",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var semaphore = (SemaphoreSlim) field!.GetValue(pool.StreamPoolForTests)!;
+            return semaphore.CurrentCount;
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/H2StreamPoolConcurrencyLeakTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/H2StreamPoolConcurrencyLeakTests.cs
@@ -1,0 +1,132 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    /// <summary>
+    ///     Reproducer for haga-rak/fluxzy.core#634 — "H2ConnectionPool: stray
+    ///     OperationCanceledException escalating over time".
+    ///
+    ///     <para>
+    ///         Every HTTP/2 stream creation acquires one permit from
+    ///         <c>StreamPool._maxConcurrentStreamBarrier</c> (capacity =
+    ///         <see cref="PeerSetting.SettingsMaxConcurrentStreams"/>). That permit is
+    ///         released in exactly one place — <see cref="StreamPool.NotifyDispose"/>,
+    ///         which only runs once the <see cref="StreamWorker"/> has been registered in
+    ///         <c>_runningStreams</c> and later torn down.
+    ///     </para>
+    ///
+    ///     <para>
+    ///         If the caller's (or the linked pool/stream) token is cancelled <em>during
+    ///         stream setup</em> — after the permit is taken in
+    ///         <see cref="StreamPool.CreateNewStreamProcessing"/> but before the worker is
+    ///         registered in <c>CreateActiveStreamAsync</c> — the method throws
+    ///         <see cref="OperationCanceledException"/> and the permit is never returned.
+    ///         Under load this happens constantly (HttpClient timeouts, client aborts).
+    ///         On a long-lived, reused pool the permits drain monotonically to zero; once
+    ///         exhausted, every subsequent stream blocks on the barrier until the caller's
+    ///         own timeout fires — surfacing as the flood of stray
+    ///         <see cref="OperationCanceledException"/> the issue reports, escalating over
+    ///         time, with throughput collapsing. Reverting to HTTP/1.1 (no per-stream
+    ///         barrier) sidesteps it entirely, matching the reporter's observation.
+    ///     </para>
+    ///
+    ///     The test drives the cancellation deterministically (pre-cancelled token, no
+    ///     wall-clock waits) and asserts the invariant: with zero active streams, the pool
+    ///     must hold all of its concurrency permits.
+    /// </summary>
+    public class H2StreamPoolConcurrencyLeakTests
+    {
+        [Fact]
+        public async Task StreamSetupCancellation_DoesNotLeakConcurrencyPermits()
+        {
+            const int maxConcurrent = 2;
+
+            var setting = new H2StreamSetting();
+            setting.Remote.SettingsMaxConcurrentStreams = maxConcurrent;
+
+            var pool = BuildStreamPool(setting);
+
+            Assert.Equal(maxConcurrent, AvailablePermits(pool));
+
+            // Simulate caller/stream cancellations that land *during stream setup*: the
+            // barrier permit is taken, then the wait on the stream-creation lock throws
+            // OperationCanceledException before the StreamWorker is registered.
+            for (var i = 0; i < maxConcurrent; i++) {
+                using var cancelled = new CancellationTokenSource();
+                cancelled.Cancel();
+
+                // An available lock — the cancellation, not contention, is what aborts the
+                // setup. WaitAsync on an already-cancelled token throws without consuming
+                // this permit, so the *only* permit in flight is the barrier one.
+                var ongoingInit = new SemaphoreSlim(1, 1);
+                using var resetCts = new CancellationTokenSource();
+
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                    pool.CreateNewStreamProcessing(null!, cancelled.Token, ongoingInit, resetCts).AsTask());
+            }
+
+            // No stream ever became active — every attempt aborted before registration.
+            Assert.Equal(0, pool.ActiveStreamCount);
+
+            // INVARIANT (fails on buggy code): zero active streams => all permits available.
+            var leaked = maxConcurrent - AvailablePermits(pool);
+            Assert.True(leaked == 0,
+                $"Leaked {leaked} of {maxConcurrent} concurrency permits while ActiveStreamCount=0. " +
+                $"On a long-lived H2 pool these drain to zero and every new stream stalls, " +
+                $"producing the escalating OperationCanceledException of issue #634.");
+
+            // BEHAVIOURAL PROOF: with the permits returned, a clean uncontended creation
+            // succeeds promptly. On buggy code the barrier is depleted and this blocks
+            // until the 5s timeout, throwing the stray OperationCanceledException directly.
+            using var liveReset = new CancellationTokenSource();
+            var liveInit = new SemaphoreSlim(1, 1);
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            var stream = await pool.CreateNewStreamProcessing(null!, timeout.Token, liveInit, liveReset);
+            Assert.NotNull(stream);
+        }
+
+        private static StreamPool BuildStreamPool(H2StreamSetting setting)
+        {
+            var authority = new Authority("test.local", 443, true);
+
+            var hPackEncoder = new HPackEncoder(new EncodingContext(ArrayPoolMemoryProvider<char>.Default));
+            var hPackDecoder = new HPackDecoder(new DecodingContext(authority, ArrayPoolMemoryProvider<char>.Default));
+            var headerEncoder = new HeaderEncoder(hPackEncoder, hPackDecoder, setting);
+
+            var overallWindow = new WindowSizeHolder(setting.OverallWindowSize, 0);
+
+            UpStreamChannel upStreamChannel = (ref WriteTask _) => { };
+
+            var context = new StreamContext(
+                connectionId: 1,
+                authority,
+                setting,
+                headerEncoder,
+                upStreamChannel,
+                overallWindow);
+
+            return new StreamPool(context);
+        }
+
+        private static int AvailablePermits(StreamPool pool)
+        {
+            var field = typeof(StreamPool).GetField(
+                "_maxConcurrentStreamBarrier",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var semaphore = (SemaphoreSlim) field!.GetValue(pool)!;
+            return semaphore.CurrentCount;
+        }
+    }
+}


### PR DESCRIPTION
Fixes the escalating OperationCanceledException and throughput collapse in #634, covering connection-lifecycle leaks found in the lime-fluxzy-spiral heap dump.

An h2 stream cancelled during setup left its StreamPool permit unreleased and ActiveStreamCount pinned, draining permits over time; `CreateNewStreamProcessing`, `InternalSend`, and `ProcessResponse` now release the permit and dispose the stream on every cancelled exit. 