### PR TITLE
Fix cross-host routing on keep-alive plain proxy connections

### DIFF
--- a/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/FromProxyConnectSourceProvider.cs
@@ -183,25 +183,9 @@ namespace Fluxzy.Core
                     stream);
             }
 
-            var path = plainHeader.Path.ToString();
+            if (!AuthorityUtility.TryParsePlainRequestAuthority(plainHeader, null, out var plainAuthority))
+                return new (false, null); // UNABLE TO READ URI FROM CLIENT
 
-            if (!Uri.TryCreate(path, UriKind.Absolute, out var uri)
-                || !uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                var builder = new StringBuilder("http://");
-
-                builder.Append(plainHeader.Authority.Span);
-
-                if (!path.StartsWith("/"))
-                    builder.Append("/");
-
-                builder.Append(path);
-
-                if (!Uri.TryCreate(builder.ToString(), UriKind.Absolute, out uri))
-                    return new (false, null); // UNABLE TO READ URI FROM CLIENT
-            }
-
-            var plainAuthority = new Authority(uri.Host, uri.Port, false);
             var plainExchangeContext = await contextBuilder.Create(plainAuthority, false).ConfigureAwait(false);
 
             var bodyStream = Http11DownStreamPipe.SetChunkedBody(plainHeader, stream);
@@ -212,7 +196,8 @@ namespace Fluxzy.Core
                 plainHeader, bodyStream, "HTTP/1.1", receivedFromProxy);
 
             return new(false, new ExchangeSourceInitResult(new Http11DownStreamPipe(
-                _idProvider, plainAuthority, stream, stream, _contextBuilder), nextExchange));
+                _idProvider, plainAuthority, stream, stream, _contextBuilder,
+                plainAuthorityPerRequest: true), nextExchange));
         }
 
         private record ReadNextBlockResult(

--- a/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
@@ -9,6 +9,7 @@ using Fluxzy.Clients;
 using Fluxzy.Clients.H11;
 using Fluxzy.Misc.ResizableBuffers;
 using Fluxzy.Misc.Streams;
+using Fluxzy.Utils;
 
 namespace Fluxzy.Core
 {
@@ -16,6 +17,8 @@ namespace Fluxzy.Core
     {
         private readonly IIdProvider _idProvider;
         private readonly IExchangeContextBuilder _contextBuilder;
+        private readonly bool _plainAuthorityPerRequest;
+        private readonly int? _plainAuthorityForcedPort;
         private static int _count;
 
         private Stream? _readStream;
@@ -24,10 +27,14 @@ namespace Fluxzy.Core
         public Http11DownStreamPipe(
             IIdProvider idProvider,
             Authority requestedAuthority, Stream readStream, Stream writeStream,
-            IExchangeContextBuilder contextBuilder)
+            IExchangeContextBuilder contextBuilder,
+            bool plainAuthorityPerRequest = false,
+            int? plainAuthorityForcedPort = null)
         {
             _idProvider = idProvider;
             _contextBuilder = contextBuilder;
+            _plainAuthorityPerRequest = plainAuthorityPerRequest;
+            _plainAuthorityForcedPort = plainAuthorityForcedPort;
             RequestedAuthority = requestedAuthority;
             _readStream = readStream;
             _writeStream = writeStream;
@@ -84,11 +91,21 @@ namespace Fluxzy.Core
                     buffer.Buffer.AsSpan(blockReadResult.HeaderLength, remainingLength), _readStream);
             }
 
-            var exchangeContext = await _contextBuilder.Create(RequestedAuthority, RequestedAuthority.Secure).ConfigureAwait(false);
+            var authority = RequestedAuthority;
+
+            // Plain proxy connections carry a per-request authority: routing with the
+            // connection-level one sends the request to whichever host came first
+            // (cross-host contamination, 421). Tunnels (CONNECT, SOCKS5) keep it.
+            if (_plainAuthorityPerRequest
+                && !AuthorityUtility.TryParsePlainRequestAuthority(
+                    secureHeader, _plainAuthorityForcedPort, out authority))
+                return null;
+
+            var exchangeContext = await _contextBuilder.Create(authority, authority.Secure).ConfigureAwait(false);
 
             var bodyStream = SetChunkedBody(secureHeader, _readStream);
 
-            return new Exchange(_idProvider, exchangeContext, RequestedAuthority, secureHeader, bodyStream, null!, receivedFromProxy);
+            return new Exchange(_idProvider, exchangeContext, authority, secureHeader, bodyStream, null!, receivedFromProxy);
         }
 
         public async ValueTask WriteInterimResponse(int statusCode, ReadOnlyMemory<char> reasonPhrase, int _, CancellationToken token)

--- a/src/Fluxzy.Core/Core/ReverseProxyPlainExchangeSourceProvider.cs
+++ b/src/Fluxzy.Core/Core/ReverseProxyPlainExchangeSourceProvider.cs
@@ -10,6 +10,7 @@ using Fluxzy.Clients;
 using Fluxzy.Clients.H11;
 using Fluxzy.Misc.ResizableBuffers;
 using Fluxzy.Misc.Streams;
+using Fluxzy.Utils;
 
 namespace Fluxzy.Core
 {
@@ -60,27 +61,12 @@ namespace Fluxzy.Core
                     plainStream);
             }
 
-            // Plain request 
+            // Plain request
 
-            var path = plainHeader.Path.ToString();
+            if (!AuthorityUtility.TryParsePlainRequestAuthority(
+                    plainHeader, _reverseModeForcedPort, out var plainAuthority))
+                return null; // UNABLE TO READ URI FROM CLIENT
 
-            if (!Uri.TryCreate(path, UriKind.Absolute, out var uri)
-                || !uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-            {
-                var builder = new StringBuilder("http://");
-
-                builder.Append(plainHeader.Authority.Span);
-
-                if (!path.StartsWith("/"))
-                    builder.Append("/");
-
-                builder.Append(path);
-
-                if (!Uri.TryCreate(builder.ToString(), UriKind.Absolute, out uri))
-                    return null; // UNABLE TO READ URI FROM CLIENT
-            }
-
-            var plainAuthority = new Authority(uri.Host, _reverseModeForcedPort ?? uri.Port, false);
             var plainExchangeContext = await _contextBuilder.Create(plainAuthority, false).ConfigureAwait(false);
 
             var bodyStream = Http11DownStreamPipe.SetChunkedBody(plainHeader, plainStream);
@@ -92,7 +78,8 @@ namespace Fluxzy.Core
 
             return new ExchangeSourceInitResult(
                 new Http11DownStreamPipe(_idProvider, plainAuthority, plainStream, plainStream,
-                     _contextBuilder), provisionalExchange);
+                     _contextBuilder, plainAuthorityPerRequest: true,
+                     plainAuthorityForcedPort: _reverseModeForcedPort), provisionalExchange);
         }
     }
 }

--- a/src/Fluxzy.Core/Utils/AuthorityUtility.cs
+++ b/src/Fluxzy.Core/Utils/AuthorityUtility.cs
@@ -1,10 +1,43 @@
 using System;
 using System.Net;
+using System.Text;
+using Fluxzy.Core;
 
 namespace Fluxzy.Utils
 {
     public static class AuthorityUtility
     {
+        /// <summary>
+        /// Resolve the target authority of a plain (non-tunneled) request, from an
+        /// absolute-form URI or the Host header.
+        /// </summary>
+        internal static bool TryParsePlainRequestAuthority(
+            RequestHeader header, int? forcedPort, out Authority authority)
+        {
+            authority = default;
+
+            var path = header.Path.ToString();
+
+            if (!Uri.TryCreate(path, UriKind.Absolute, out var uri)
+                || !uri.Scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
+                var builder = new StringBuilder("http://");
+
+                builder.Append(header.Authority.Span);
+
+                if (!path.StartsWith("/"))
+                    builder.Append("/");
+
+                builder.Append(path);
+
+                if (!Uri.TryCreate(builder.ToString(), UriKind.Absolute, out uri))
+                    return false;
+            }
+
+            authority = new Authority(uri.Host, forcedPort ?? uri.Port, false);
+
+            return true;
+        }
+
         /// <summary>
         /// Parse an authority, accepted separator are ':' and '/'.
         /// </summary>

--- a/test/Fluxzy.Tests/UnitTests/Core/PlainProxyPerRequestAuthorityTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/PlainProxyPerRequestAuthorityTests.cs
@@ -1,0 +1,181 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    /// <summary>
+    ///     Regression test for cross-authority routing on a keep-alive plain HTTP proxy
+    ///     connection: Http11DownStreamPipe used to stamp every request after the first
+    ///     with the connection-level authority, sending it to whichever host came first
+    ///     (wrong body from permissive origins, 421 from strict ones).
+    /// </summary>
+    public class PlainProxyPerRequestAuthorityTests
+    {
+        [Fact]
+        public async Task KeepAlive_Plain_Proxy_Connection_Routes_Each_Request_By_Its_Own_Authority()
+        {
+            await using var originA = new TaggedOrigin("server-a");
+            await using var originB = new TaggedOrigin("server-b");
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            await using var proxy = new Proxy(setting);
+            var proxyPort = proxy.Run().First().Port;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, proxyPort);
+            var stream = client.GetStream();
+
+            // Three absolute-form requests on the same downstream connection,
+            // alternating authorities
+            var first = await SendAbsoluteFormRequest(stream, originA.Port);
+            var second = await SendAbsoluteFormRequest(stream, originB.Port);
+            var third = await SendAbsoluteFormRequest(stream, originA.Port);
+
+            Assert.Equal($"server-a host=127.0.0.1:{originA.Port}", first);
+            Assert.Equal($"server-b host=127.0.0.1:{originB.Port}", second);
+            Assert.Equal($"server-a host=127.0.0.1:{originA.Port}", third);
+        }
+
+        private static async Task<string> SendAbsoluteFormRequest(NetworkStream stream, int targetPort)
+        {
+            var request =
+                $"GET http://127.0.0.1:{targetPort}/resource HTTP/1.1\r\n" +
+                $"Host: 127.0.0.1:{targetPort}\r\n\r\n";
+
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(request));
+
+            var buffer = new byte[65536];
+            var total = 0;
+            int headerEnd;
+
+            while (true) {
+                var read = await stream.ReadAsync(buffer.AsMemory(total));
+
+                if (read == 0)
+                    throw new IOException("Proxy closed the connection");
+
+                total += read;
+
+                headerEnd = Encoding.ASCII.GetString(buffer, 0, total)
+                                    .IndexOf("\r\n\r\n", StringComparison.Ordinal);
+
+                if (headerEnd >= 0)
+                    break;
+            }
+
+            var contentLength = int.Parse(Encoding.ASCII.GetString(buffer, 0, headerEnd)
+                                                  .Split("\r\n")
+                                                  .First(l => l.StartsWith("Content-Length:",
+                                                      StringComparison.OrdinalIgnoreCase))
+                                                  .Split(':')[1].Trim());
+
+            var bodyStart = headerEnd + 4;
+
+            while (total - bodyStart < contentLength) {
+                var read = await stream.ReadAsync(buffer.AsMemory(total));
+
+                if (read == 0)
+                    throw new IOException("Proxy closed the connection mid-body");
+
+                total += read;
+            }
+
+            return Encoding.ASCII.GetString(buffer, bodyStart, contentLength);
+        }
+
+        /// <summary>
+        ///     Keep-alive origin answering every request with its tag and the received Host.
+        /// </summary>
+        private sealed class TaggedOrigin : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly string _tag;
+
+            public TaggedOrigin(string tag)
+            {
+                _tag = tag;
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _ = AcceptLoop();
+            }
+
+            public int Port { get; }
+
+            private async Task AcceptLoop()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                        _ = Serve(client);
+                    }
+                }
+                catch {
+                    // shutting down
+                }
+            }
+
+            private async Task Serve(TcpClient client)
+            {
+                try {
+                    using var _ = client;
+                    var stream = client.GetStream();
+                    var buffer = new byte[16 * 1024];
+
+                    while (!_cts.IsCancellationRequested) {
+                        var total = 0;
+
+                        while (true) {
+                            var read = await stream.ReadAsync(buffer.AsMemory(total), _cts.Token)
+                                                   .ConfigureAwait(false);
+
+                            if (read == 0)
+                                return;
+
+                            total += read;
+
+                            if (Encoding.ASCII.GetString(buffer, 0, total).Contains("\r\n\r\n"))
+                                break;
+                        }
+
+                        var hostValue = Encoding.ASCII.GetString(buffer, 0, total)
+                                                .Split("\r\n")
+                                                .First(l => l.StartsWith("Host:", StringComparison.OrdinalIgnoreCase))
+                                                .Split(':', 2)[1].Trim();
+
+                        var body = $"{_tag} host={hostValue}";
+
+                        var response =
+                            $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n" +
+                            $"Content-Length: {body.Length}\r\nConnection: keep-alive\r\n\r\n{body}";
+
+                        await stream.WriteAsync(Encoding.ASCII.GetBytes(response), _cts.Token)
+                                    .ConfigureAwait(false);
+                    }
+                }
+                catch {
+                    // client or shutdown
+                }
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+                _cts.Dispose();
+
+                return default;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the cross-host contamination reported on 1.39.6-alpha: a feed fetch could receive and persist the body of an unrelated site, and strict origins rejected misdirected requests with 421.

On a keep-alive plain HTTP proxy connection, Http11DownStreamPipe stamped every request after the first with the connection level authority, parsed from the first request only. A request for host B was then routed through host A's connection pool while carrying Host: B. Permissive origins answer that with their default vhost content, strict ones with 421 Misdirected Request. 

The plain forward and reverse proxy providers now enable per-request authority resolution on the pipe, using the same absolute-form URI or Host fallback logic as the first request, factored into AuthorityUtility.TryParsePlainRequestAuthority. Tunneled connections (CONNECT, SOCKS5) keep the connection level authority since their destination is fixed by the tunnel.

Includes a regression test driving three absolute-form requests alternating between two local origins over a single keep-alive client connection; it fails on the previous code.