### PR TITLE
Fix unbounded growth of the per-authority lock registry

### DIFF
--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -49,7 +49,9 @@ namespace Fluxzy.Clients
 
         private readonly ConcurrentDictionary<string, DefaultDnsResolver> _dnsSolversCache = new();
 
-        private readonly Synchronizer<Authority> _synchronizer = new(true);
+        // Self-cleaning mode: the per-authority LockInfo/SemaphoreSlim is removed as soon
+        // as no creation is in flight, otherwise the registry grows with each distinct host.
+        private readonly Synchronizer<Authority> _synchronizer = new();
 
         public PoolBuilder(
             RemoteConnectionBuilder remoteConnectionBuilder,

--- a/src/Fluxzy.Core/Utils/Synchronizer.cs
+++ b/src/Fluxzy.Core/Utils/Synchronizer.cs
@@ -50,8 +50,10 @@ namespace Fluxzy.Utils
 
         private void Release(T key, LockInfo lockInfo)
         {
-            Interlocked.Decrement(ref lockInfo.OwnerCount);
+            // Release the semaphore before dropping the owner count: once both counters
+            // read zero, a concurrent cleanup may remove the entry and dispose the semaphore.
             lockInfo.Semaphore.Release();
+            Interlocked.Decrement(ref lockInfo.OwnerCount);
 
             if (_preserve)
                 return;

--- a/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
@@ -102,6 +102,37 @@ namespace Fluxzy.Tests.UnitTests.Util
         }
 
         [Fact]
+        public async Task DefaultMode_HighChurnRemoveRecreateStress()
+        {
+            // Few keys and no work inside the critical section: entries constantly hit
+            // zero owners/waiters and cycle through remove, dispose and recreate
+            var synchronizer = new Synchronizer<Authority>();
+
+            var authorities = Enumerable.Range(0, 4)
+                                        .Select(i => new Authority($"host-{i}.example.com", 443, true))
+                                        .ToArray();
+
+            var owners = new int[authorities.Length];
+            var overlapDetected = false;
+
+            await Task.WhenAll(Enumerable.Range(0, 16).Select(worker => Task.Run(async () => {
+                for (var i = 0; i < 2500; i++) {
+                    var index = (worker + i) % authorities.Length;
+
+                    using var guard = await synchronizer.LockAsync(authorities[index]);
+
+                    if (Interlocked.Increment(ref owners[index]) > 1)
+                        overlapDetected = true;
+
+                    Interlocked.Decrement(ref owners[index]);
+                }
+            })));
+
+            Assert.False(overlapDetected);
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
         public void PoolBuilder_UsesSelfCleaningSynchronizer()
         {
             // Guards against reintroducing the unbounded per-authority lock registry

--- a/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
@@ -1,0 +1,129 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Utils;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Util
+{
+    public class SynchronizerTests
+    {
+        [Fact]
+        public async Task PreserveMode_RetainsOneEntryPerDistinctKey()
+        {
+            // Same configuration as PoolBuilder._synchronizer
+            var synchronizer = new Synchronizer<Authority>(true);
+            const int distinctAuthorityCount = 100;
+
+            for (var i = 0; i < distinctAuthorityCount; i++) {
+                var authority = new Authority($"host-{i}.example.com", 443, true);
+                (await synchronizer.LockAsync(authority)).Dispose();
+            }
+
+            // Nothing is held anymore, yet every LockInfo and its SemaphoreSlim is retained
+            Assert.Equal(distinctAuthorityCount, GetRegistryCount(synchronizer));
+
+            // Re-locking existing keys adds nothing: growth tracks distinct-key discovery only
+            for (var i = 0; i < distinctAuthorityCount; i++) {
+                var authority = new Authority($"host-{i}.example.com", 443, true);
+                (await synchronizer.LockAsync(authority)).Dispose();
+            }
+
+            Assert.Equal(distinctAuthorityCount, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public async Task DefaultMode_RemovesEntryOnceReleased()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            const int distinctAuthorityCount = 100;
+
+            for (var i = 0; i < distinctAuthorityCount; i++) {
+                var authority = new Authority($"host-{i}.example.com", 443, true);
+                (await synchronizer.LockAsync(authority)).Dispose();
+            }
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public async Task DefaultMode_KeepsEntryWhileHeldOrAwaited()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            var authority = new Authority("host.example.com", 443, true);
+
+            var holder = await synchronizer.LockAsync(authority);
+
+            // Registers as waiter synchronously, then awaits the semaphore
+            var waiterTask = synchronizer.LockAsync(authority).AsTask();
+
+            Assert.Equal(1, GetRegistryCount(synchronizer));
+
+            holder.Dispose();
+
+            Assert.Equal(1, GetRegistryCount(synchronizer));
+
+            (await waiterTask).Dispose();
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public async Task DefaultMode_MutualExclusionUnderContention()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            var authority = new Authority("host.example.com", 443, true);
+
+            var concurrentOwners = 0;
+            var overlapDetected = false;
+
+            await Task.WhenAll(Enumerable.Range(0, 32).Select(async _ => {
+                for (var i = 0; i < 20; i++) {
+                    using var guard = await synchronizer.LockAsync(authority);
+
+                    if (Interlocked.Increment(ref concurrentOwners) > 1)
+                        overlapDetected = true;
+
+                    await Task.Yield();
+
+                    Interlocked.Decrement(ref concurrentOwners);
+                }
+            }));
+
+            Assert.False(overlapDetected);
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public void PoolBuilder_UsesSelfCleaningSynchronizer()
+        {
+            // Guards against reintroducing the unbounded per-authority lock registry
+            var poolBuilder = new PoolBuilder(null!, null!, null!, null!);
+
+            var synchronizer = typeof(PoolBuilder)
+                .GetField("_synchronizer", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(poolBuilder)!;
+
+            var preserve = (bool) synchronizer.GetType()
+                .GetField("_preserve", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(synchronizer)!;
+
+            Assert.False(preserve);
+        }
+
+        private static int GetRegistryCount<T>(Synchronizer<T> synchronizer) where T : IEquatable<T>
+        {
+            var locksField = typeof(Synchronizer<T>)
+                .GetField("_locks", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            return ((ICollection) locksField.GetValue(synchronizer)!).Count;
+        }
+    }
+}


### PR DESCRIPTION
The per-authority Synchronizer in PoolBuilder ran in preserve mode, so one LockInfo and SemaphoreSlim stuck around per distinct host for the whole process lifetime (about 34k entries after 71h in a long running capture). Switched to the default self cleaning mode, which drops the entry as soon as no pool creation is in flight. The pool reuse fast path no longer goes through the synchronizer, so the global lock only matters during pool creation anyway.

Also adds Synchronizer tests for both modes and a small guard test so the flag does not silently flip back.