### PR TITLE
Fix upstream reads hanging forever when the response header never arrives

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -175,6 +175,11 @@ namespace Fluxzy.Clients.H11
             try {
                 var requestDate = _timingProvider.Instant();
 
+                // May still be true from a previous relaunched attempt: it must reflect
+                // the connection actually used by this attempt, otherwise a fresh
+                // connection dying before any response byte relaunches unboundedly.
+                exchange.RecycledConnection = false;
+
                 while (_pendingConnections.Reader.TryRead(out var state)) {
 
                     if (HasConnectionExpired(requestDate, state))
@@ -210,6 +215,7 @@ namespace Fluxzy.Clients.H11
 
                 var poolProcessing = new Http11PoolProcessing(
                     _proxyRuntimeSetting.ExpectContinueTimeout,
+                    _proxyRuntimeSetting.ResponseHeaderTimeout,
                     _proxyRuntimeSetting.GetLogger<Http11PoolProcessing>());
 
                 try {
@@ -257,19 +263,26 @@ namespace Fluxzy.Clients.H11
                 }
                 catch (Exception ex) {
 
-                    // Any "connection is dead" signal must dispose the read stream and
-                    // null the connection so the next attempt opens a fresh one. The
-                    // original code only handled ConnectionCloseException, leaking the
-                    // read stream when TlsFatalAlert / IOException / SocketException
-                    // bubbled through unconverted (e.g. from the request-write path).
+                    // Any exception escaping Process leaves an HTTP/1.1 connection with an
+                    // outstanding request: it is unusable and must be torn down. This
+                    // includes cancellation and timeout, which would otherwise orphan a
+                    // connection whose transport was already aborted.
                     var deadConnSignal = ex is ConnectionCloseException
                         || ex is TlsFatalAlert
                         || ex is IOException
-                        || ex is SocketException;
+                        || ex is SocketException
+                        || ex is OperationCanceledException
+                        || ex is ClientErrorException;
 
                     if (deadConnSignal) {
-                        if (exchange.Connection?.ReadStream != null)
-                            await exchange.Connection.ReadStream.DisposeAsync();
+                        if (exchange.Connection?.ReadStream != null) {
+                            try {
+                                await exchange.Connection.ReadStream.DisposeAsync();
+                            }
+                            catch {
+                                // transport may already be aborted
+                            }
+                        }
 
                         exchange.Connection = null;
                     }
@@ -278,9 +291,9 @@ namespace Fluxzy.Clients.H11
                     // safe to relaunch on a fresh connection regardless of whether the
                     // failure happened on the request write or the response read. The
                     // recycled-and-no-response gate keeps a fresh-connection failure
-                    // (server closes immediately) flowing through as 528.
-                    if (deadConnSignal
-                        && !(ex is ConnectionCloseException)
+                    // (server closes immediately) flowing through as 528. Cancellation
+                    // and timeout (ClientErrorException) never relaunch.
+                    if ((ex is TlsFatalAlert || ex is IOException || ex is SocketException)
                         && exchange.RecycledConnection
                         && exchange.Metrics.ResponseHeaderStart == default) {
                         throw new ConnectionCloseException("Relaunch");

--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -275,6 +275,8 @@ namespace Fluxzy.Clients.H11
                         || ex is ClientErrorException;
 
                     if (deadConnSignal) {
+                        exchange.Connection?.HeaderTimeoutCts?.Dispose();
+
                         if (exchange.Connection?.ReadStream != null) {
                             try {
                                 await exchange.Connection.ReadStream.DisposeAsync();
@@ -315,6 +317,7 @@ namespace Fluxzy.Clients.H11
 
         private static void FreeConnectionStreams(Connection connection)
         {
+            connection.HeaderTimeoutCts?.Dispose();
             connection.ReadStream?.Dispose();
 
             if (connection.ReadStream != connection.WriteStream)

--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -21,11 +21,14 @@ namespace Fluxzy.Clients.H11
     internal class Http11PoolProcessing
     {
         private readonly TimeSpan _expectContinueTimeout;
+        private readonly TimeSpan _responseHeaderTimeout;
         private readonly ILogger _logger;
 
-        public Http11PoolProcessing(TimeSpan expectContinueTimeout, ILogger? logger = null)
+        public Http11PoolProcessing(
+            TimeSpan expectContinueTimeout, TimeSpan responseHeaderTimeout, ILogger? logger = null)
         {
             _expectContinueTimeout = expectContinueTimeout;
+            _responseHeaderTimeout = responseHeaderTimeout;
             _logger = logger ?? NullLogger.Instance;
         }
 
@@ -141,6 +144,19 @@ namespace Fluxzy.Clients.H11
             // produced the final response header.
 
             if (!hasEarlyResponseHeader) {
+                var headerTimeoutEnabled = _responseHeaderTimeout > TimeSpan.Zero &&
+                                           _responseHeaderTimeout != System.Threading.Timeout.InfiniteTimeSpan;
+
+                using var headerReadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                // Closing the transport is the only reliable unblock: the TLS stack may
+                // not observe the token once parked on a read.
+                using var abortRegistration = headerReadCts.Token.Register(
+                    static state => ((Connection) state!).AbortTransport(), exchange.Connection);
+
+                if (headerTimeoutEnabled)
+                    headerReadCts.CancelAfter(_responseHeaderTimeout);
+
                 try {
                     while (true) {
                         headerBlockDetectResult = await Http11HeaderBlockReader.GetNext(exchange.Connection.ReadStream!,
@@ -148,16 +164,21 @@ namespace Fluxzy.Clients.H11
                             () => exchange.Metrics.ResponseHeaderStart = ITimingProvider.Default.Instant(),
                             () => exchange.Metrics.ResponseHeaderEnd = ITimingProvider.Default.Instant(),
                             true,
-                            cancellationToken,
+                            headerReadCts.Token,
                             true).ConfigureAwait(false);
 
                         // Close-notify path: GetNext signals close_notify by returning
                         // HeaderLength = -1. Skip the interim-response sniff (which would
                         // index into the buffer with a negative length) and fall through
                         // so the post-try CloseNotify branch can throw the relaunch
-                        // exception.
-                        if (headerBlockDetectResult.CloseNotify)
+                        // exception. A close caused by our own abort must not take that
+                        // relaunch path: surface the cancellation instead.
+                        if (headerBlockDetectResult.CloseNotify) {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            headerReadCts.Token.ThrowIfCancellationRequested();
+
                             break;
+                        }
 
                         var earlyStatus = HttpHelper.ReadStatusCode(
                             buffer.Buffer.AsSpan(0, headerBlockDetectResult.HeaderLength));
@@ -167,8 +188,12 @@ namespace Fluxzy.Clients.H11
                             // only 100 Continue was silently dropped). Apache-style
                             // origins can send a 100 here even without Expect:
                             // that still needs to reach the client per RFC 9110.
-                            await ForwardInterimToClient(exchange, earlyStatus, cancellationToken)
+                            await ForwardInterimToClient(exchange, earlyStatus, headerReadCts.Token)
                                   .ConfigureAwait(false);
+
+                            if (headerTimeoutEnabled)
+                                headerReadCts.CancelAfter(_responseHeaderTimeout);
+
                             continue;
                         }
 
@@ -176,6 +201,25 @@ namespace Fluxzy.Clients.H11
                     }
                 }
                 catch (Exception ex) {
+                    // Order matters: caller cancellation and timeout both hard-close the
+                    // transport, so the resulting IOException/ObjectDisposedException and
+                    // the Faulted flag must not be mistaken for a dead recycled connection
+                    // (which would relaunch, forever for a tarpit host).
+
+                    if (cancellationToken.IsCancellationRequested) {
+                        throw new OperationCanceledException(
+                            "Exchange was cancelled while waiting for the response header",
+                            ex, cancellationToken);
+                    }
+
+                    if (headerReadCts.IsCancellationRequested) {
+                        throw new ClientErrorException(0,
+                            $"The remote server did not send a response header within " +
+                            $"{(int) _responseHeaderTimeout.TotalSeconds} seconds",
+                            innerMessageException: ex.Message,
+                            networkErrorCode: NetworkErrorCodes.ResponseHeaderTimeout);
+                    }
+
                     // A read failure on a connection that came from the pool, before any
                     // response byte has been seen, means the upstream tore the connection
                     // down while it was idle (TLS close_notify + FIN, or an outright RST).

--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -147,24 +147,39 @@ namespace Fluxzy.Clients.H11
                 var headerTimeoutEnabled = _responseHeaderTimeout > TimeSpan.Zero &&
                                            _responseHeaderTimeout != System.Threading.Timeout.InfiniteTimeSpan;
 
-                using var headerReadCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var connection = exchange.Connection;
+                CancellationTokenSource? timeoutCts = null;
+
+                if (headerTimeoutEnabled) {
+                    // One reusable source per connection: recycled connections re-arm the
+                    // same timer instead of allocating a linked CTS per request.
+                    timeoutCts = connection.HeaderTimeoutCts;
+
+                    if (timeoutCts == null) {
+                        timeoutCts = connection.HeaderTimeoutCts = new CancellationTokenSource();
+
+                        timeoutCts.Token.UnsafeRegister(
+                            static state => ((Connection) state!).AbortTransport(), connection);
+                    }
+                }
 
                 // Closing the transport is the only reliable unblock: the TLS stack may
                 // not observe the token once parked on a read.
-                using var abortRegistration = headerReadCts.Token.Register(
-                    static state => ((Connection) state!).AbortTransport(), exchange.Connection);
+                using var abortRegistration = cancellationToken.UnsafeRegister(
+                    static state => ((Connection) state!).AbortTransport(), connection);
 
-                if (headerTimeoutEnabled)
-                    headerReadCts.CancelAfter(_responseHeaderTimeout);
+                var readToken = timeoutCts?.Token ?? cancellationToken;
 
                 try {
+                    timeoutCts?.CancelAfter(_responseHeaderTimeout);
+
                     while (true) {
                         headerBlockDetectResult = await Http11HeaderBlockReader.GetNext(exchange.Connection.ReadStream!,
                             buffer,
                             () => exchange.Metrics.ResponseHeaderStart = ITimingProvider.Default.Instant(),
                             () => exchange.Metrics.ResponseHeaderEnd = ITimingProvider.Default.Instant(),
                             true,
-                            headerReadCts.Token,
+                            readToken,
                             true).ConfigureAwait(false);
 
                         // Close-notify path: GetNext signals close_notify by returning
@@ -175,7 +190,9 @@ namespace Fluxzy.Clients.H11
                         // relaunch path: surface the cancellation instead.
                         if (headerBlockDetectResult.CloseNotify) {
                             cancellationToken.ThrowIfCancellationRequested();
-                            headerReadCts.Token.ThrowIfCancellationRequested();
+
+                            if (timeoutCts?.IsCancellationRequested == true)
+                                throw new OperationCanceledException(timeoutCts.Token);
 
                             break;
                         }
@@ -188,11 +205,10 @@ namespace Fluxzy.Clients.H11
                             // only 100 Continue was silently dropped). Apache-style
                             // origins can send a 100 here even without Expect:
                             // that still needs to reach the client per RFC 9110.
-                            await ForwardInterimToClient(exchange, earlyStatus, headerReadCts.Token)
+                            await ForwardInterimToClient(exchange, earlyStatus, cancellationToken)
                                   .ConfigureAwait(false);
 
-                            if (headerTimeoutEnabled)
-                                headerReadCts.CancelAfter(_responseHeaderTimeout);
+                            timeoutCts?.CancelAfter(_responseHeaderTimeout);
 
                             continue;
                         }
@@ -212,7 +228,7 @@ namespace Fluxzy.Clients.H11
                             ex, cancellationToken);
                     }
 
-                    if (headerReadCts.IsCancellationRequested) {
+                    if (timeoutCts?.IsCancellationRequested == true) {
                         throw new ClientErrorException(0,
                             $"The remote server did not send a response header within " +
                             $"{(int) _responseHeaderTimeout.TotalSeconds} seconds",
@@ -242,6 +258,10 @@ namespace Fluxzy.Clients.H11
                         innerMessageException: ex.Message,
                         innerException: ex,
                         networkErrorCode: NetworkErrorCodes.ConnectionClosed);
+                }
+                finally {
+                    // Disarm for the next request on this connection; harmless if fired.
+                    timeoutCts?.CancelAfter(System.Threading.Timeout.InfiniteTimeSpan);
                 }
             }
 

--- a/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
+++ b/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
@@ -81,6 +81,8 @@ namespace Fluxzy.Clients
 
             var newlyOpenedStream = connectResult.Stream;
 
+            exchange.Connection.UnderlyingTransport = newlyOpenedStream;
+
             if (proxyConfiguration != null) {
                 exchange.Connection.ProxyConnectStart = _timeProvider.Instant();
 

--- a/src/Fluxzy.Core/Core/Connection.cs
+++ b/src/Fluxzy.Core/Core/Connection.cs
@@ -65,6 +65,13 @@ namespace Fluxzy.Core
         /// </summary>
         internal Stream? UnderlyingTransport { get; set; }
 
+        /// <summary>
+        ///     Reusable response-header timeout source, armed and disarmed per request via
+        ///     CancelAfter so recycled connections pay no per-request allocation. Once fired,
+        ///     the connection is dead and never recycled, so it is never reused cancelled.
+        /// </summary>
+        internal CancellationTokenSource? HeaderTimeoutCts { get; set; }
+
         public int TimeoutIdleSeconds { get; set; } = -1;
 
         public void AddNewRequestProcessed()

--- a/src/Fluxzy.Core/Core/Connection.cs
+++ b/src/Fluxzy.Core/Core/Connection.cs
@@ -58,11 +58,33 @@ namespace Fluxzy.Core
 
         public Stream? ReadStream { get; set; }
 
-        public int TimeoutIdleSeconds { get; set; } = -1; 
+        /// <summary>
+        ///     Raw socket-level stream beneath any TLS layer. Closing it is the only
+        ///     reliable way to unblock a read parked inside a TLS stack that does not
+        ///     observe cancellation tokens.
+        /// </summary>
+        internal Stream? UnderlyingTransport { get; set; }
+
+        public int TimeoutIdleSeconds { get; set; } = -1;
 
         public void AddNewRequestProcessed()
         {
             Interlocked.Increment(ref _requestProcessed);
+        }
+
+        internal void AbortTransport()
+        {
+            try {
+                if (UnderlyingTransport != null) {
+                    UnderlyingTransport.Close();
+                    return;
+                }
+
+                ReadStream?.Close();
+            }
+            catch {
+                // already torn down
+            }
         }
     }
 }

--- a/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
+++ b/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
@@ -1,0 +1,91 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Core
+{
+    /// <summary>
+    ///     Detects a downstream client abort (FIN/RST) while a sequential exchange is parked
+    ///     on upstream I/O and cancels the connection token source so the upstream work is
+    ///     released. Nothing else observes the client socket during that window, which is
+    ///     also what makes the poll race-free: it only runs once the request body has been
+    ///     fully consumed (data still readable then means a pipelined request, not an abort).
+    /// </summary>
+    internal sealed class DownStreamAbortWatchdog : IAsyncDisposable
+    {
+        private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
+
+        private readonly CancellationTokenSource _stopSource = new();
+        private readonly Task _runningTask;
+
+        private DownStreamAbortWatchdog(Socket socket, Exchange exchange, CancellationTokenSource callerTokenSource)
+        {
+            _runningTask = RunAsync(socket, exchange, callerTokenSource, _stopSource.Token);
+        }
+
+        public static DownStreamAbortWatchdog? Start(
+            Socket? socket, Exchange exchange, CancellationTokenSource callerTokenSource)
+        {
+            if (socket == null
+                || exchange.Unprocessed
+                || exchange.Context.BlindMode
+                || exchange.Request.Header.IsWebSocketRequest) {
+                return null;
+            }
+
+            return new DownStreamAbortWatchdog(socket, exchange, callerTokenSource);
+        }
+
+        private static async Task RunAsync(
+            Socket socket, Exchange exchange,
+            CancellationTokenSource callerTokenSource, CancellationToken stopToken)
+        {
+            try {
+                using var timer = new PeriodicTimer(PollInterval);
+
+                while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false)) {
+                    if (exchange.Metrics.RequestBodySent == default)
+                        continue;
+
+                    if (!IsSocketAborted(socket))
+                        continue;
+
+                    callerTokenSource.Cancel();
+
+                    return;
+                }
+            }
+            catch (OperationCanceledException) {
+            }
+            catch (ObjectDisposedException) {
+            }
+        }
+
+        private static bool IsSocketAborted(Socket socket)
+        {
+            try {
+                return socket.Poll(0, SelectMode.SelectRead) && socket.Available == 0;
+            }
+            catch {
+                return true;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _stopSource.Cancel();
+
+            try {
+                await _runningTask.ConfigureAwait(false);
+            }
+            catch {
+                // watchdog never propagates
+            }
+
+            _stopSource.Dispose();
+        }
+    }
+}

--- a/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
+++ b/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
@@ -10,55 +10,72 @@ namespace Fluxzy.Core
     /// <summary>
     ///     Detects a downstream client abort (FIN/RST) while a sequential exchange is parked
     ///     on upstream I/O and cancels the connection token source so the upstream work is
-    ///     released. Nothing else observes the client socket during that window, which is
-    ///     also what makes the poll race-free: it only runs once the request body has been
-    ///     fully consumed (data still readable then means a pipelined request, not an abort).
+    ///     released. One instance lives per downstream connection; exchanges are armed and
+    ///     disarmed via <see cref="Watch"/>/<see cref="Unwatch"/>, so the per-request cost is
+    ///     two uncontended lock operations and no allocation. The poll only runs once the
+    ///     request body has been fully consumed, so nothing else reads the client socket
+    ///     during the check (data still readable then means a pipelined request, not an
+    ///     abort). The gate guarantees no cancel can fire after Unwatch returns.
     /// </summary>
     internal sealed class DownStreamAbortWatchdog : IAsyncDisposable
     {
         private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
 
-        private readonly CancellationTokenSource _stopSource = new();
+        private readonly Socket _socket;
+        private readonly CancellationTokenSource _callerTokenSource;
+        private readonly PeriodicTimer _timer = new(PollInterval);
         private readonly Task _runningTask;
+        private readonly object _gate = new();
 
-        private DownStreamAbortWatchdog(Socket socket, Exchange exchange, CancellationTokenSource callerTokenSource)
+        private Exchange? _watched;
+
+        public DownStreamAbortWatchdog(Socket socket, CancellationTokenSource callerTokenSource)
         {
-            _runningTask = RunAsync(socket, exchange, callerTokenSource, _stopSource.Token);
+            _socket = socket;
+            _callerTokenSource = callerTokenSource;
+            _runningTask = RunAsync();
         }
 
-        public static DownStreamAbortWatchdog? Start(
-            Socket? socket, Exchange exchange, CancellationTokenSource callerTokenSource)
+        public static bool IsEligible(Exchange exchange)
         {
-            if (socket == null
-                || exchange.Unprocessed
-                || exchange.Context.BlindMode
-                || exchange.Request.Header.IsWebSocketRequest) {
-                return null;
+            return !exchange.Unprocessed
+                   && !exchange.Context.BlindMode
+                   && !exchange.Request.Header.IsWebSocketRequest;
+        }
+
+        public void Watch(Exchange exchange)
+        {
+            lock (_gate) {
+                _watched = exchange;
             }
-
-            return new DownStreamAbortWatchdog(socket, exchange, callerTokenSource);
         }
 
-        private static async Task RunAsync(
-            Socket socket, Exchange exchange,
-            CancellationTokenSource callerTokenSource, CancellationToken stopToken)
+        public void Unwatch()
+        {
+            lock (_gate) {
+                _watched = null;
+            }
+        }
+
+        private async Task RunAsync()
         {
             try {
-                using var timer = new PeriodicTimer(PollInterval);
+                while (await _timer.WaitForNextTickAsync().ConfigureAwait(false)) {
+                    lock (_gate) {
+                        var exchange = _watched;
 
-                while (await timer.WaitForNextTickAsync(stopToken).ConfigureAwait(false)) {
-                    if (exchange.Metrics.RequestBodySent == default)
-                        continue;
+                        if (exchange == null || exchange.Metrics.RequestBodySent == default)
+                            continue;
 
-                    if (!IsSocketAborted(socket))
-                        continue;
+                        if (!IsSocketAborted(_socket))
+                            continue;
 
-                    callerTokenSource.Cancel();
+                        _watched = null;
+                        _callerTokenSource.Cancel();
 
-                    return;
+                        return;
+                    }
                 }
-            }
-            catch (OperationCanceledException) {
             }
             catch (ObjectDisposedException) {
             }
@@ -76,7 +93,7 @@ namespace Fluxzy.Core
 
         public async ValueTask DisposeAsync()
         {
-            _stopSource.Cancel();
+            _timer.Dispose();
 
             try {
                 await _runningTask.ConfigureAwait(false);
@@ -84,8 +101,6 @@ namespace Fluxzy.Core
             catch {
                 // watchdog never propagates
             }
-
-            _stopSource.Dispose();
         }
     }
 }

--- a/src/Fluxzy.Core/Core/NetworkErrorCodes.cs
+++ b/src/Fluxzy.Core/Core/NetworkErrorCodes.cs
@@ -17,6 +17,7 @@ namespace Fluxzy.Core
         public const string HostUnreachable = "host_unreachable";
         public const string NetworkUnreachable = "network_unreachable";
         public const string ConnectionClosed = "connection_closed";
+        public const string ResponseHeaderTimeout = "response_header_timeout";
 
         // DNS layer
         public const string DnsNotFound = "dns_notfound";

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -203,11 +203,27 @@ namespace Fluxzy.Core
                 exchange.InterimResponseWriter = (statusCode, reason, ct) =>
                     capturedPipe.WriteInterimResponse(statusCode, reason, capturedStreamId, ct);
 
-                var shouldCloseDownStreamConnection = await EnterProcessExchange(
-                    buffer, closeImmediately, token, exchange,
-                    remoteEndPoint, downStreamClientAddress,
-                    localEndPoint, localEndPointsAddress,
-                    downStreamPipe, callerTokenSource, processInfo);
+                bool shouldCloseDownStreamConnection;
+
+                var abortWatchdog = DownStreamAbortWatchdog.Start(
+                    client.Client, exchange, callerTokenSource);
+
+                try
+                {
+                    shouldCloseDownStreamConnection = await EnterProcessExchange(
+                        buffer, closeImmediately, token, exchange,
+                        remoteEndPoint, downStreamClientAddress,
+                        localEndPoint, localEndPointsAddress,
+                        downStreamPipe, callerTokenSource, processInfo);
+                }
+                finally
+                {
+                    // Fully stopped before the next ReadNextExchange touches the socket,
+                    // otherwise a concurrent poll could mistake a consumed pipelined
+                    // request for an abort.
+                    if (abortWatchdog != null)
+                        await abortWatchdog.DisposeAsync();
+                }
 
                 if (shouldCloseDownStreamConnection)
                 {
@@ -246,10 +262,16 @@ namespace Fluxzy.Core
                 }
                 catch (IOException)
                 {
+                    // Downstream connection is gone: release in-flight exchanges,
+                    // otherwise WaitForAll below can park forever on a wedged upstream.
+                    callerTokenSource.Cancel();
+
                     break;
                 }
                 catch (OperationCanceledException)
                 {
+                    callerTokenSource.Cancel();
+
                     break;
                 }
 

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -163,72 +163,87 @@ namespace Fluxzy.Core
         {
             var processedProvisional = false;
 
-            while (true)
+            DownStreamAbortWatchdog? abortWatchdog = null;
+
+            try
             {
-                using var exchangeScope = new ExchangeScope();
-
-                Exchange? exchange = null;
-
-                try
+                while (true)
                 {
-                    if (!processedProvisional)
+                    using var exchangeScope = new ExchangeScope();
+
+                    Exchange? exchange = null;
+
+                    try
                     {
-                        exchange = provisionalExchange;
-                        processedProvisional = true;
+                        if (!processedProvisional)
+                        {
+                            exchange = provisionalExchange;
+                            processedProvisional = true;
+                        }
+                        else
+                        {
+                            exchange = await downStreamPipe.ReadNextExchange(buffer, exchangeScope, token)
+                                                           .ConfigureAwait(false);
+                        }
+
+                        lastExchangeHolder.Exchange = exchange;
                     }
-                    else
+                    catch (IOException)
                     {
-                        exchange = await downStreamPipe.ReadNextExchange(buffer, exchangeScope, token)
-                                                       .ConfigureAwait(false);
+                        // Client closed mid-read — normal connection-close path.
+                        return;
                     }
 
-                    lastExchangeHolder.Exchange = exchange;
-                }
-                catch (IOException)
-                {
-                    // Client closed mid-read — normal connection-close path.
-                    return;
-                }
+                    if (exchange == null)
+                    {
+                        return;
+                    }
 
-                if (exchange == null)
-                {
-                    return;
+                    // Bridge the upstream pool to the downstream pipe so it can
+                    // forward interim (1xx) responses — notably `100 Continue`
+                    // for `Expect: 100-continue` (issue #624).
+                    var capturedPipe = downStreamPipe;
+                    var capturedStreamId = exchange.StreamIdentifier;
+                    exchange.InterimResponseWriter = (statusCode, reason, ct) =>
+                        capturedPipe.WriteInterimResponse(statusCode, reason, capturedStreamId, ct);
+
+                    bool shouldCloseDownStreamConnection;
+
+                    var watched = DownStreamAbortWatchdog.IsEligible(exchange);
+
+                    if (watched)
+                    {
+                        abortWatchdog ??= new DownStreamAbortWatchdog(client.Client, callerTokenSource);
+                        abortWatchdog.Watch(exchange);
+                    }
+
+                    try
+                    {
+                        shouldCloseDownStreamConnection = await EnterProcessExchange(
+                            buffer, closeImmediately, token, exchange,
+                            remoteEndPoint, downStreamClientAddress,
+                            localEndPoint, localEndPointsAddress,
+                            downStreamPipe, callerTokenSource, processInfo);
+                    }
+                    finally
+                    {
+                        // Disarmed before the next ReadNextExchange touches the socket,
+                        // otherwise a concurrent poll could mistake a consumed pipelined
+                        // request for an abort.
+                        if (watched)
+                            abortWatchdog!.Unwatch();
+                    }
+
+                    if (shouldCloseDownStreamConnection)
+                    {
+                        return;
+                    }
                 }
-
-                // Bridge the upstream pool to the downstream pipe so it can
-                // forward interim (1xx) responses — notably `100 Continue`
-                // for `Expect: 100-continue` (issue #624).
-                var capturedPipe = downStreamPipe;
-                var capturedStreamId = exchange.StreamIdentifier;
-                exchange.InterimResponseWriter = (statusCode, reason, ct) =>
-                    capturedPipe.WriteInterimResponse(statusCode, reason, capturedStreamId, ct);
-
-                bool shouldCloseDownStreamConnection;
-
-                var abortWatchdog = DownStreamAbortWatchdog.Start(
-                    client.Client, exchange, callerTokenSource);
-
-                try
-                {
-                    shouldCloseDownStreamConnection = await EnterProcessExchange(
-                        buffer, closeImmediately, token, exchange,
-                        remoteEndPoint, downStreamClientAddress,
-                        localEndPoint, localEndPointsAddress,
-                        downStreamPipe, callerTokenSource, processInfo);
-                }
-                finally
-                {
-                    // Fully stopped before the next ReadNextExchange touches the socket,
-                    // otherwise a concurrent poll could mistake a consumed pipelined
-                    // request for an abort.
-                    if (abortWatchdog != null)
-                        await abortWatchdog.DisposeAsync();
-                }
-
-                if (shouldCloseDownStreamConnection)
-                {
-                    return;
-                }
+            }
+            finally
+            {
+                if (abortWatchdog != null)
+                    await abortWatchdog.DisposeAsync();
             }
         }
 

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -53,6 +53,7 @@ namespace Fluxzy.Core
             UserAgentProvider = userAgentProvider;
             ConcurrentConnection = startupSetting.ConnectionPerHost;
             ExpectContinueTimeout = startupSetting.ExpectContinueTimeout;
+            ResponseHeaderTimeout = startupSetting.ResponseHeaderTimeout;
             ActionMapping = new SetUserAgentActionMapping(startupSetting.UserAgentActionConfigurationFile);
             LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             ProxyInstanceId = proxyInstanceId;
@@ -100,6 +101,12 @@ namespace Fluxzy.Core
         ///     Matches .NET's default `Expect100ContinueTimeout` of 1 second.
         /// </summary>
         public TimeSpan ExpectContinueTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        ///     Maximum time to wait for the upstream response header after the request has
+        ///     been fully sent. Non-positive or infinite disables the timeout.
+        /// </summary>
+        public TimeSpan ResponseHeaderTimeout { get; set; } = TimeSpan.FromSeconds(100);
 
         public IIdProvider IdProvider { get; set; } = new FromIndexIdProvider(0, 0);
 

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -241,6 +241,19 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Configure how long the proxy waits for the upstream response header once the
+        ///     request has been fully sent. When the delay expires, the upstream connection
+        ///     is aborted and the client receives a 528 carrying the network error code
+        ///     `response_header_timeout`. A value of <see cref="TimeSpan.Zero"/>, negative or
+        ///     <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> disables the timeout.
+        /// </summary>
+        public FluxzySetting SetResponseHeaderTimeout(TimeSpan timeout)
+        {
+            ResponseHeaderTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
         ///     Set the default protocols used by fluxzy
         /// </summary>
         /// <param name="protocols"></param>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -68,6 +68,16 @@ namespace Fluxzy
         public TimeSpan ExpectContinueTimeout { get; internal set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
+        ///     Maximum time fluxzy waits for the upstream response header after the request
+        ///     has been fully sent. When exceeded, the upstream connection is aborted and a
+        ///     528 with network error code `response_header_timeout` is returned. Zero,
+        ///     negative or <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> disables
+        ///     the timeout. Default: 100 seconds (matches `HttpClient.Timeout`).
+        /// </summary>
+        [JsonInclude]
+        public TimeSpan ResponseHeaderTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
+
+        /// <summary>
         ///     Ssl protocols for remote host connection
         /// </summary>
         [JsonInclude]

--- a/test/Fluxzy.Tests/Cases/UpstreamResponseHeaderHangTests.cs
+++ b/test/Fluxzy.Tests/Cases/UpstreamResponseHeaderHangTests.cs
@@ -1,0 +1,264 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Rules.Actions;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    /// <summary>
+    ///     Regression tests for upstream hosts that accept the connection (and the TLS
+    ///     handshake) but never send a response header (haga-rak/fluxzy.core#634).
+    ///     Before the fix, the exchange parked forever on the upstream read: no response
+    ///     header timeout existed, and a downstream client abort was never observed while
+    ///     waiting on upstream.
+    /// </summary>
+    public class UpstreamResponseHeaderHangTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Tarpit_Upstream_Times_Out_With_Response_Header_Timeout(bool useBouncyCastle)
+        {
+            await using var server = TarpitServer.Start(useTls: true);
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            if (useBouncyCastle)
+                setting.UseBouncyCastleSslEngine();
+
+            setting.SetResponseHeaderTimeout(TimeSpan.FromSeconds(2));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            var watch = Stopwatch.StartNew();
+
+            using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+
+            watch.Stop();
+
+            Assert.Equal(528, (int) response.StatusCode);
+
+            Assert.True(response.Headers.TryGetValues("x-fluxzy-network-error", out var errorCodes));
+            Assert.Equal(NetworkErrorCodes.ResponseHeaderTimeout, errorCodes!.First());
+
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20),
+                $"Timeout was configured at 2s but the response took {watch.Elapsed}");
+
+            Assert.True(await server.WaitForTeardown(TimeSpan.FromSeconds(10)),
+                "The hung upstream connection should be aborted when the timeout fires");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Client_Abort_Tears_Down_Hung_Upstream(bool useTls)
+        {
+            await using var server = TarpitServer.Start(useTls);
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseHeaderTimeout(TimeSpan.FromSeconds(120));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(2);
+
+            var url = useTls
+                ? $"https://local.fluxzy.io:{server.Port}/"
+                : $"http://127.0.0.1:{server.Port}/";
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => client.GetAsync(url));
+
+            Assert.True(await server.WaitForTeardown(TimeSpan.FromSeconds(10)),
+                "The hung upstream connection should be torn down shortly after the " +
+                "downstream client aborts, instead of parking until the header timeout");
+        }
+
+        [Fact]
+        public async Task Slow_Response_Within_Timeout_Succeeds()
+        {
+            await using var server = TarpitServer.Start(useTls: true, respondAfter: TimeSpan.FromSeconds(3));
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseHeaderTimeout(TimeSpan.FromSeconds(30));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("ok", body);
+        }
+
+        /// <summary>
+        ///     Accepts connections (optionally completing a TLS handshake), reads the
+        ///     request, then never answers unless <c>respondAfter</c> is set. Signals
+        ///     when its first connection is torn down (FIN, RST or local error).
+        /// </summary>
+        private sealed class TarpitServer : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly bool _useTls;
+            private readonly TimeSpan? _respondAfter;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly Task _acceptLoop;
+
+            private readonly TaskCompletionSource<bool> _tornDown =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private readonly X509Certificate2? _certificate;
+
+            private TarpitServer(bool useTls, TimeSpan? respondAfter)
+            {
+                _useTls = useTls;
+                _respondAfter = respondAfter;
+
+                if (useTls) {
+                    _certificate = new X509Certificate2(
+                        "_Files/Certificates/client-cert.pifix",
+                        CertificateContext.DefaultPassword);
+                }
+
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _acceptLoop = AcceptLoopAsync();
+            }
+
+            public int Port { get; }
+
+            public static TarpitServer Start(bool useTls, TimeSpan? respondAfter = null)
+            {
+                return new TarpitServer(useTls, respondAfter);
+            }
+
+            public async Task<bool> WaitForTeardown(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_tornDown.Task, Task.Delay(timeout, _cts.Token));
+
+                return completed == _tornDown.Task;
+            }
+
+            private async Task AcceptLoopAsync()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                        _ = HandleClientAsync(client);
+                    }
+                }
+                catch {
+                    // listener stopped
+                }
+            }
+
+            private async Task HandleClientAsync(TcpClient client)
+            {
+                try {
+                    using var _ = client;
+
+                    Stream stream = client.GetStream();
+
+                    if (_useTls) {
+                        var sslStream = new SslStream(stream, false);
+
+                        await sslStream.AuthenticateAsServerAsync(_certificate!,
+                            clientCertificateRequired: false,
+                            enabledSslProtocols: SslProtocols.Tls12,
+                            checkCertificateRevocation: false);
+
+                        stream = sslStream;
+                    }
+
+                    var buffer = new byte[16 * 1024];
+                    var received = new StringBuilder();
+                    var requestReceived = false;
+
+                    while (true) {
+                        var read = await stream.ReadAsync(buffer, _cts.Token);
+
+                        if (read == 0)
+                            return;
+
+                        received.Append(Encoding.ASCII.GetString(buffer, 0, read));
+
+                        if (!requestReceived &&
+                            received.ToString().Contains("\r\n\r\n", StringComparison.Ordinal)) {
+                            requestReceived = true;
+
+                            if (_respondAfter != null) {
+                                await Task.Delay(_respondAfter.Value, _cts.Token);
+
+                                var response =
+                                    "HTTP/1.1 200 OK\r\n" +
+                                    "Content-Length: 2\r\n" +
+                                    "Connection: close\r\n" +
+                                    "\r\n" +
+                                    "ok";
+
+                                await stream.WriteAsync(Encoding.ASCII.GetBytes(response), _cts.Token);
+
+                                return;
+                            }
+                        }
+
+                        // Tarpit: never answer, keep draining until the peer goes away
+                    }
+                }
+                catch {
+                    // FIN/RST/abort observed
+                }
+                finally {
+                    _tornDown.TrySetResult(true);
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+
+                try {
+                    await _acceptLoop;
+                }
+                catch {
+                }
+
+                _certificate?.Dispose();
+                _cts.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
An upstream that accepts the connection and the TLS handshake but never sends a response header used to park the exchange forever: no timeout existed on the header read, and a client abort was never noticed while waiting on upstream. Each hit on such a host leaked the async chain, the upstream socket and the pool's active request count. This is the remaining hang behind the spiral discussed in #634.

Adds a ResponseHeaderTimeout setting (default 100s, disableable), armed after the request is fully sent and enforced by closing the upstream transport, since the TLS stack may ignore the token once parked. A timeout surfaces as a 528 with x-fluxzy-network-error: response_header_timeout. A poll based watchdog cancels the exchange when the downstream client goes away, so an abort tears down the hung upstream within about a second. Cancelled or timed out exchanges now dispose their connection instead of orphaning it, and never relaunch. Also resets RecycledConnection between attempts, which could previously cause unbounded relaunching.

Regression tests drive a real proxy against a tarpit origin over both TLS engines; the abort propagation tests fail without the watchdog wiring.