### PR TITLE
Apply response header timeout to h2 upstreams and add body idle timeout

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -216,24 +216,38 @@ namespace Fluxzy.Clients.H11
                 var poolProcessing = new Http11PoolProcessing(
                     _proxyRuntimeSetting.ExpectContinueTimeout,
                     _proxyRuntimeSetting.ResponseHeaderTimeout,
+                    _proxyRuntimeSetting.ResponseBodyIdleTimeout,
                     _proxyRuntimeSetting.GetLogger<Http11PoolProcessing>());
+
+                // Covers the whole exchange (request write, header read, body streaming):
+                // closing the transport is the only reliable unblock, the TLS stack may
+                // not observe the token once parked on a read. Disposed when the exchange
+                // completes, before the connection can be recycled.
+                var abortRegistration = cancellationToken.UnsafeRegister(
+                    static state => ((Connection) state!).AbortTransport(), exchange.Connection);
 
                 try {
                     await poolProcessing.Process(exchange, buffer, exchangeScope, cancellationToken)
                                         .ConfigureAwait(false);
 
                     if (exchange.Response.Header != null)
-                        exchange.Connection.TimeoutIdleSeconds = exchange.Response.Header.TimeoutIdleSeconds; 
-                    
-                    var lastUsed = _timingProvider.Instant(); 
+                        exchange.Connection.TimeoutIdleSeconds = exchange.Response.Header.TimeoutIdleSeconds;
+
+                    var lastUsed = _timingProvider.Instant();
 
                     void OnExchangeCompleteFunction(Task<bool> completeTask)
                     {
-                        var closeConnectionRequest = completeTask.Result;
+                        abortRegistration.Dispose();
+
+                        // A faulted or cancelled completion means the body read failed:
+                        // never recycle, always free. Reading .Result unguarded would
+                        // rethrow here and skip the teardown entirely.
+                        var closeConnectionRequest =
+                            !completeTask.IsCompletedSuccessfully || completeTask.Result;
 
                         if (exchange.Response.Header!.MaxConnection != -1 &&
                             exchange.Response.Header!.MaxConnection <= exchange.Connection.RequestProcessed) {
-                            closeConnectionRequest = true; 
+                            closeConnectionRequest = true;
                         }
 
                         if (exchange.Metrics.ResponseBodyEnd == default)
@@ -244,7 +258,7 @@ namespace Fluxzy.Clients.H11
                                 exchange.Errors.Add(new Error("Error while reading response", exception));
                             }
                         }
-                        else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { // 
+                        else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { //
 
                             if (_pendingConnections.Writer.TryWrite(
                                     new Http11ProcessingState(exchange.Connection, lastUsed)))
@@ -253,15 +267,20 @@ namespace Fluxzy.Clients.H11
                             }
                         }
                         else {
-                            // should close connection 
+                            // should close connection
                         }
-                        
+
                         FreeConnectionStreams(exchange.Connection);
                     }
 
-                    var _ = exchange.Complete.ContinueWith(OnExchangeCompleteFunction, cancellationToken);
+                    // CancellationToken.None: the cleanup must run even when the caller
+                    // has already cancelled, otherwise an aborted exchange leaks its
+                    // connection (the continuation would be cancelled instead of run).
+                    var _ = exchange.Complete.ContinueWith(OnExchangeCompleteFunction, CancellationToken.None);
                 }
                 catch (Exception ex) {
+
+                    abortRegistration.Dispose();
 
                     // Any exception escaping Process leaves an HTTP/1.1 connection with an
                     // outstanding request: it is unusable and must be torn down. This

--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -22,13 +22,16 @@ namespace Fluxzy.Clients.H11
     {
         private readonly TimeSpan _expectContinueTimeout;
         private readonly TimeSpan _responseHeaderTimeout;
+        private readonly TimeSpan _responseBodyIdleTimeout;
         private readonly ILogger _logger;
 
         public Http11PoolProcessing(
-            TimeSpan expectContinueTimeout, TimeSpan responseHeaderTimeout, ILogger? logger = null)
+            TimeSpan expectContinueTimeout, TimeSpan responseHeaderTimeout,
+            TimeSpan responseBodyIdleTimeout, ILogger? logger = null)
         {
             _expectContinueTimeout = expectContinueTimeout;
             _responseHeaderTimeout = responseHeaderTimeout;
+            _responseBodyIdleTimeout = responseBodyIdleTimeout;
             _logger = logger ?? NullLogger.Instance;
         }
 
@@ -163,11 +166,8 @@ namespace Fluxzy.Clients.H11
                     }
                 }
 
-                // Closing the transport is the only reliable unblock: the TLS stack may
-                // not observe the token once parked on a read.
-                using var abortRegistration = cancellationToken.UnsafeRegister(
-                    static state => ((Connection) state!).AbortTransport(), connection);
-
+                // Caller-cancellation hard-close is registered by the pool for the whole
+                // exchange lifetime (request write, header read, body streaming).
                 var readToken = timeoutCts?.Token ?? cancellationToken;
 
                 try {
@@ -332,6 +332,16 @@ namespace Fluxzy.Clients.H11
 
             if (exchange.Response.Header.ContentLength > 0) {
                 bodyStream = new ContentBoundStream(bodyStream, exchange.Response.Header.ContentLength);
+            }
+
+            if (_responseBodyIdleTimeout > TimeSpan.Zero &&
+                _responseBodyIdleTimeout != System.Threading.Timeout.InfiniteTimeSpan) {
+                var bodyConnection = exchange.Connection;
+
+                bodyStream = new ReadIdleTimeoutStream(bodyStream, _responseBodyIdleTimeout,
+                    $"The remote server sent no response body byte for more than " +
+                    $"{(int) _responseBodyIdleTimeout.TotalSeconds} seconds",
+                    bodyConnection.AbortTransport);
             }
 
             exchange.Response.Body = new MetricsStream(bodyStream,

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -287,9 +287,15 @@ namespace Fluxzy.Clients.H2
                 // ConnectionCloseException here means either (a) the pool was already
                 // draining/complete when the exchange arrived, or (b) this stream was
                 // proactively abandoned because the server's GOAWAY LastStreamId ruled
-                // it out. Neither case is a pool-level transport failure — other
-                // in-flight streams on this pool may still complete. Skip OnLoopEnd.
-                if (ex is not ConnectionCloseException)
+                // it out. A response header timeout is a per-stream failure already
+                // settled with RST_STREAM. None of these are pool-level transport
+                // failures — other in-flight streams on this pool may still complete.
+                // Skip OnLoopEnd.
+                var perStreamFailure = ex is ClientErrorException clientError &&
+                                       clientError.ClientError.NetworkErrorCode ==
+                                       NetworkErrorCodes.ResponseHeaderTimeout;
+
+                if (ex is not ConnectionCloseException && !perStreamFailure)
                     OnLoopEnd(ex, true);
 
                 throw;

--- a/src/Fluxzy.Core/Clients/H2/H2StreamSetting.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2StreamSetting.cs
@@ -31,6 +31,13 @@ namespace Fluxzy.Clients.H2
         public int MaxIdleSeconds { get; set; } = 500;
 
         /// <summary>
+        ///     Assigned by the pool builder from the proxy runtime setting; not a user H2 knob.
+        /// </summary>
+        internal TimeSpan ResponseHeaderTimeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        internal TimeSpan ResponseBodyIdleTimeout { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
         ///     Read buffer used by the connection. Should be at least MAX_FRAME_SIZE
         /// </summary>
         public int ReadBufferLength { get; set; } = 0x4000;

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -10,6 +10,7 @@ using Fluxzy.Clients.H2.Frames;
 using Fluxzy.Core;
 using Fluxzy.Logging;
 using Fluxzy.Misc.ResizableBuffers;
+using Fluxzy.Misc.Streams;
 
 namespace Fluxzy.Clients.H2
 {
@@ -458,8 +459,39 @@ namespace Fluxzy.Clients.H2
                 // instead let an already-cancelled token fall through with a null
                 // Response.Header and leave this stream registered but undisposed — a silent
                 // permit leak with no exception for the caller to release on (#634).
-                if (!_responseHeadersComplete)
-                    await _headerReceivedSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (!_responseHeadersComplete) {
+                    var headerTimeout = Parent.Context.Setting.ResponseHeaderTimeout;
+
+                    var headerTimeoutEnabled = headerTimeout > TimeSpan.Zero &&
+                                               headerTimeout != Timeout.InfiniteTimeSpan;
+
+                    if (!headerTimeoutEnabled) {
+                        await _headerReceivedSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    }
+                    else {
+                        while (true) {
+                            var acquired = await _headerReceivedSemaphore
+                                                 .WaitAsync(headerTimeout, cancellationToken)
+                                                 .ConfigureAwait(false);
+
+                            if (acquired)
+                                break;
+
+                            // The response wait runs concurrently with the request body
+                            // upload (gRPC-style). The budget only counts once the request
+                            // has been fully sent, matching the HTTP/1.1 semantics.
+                            if (_exchange.Metrics.RequestBodySent == default)
+                                continue;
+
+                            ResetByCaller(H2ErrorCode.Cancel);
+
+                            throw new ClientErrorException(0,
+                                $"The remote server did not send a response header within " +
+                                $"{(int) headerTimeout.TotalSeconds} seconds",
+                                networkErrorCode: NetworkErrorCodes.ResponseHeaderTimeout);
+                        }
+                    }
+                }
             }
             catch (OperationCanceledException) {
                 if (_abandonedByGoAway) {
@@ -479,15 +511,46 @@ namespace Fluxzy.Clients.H2
                 throw;
             }
 
-            _exchange.Response.Body = _pipeResponseBody.Reader.AsStream();
+            var responseBodyStream = _pipeResponseBody.Reader.AsStream();
+            var bodyIdleTimeout = Parent.Context.Setting.ResponseBodyIdleTimeout;
+
+            if (!_noBodyStream
+                && bodyIdleTimeout > TimeSpan.Zero
+                && bodyIdleTimeout != Timeout.InfiniteTimeSpan) {
+                _exchange.Response.Body = new ReadIdleTimeoutStream(responseBodyStream, bodyIdleTimeout,
+                    $"The remote server sent no response body byte for more than " +
+                    $"{(int) bodyIdleTimeout.TotalSeconds} seconds",
+                    AbandonAsBodyIdleTimeout);
+            }
+            else {
+                _exchange.Response.Body = responseBodyStream;
+            }
 
             if (_noBodyStream) {
-                // This stream as no more body 
+                // This stream as no more body
                 await _pipeResponseBody.Writer.CompleteAsync().ConfigureAwait(false);
 
                 _exchange.ExchangeCompletionSource.TrySetResult(false);
                 Parent.NotifyDispose(this);
             }
+        }
+
+        /// <summary>
+        ///     Body idle timeout: reset the stream and unblock the parked pipe read.
+        ///     Runs on a timer thread, so only thread-safe members are touched
+        ///     (RST via the write channel, idempotent completion and dispose,
+        ///     CancelPendingRead by contract).
+        /// </summary>
+        internal void AbandonAsBodyIdleTimeout()
+        {
+            ResetByCaller(H2ErrorCode.Cancel);
+
+            _exchange.ExchangeCompletionSource.TrySetException(
+                new ExchangeException("Response body idle timeout reached"));
+
+            _pipeResponseBody.Reader.CancelPendingRead();
+
+            Parent.NotifyDispose(this);
         }
 
         public void ReceiveBodyFragmentFromConnection(ReadOnlyMemory<byte> buffer, bool endStream)

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -239,10 +239,15 @@ namespace Fluxzy.Clients
             }
 
             if (openingResult.Type == RemoteConnectionResultType.Http2) {
+                var h2StreamSetting = exchange.Context.AdvancedTlsSettings.H2StreamSetting ?? new H2StreamSetting();
+
+                h2StreamSetting.ResponseHeaderTimeout = proxyRuntimeSetting.ResponseHeaderTimeout;
+                h2StreamSetting.ResponseBodyIdleTimeout = proxyRuntimeSetting.ResponseBodyIdleTimeout;
+
                 var h2ConnectionPool = new H2ConnectionPool(
                     openingResult.Connection
                                  .ReadStream!, // Read and write stream are the same after the sslhandshake
-                    exchange.Context.AdvancedTlsSettings.H2StreamSetting ?? new H2StreamSetting(),
+                    h2StreamSetting,
                     exchange.Authority, exchange.Connection!, OnConnectionFaulted,
                     proxyRuntimeSetting.GetLogger<H2ConnectionPool>());
 

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -758,10 +758,12 @@ namespace Fluxzy.Core
                         {
                             if (ex is IOException || ex is OperationCanceledException)
                             {
-                                // Local connection may close the underlying stream before 
-                                // receiving the entire message. Particulary when waiting for the last 0\r\n\r\n on chunked stream.
-                                // In that case, we just leave
-                                // without any error
+                                // Two cases land here: the client closed early (harmless),
+                                // or the upstream body read failed mid-response (reset,
+                                // idle timeout, abort). Either way the response is
+                                // incomplete, so the downstream connection must be closed:
+                                // keeping it alive would leave the client waiting for
+                                // bytes that will never come, or desync the next exchange.
 
                                 if (ex is IOException && ex.InnerException is SocketException sex)
                                 {
@@ -775,7 +777,7 @@ namespace Fluxzy.Core
                                     }
                                 }
 
-                                return false;
+                                return true;
                             }
 
                             throw;

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -54,6 +54,7 @@ namespace Fluxzy.Core
             ConcurrentConnection = startupSetting.ConnectionPerHost;
             ExpectContinueTimeout = startupSetting.ExpectContinueTimeout;
             ResponseHeaderTimeout = startupSetting.ResponseHeaderTimeout;
+            ResponseBodyIdleTimeout = startupSetting.ResponseBodyIdleTimeout;
             ActionMapping = new SetUserAgentActionMapping(startupSetting.UserAgentActionConfigurationFile);
             LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             ProxyInstanceId = proxyInstanceId;
@@ -107,6 +108,12 @@ namespace Fluxzy.Core
         ///     been fully sent. Non-positive or infinite disables the timeout.
         /// </summary>
         public TimeSpan ResponseHeaderTimeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        /// <summary>
+        ///     Maximum time between two successive upstream response body reads.
+        ///     Non-positive or infinite disables the timeout (the default).
+        /// </summary>
+        public TimeSpan ResponseBodyIdleTimeout { get; set; } = TimeSpan.Zero;
 
         public IIdProvider IdProvider { get; set; } = new FromIndexIdProvider(0, 0);
 

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -254,6 +254,21 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Configure the maximum time the proxy waits between two successive response
+        ///     body reads from the upstream before aborting the exchange (HTTP/1.1: the
+        ///     connection is closed, HTTP/2: the stream is reset). Off by default; a value
+        ///     of <see cref="TimeSpan.Zero"/>, negative or
+        ///     <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> disables it. Leave
+        ///     disabled when proxying streams that can legitimately stay quiet for long
+        ///     periods (server-sent events, long polling).
+        /// </summary>
+        public FluxzySetting SetResponseBodyIdleTimeout(TimeSpan timeout)
+        {
+            ResponseBodyIdleTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
         ///     Set the default protocols used by fluxzy
         /// </summary>
         /// <param name="protocols"></param>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -78,6 +78,15 @@ namespace Fluxzy
         public TimeSpan ResponseHeaderTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
 
         /// <summary>
+        ///     Maximum time fluxzy waits between two successive response body reads from the
+        ///     upstream. When exceeded, the exchange is aborted (HTTP/1.1: the connection is
+        ///     closed, HTTP/2: the stream is reset). Disabled by default because legitimate
+        ///     streams can stay quiet for long periods (server-sent events, long polling).
+        /// </summary>
+        [JsonInclude]
+        public TimeSpan ResponseBodyIdleTimeout { get; internal set; } = TimeSpan.Zero;
+
+        /// <summary>
         ///     Ssl protocols for remote host connection
         /// </summary>
         [JsonInclude]

--- a/src/Fluxzy.Core/Misc/Streams/ReadIdleTimeoutStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ReadIdleTimeoutStream.cs
@@ -1,0 +1,117 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Misc.Streams
+{
+    /// <summary>
+    ///     Read-only pass-through that bounds the time between two successive reads.
+    ///     The deadline is re-armed before each read and disarmed after, so a slow but
+    ///     steady stream never trips it. On expiry the provided callback must unblock
+    ///     the pending inner read out of band (closing the transport, cancelling a pipe
+    ///     read), after which the failure surfaces as a timeout IOException.
+    /// </summary>
+    internal sealed class ReadIdleTimeoutStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly TimeSpan _idleTimeout;
+        private readonly string _timeoutMessage;
+        private readonly CancellationTokenSource _timeoutCts = new();
+
+        private volatile bool _timedOut;
+
+        public ReadIdleTimeoutStream(
+            Stream inner, TimeSpan idleTimeout, string timeoutMessage, Action onTimeout)
+        {
+            _inner = inner;
+            _idleTimeout = idleTimeout;
+            _timeoutMessage = timeoutMessage;
+
+            _timeoutCts.Token.UnsafeRegister(static state => {
+                var (stream, callback) = ((ReadIdleTimeoutStream, Action)) state!;
+                stream._timedOut = true;
+                callback();
+            }, (this, onTimeout));
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _timeoutCts.CancelAfter(_idleTimeout);
+
+            try {
+                return await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (_timedOut) {
+                throw new IOException(_timeoutMessage, ex);
+            }
+            finally {
+                _timeoutCts.CancelAfter(Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            _timeoutCts.CancelAfter(_idleTimeout);
+
+            try {
+                return _inner.Read(buffer, offset, count);
+            }
+            catch (Exception ex) when (_timedOut) {
+                throw new IOException(_timeoutMessage, ex);
+            }
+            finally {
+                _timeoutCts.CancelAfter(Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) {
+                _timeoutCts.Dispose();
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            _timeoutCts.Dispose();
+            await _inner.DisposeAsync().ConfigureAwait(false);
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/Cases/UpstreamStallTests.cs
+++ b/test/Fluxzy.Tests/Cases/UpstreamStallTests.cs
@@ -1,0 +1,473 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Rules.Actions;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    /// <summary>
+    ///     Follow-up coverage for haga-rak/fluxzy.core#634: the response header timeout on
+    ///     HTTP/2 upstreams and the opt-in response body idle timeout on both protocols.
+    /// </summary>
+    public class UpstreamStallTests
+    {
+        [Fact]
+        public async Task H2_Tarpit_Times_Out_With_Response_Header_Timeout()
+        {
+            await using var server = H2StallServer.Start(sendPartialBodyOnRequest: false);
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseHeaderTimeout(TimeSpan.FromSeconds(2));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            var watch = Stopwatch.StartNew();
+
+            using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+
+            watch.Stop();
+
+            Assert.Equal(528, (int) response.StatusCode);
+
+            Assert.True(response.Headers.TryGetValues("x-fluxzy-network-error", out var errorCodes));
+            Assert.Equal(NetworkErrorCodes.ResponseHeaderTimeout, errorCodes!.First());
+
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20),
+                $"Timeout was configured at 2s but the response took {watch.Elapsed}");
+
+            Assert.True(await server.WaitForRstStream(TimeSpan.FromSeconds(10)),
+                "The timed out stream should be reset instead of leaving the server waiting");
+        }
+
+        [Fact]
+        public async Task H2_Stalled_Response_Body_Aborted_By_Idle_Timeout()
+        {
+            await using var server = H2StallServer.Start(sendPartialBodyOnRequest: true);
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseBodyIdleTimeout(TimeSpan.FromSeconds(2));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            var watch = Stopwatch.StartNew();
+
+            await Assert.ThrowsAnyAsync<HttpRequestException>(async () => {
+                using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+                await response.Content.ReadAsStringAsync();
+            });
+
+            watch.Stop();
+
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20),
+                $"Idle timeout was configured at 2s but the failure took {watch.Elapsed}");
+
+            Assert.True(await server.WaitForRstStream(TimeSpan.FromSeconds(10)),
+                "The stalled stream should be reset");
+        }
+
+        [Fact]
+        public async Task H1_Stalled_Response_Body_Aborted_By_Idle_Timeout()
+        {
+            await using var server = H1BodyStallServer.Start(dripDelay: null);
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseBodyIdleTimeout(TimeSpan.FromSeconds(2));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            var watch = Stopwatch.StartNew();
+
+            await Assert.ThrowsAnyAsync<HttpRequestException>(async () => {
+                using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+                await response.Content.ReadAsStringAsync();
+            });
+
+            watch.Stop();
+
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20),
+                $"Idle timeout was configured at 2s but the failure took {watch.Elapsed}");
+
+            Assert.True(await server.WaitForTeardown(TimeSpan.FromSeconds(10)),
+                "The stalled upstream connection should be aborted");
+        }
+
+        [Fact]
+        public async Task H1_Slow_Drip_Body_Within_Idle_Timeout_Succeeds()
+        {
+            await using var server = H1BodyStallServer.Start(dripDelay: TimeSpan.FromMilliseconds(400));
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            setting.SetResponseBodyIdleTimeout(TimeSpan.FromSeconds(3));
+
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal("abcdef", body);
+        }
+
+        /// <summary>
+        ///     HTTP/1.1 over TLS origin that answers with Content-Length: 6 and either
+        ///     drips one byte per <c>dripDelay</c> (completing normally) or sends 2 bytes
+        ///     and stalls forever.
+        /// </summary>
+        private sealed class H1BodyStallServer : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly TimeSpan? _dripDelay;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly Task _acceptLoop;
+            private readonly X509Certificate2 _certificate;
+
+            private readonly TaskCompletionSource<bool> _tornDown =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private H1BodyStallServer(TimeSpan? dripDelay)
+            {
+                _dripDelay = dripDelay;
+
+                _certificate = new X509Certificate2(
+                    "_Files/Certificates/client-cert.pifix",
+                    CertificateContext.DefaultPassword);
+
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _acceptLoop = AcceptLoopAsync();
+            }
+
+            public int Port { get; }
+
+            public static H1BodyStallServer Start(TimeSpan? dripDelay)
+            {
+                return new H1BodyStallServer(dripDelay);
+            }
+
+            public async Task<bool> WaitForTeardown(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_tornDown.Task, Task.Delay(timeout, _cts.Token));
+
+                return completed == _tornDown.Task;
+            }
+
+            private async Task AcceptLoopAsync()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                        _ = HandleClientAsync(client);
+                    }
+                }
+                catch {
+                    // listener stopped
+                }
+            }
+
+            private async Task HandleClientAsync(TcpClient client)
+            {
+                try {
+                    using var _ = client;
+
+                    await using var sslStream = new SslStream(client.GetStream(), false);
+
+                    await sslStream.AuthenticateAsServerAsync(_certificate,
+                        clientCertificateRequired: false,
+                        enabledSslProtocols: SslProtocols.Tls12,
+                        checkCertificateRevocation: false);
+
+                    var buffer = new byte[16 * 1024];
+                    var received = new StringBuilder();
+
+                    while (!received.ToString().Contains("\r\n\r\n", StringComparison.Ordinal)) {
+                        var read = await sslStream.ReadAsync(buffer, _cts.Token);
+
+                        if (read == 0)
+                            return;
+
+                        received.Append(Encoding.ASCII.GetString(buffer, 0, read));
+                    }
+
+                    var body = "abcdef"u8.ToArray();
+
+                    var header =
+                        "HTTP/1.1 200 OK\r\n" +
+                        $"Content-Length: {body.Length}\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "\r\n";
+
+                    await sslStream.WriteAsync(Encoding.ASCII.GetBytes(header), _cts.Token);
+
+                    if (_dripDelay == null) {
+                        await sslStream.WriteAsync(body.AsMemory(0, 2), _cts.Token);
+                        await sslStream.FlushAsync(_cts.Token);
+
+                        // Stall: never send the remaining bytes, wait for the peer to go away
+                        while (true) {
+                            var read = await sslStream.ReadAsync(buffer, _cts.Token);
+
+                            if (read == 0)
+                                return;
+                        }
+                    }
+
+                    foreach (var b in body) {
+                        await Task.Delay(_dripDelay.Value, _cts.Token);
+                        await sslStream.WriteAsync(new[] { b }, _cts.Token);
+                        await sslStream.FlushAsync(_cts.Token);
+                    }
+
+                    while (true) {
+                        var read = await sslStream.ReadAsync(buffer, _cts.Token);
+
+                        if (read == 0)
+                            return;
+                    }
+                }
+                catch {
+                    // FIN/RST/abort observed
+                }
+                finally {
+                    _tornDown.TrySetResult(true);
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+
+                try {
+                    await _acceptLoop;
+                }
+                catch {
+                }
+
+                _certificate.Dispose();
+                _cts.Dispose();
+            }
+        }
+
+        /// <summary>
+        ///     Minimal raw HTTP/2 origin (TLS, ALPN h2). Completes the SETTINGS exchange,
+        ///     then either ignores request HEADERS forever (tarpit) or answers with
+        ///     `:status: 200` plus a partial DATA frame and stalls. Records whether an
+        ///     RST_STREAM ever arrives.
+        /// </summary>
+        private sealed class H2StallServer : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly bool _sendPartialBodyOnRequest;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly Task _acceptLoop;
+            private readonly X509Certificate2 _certificate;
+
+            private readonly TaskCompletionSource<bool> _rstReceived =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private H2StallServer(bool sendPartialBodyOnRequest)
+            {
+                _sendPartialBodyOnRequest = sendPartialBodyOnRequest;
+
+                _certificate = new X509Certificate2(
+                    "_Files/Certificates/client-cert.pifix",
+                    CertificateContext.DefaultPassword);
+
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _acceptLoop = AcceptLoopAsync();
+            }
+
+            public int Port { get; }
+
+            public static H2StallServer Start(bool sendPartialBodyOnRequest)
+            {
+                return new H2StallServer(sendPartialBodyOnRequest);
+            }
+
+            public async Task<bool> WaitForRstStream(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_rstReceived.Task, Task.Delay(timeout, _cts.Token));
+
+                return completed == _rstReceived.Task;
+            }
+
+            private async Task AcceptLoopAsync()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                        _ = HandleClientAsync(client);
+                    }
+                }
+                catch {
+                    // listener stopped
+                }
+            }
+
+            private async Task HandleClientAsync(TcpClient client)
+            {
+                try {
+                    using var _ = client;
+
+                    await using var sslStream = new SslStream(client.GetStream(), false);
+
+                    await sslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions {
+                        ServerCertificate = _certificate,
+                        ApplicationProtocols = new() { SslApplicationProtocol.Http2 },
+                        EnabledSslProtocols = SslProtocols.Tls12,
+                        ClientCertificateRequired = false
+                    }, _cts.Token);
+
+                    // Client connection preface (24 bytes) before any frame
+                    await ReadExactAsync(sslStream, new byte[24]);
+
+                    // Server preface: empty SETTINGS
+                    await WriteFrameAsync(sslStream, type: 0x04, flags: 0, streamId: 0,
+                        Array.Empty<byte>());
+
+                    while (true) {
+                        var (type, flags, streamId, payload) = await ReadFrameAsync(sslStream);
+
+                        if (type == 0x04 && (flags & 0x01) == 0) {
+                            // SETTINGS from client: acknowledge
+                            await WriteFrameAsync(sslStream, type: 0x04, flags: 0x01, streamId: 0,
+                                Array.Empty<byte>());
+                        }
+                        else if (type == 0x06 && (flags & 0x01) == 0) {
+                            // PING: acknowledge with same payload
+                            await WriteFrameAsync(sslStream, type: 0x06, flags: 0x01, streamId: 0, payload);
+                        }
+                        else if (type == 0x01 && _sendPartialBodyOnRequest) {
+                            // Request HEADERS: answer `:status: 200` (HPACK static index 8)
+                            // without END_STREAM, then a partial DATA frame, then stall.
+                            await WriteFrameAsync(sslStream, type: 0x01, flags: 0x04, streamId,
+                                new byte[] { 0x88 });
+
+                            await WriteFrameAsync(sslStream, type: 0x00, flags: 0, streamId,
+                                "partial-"u8.ToArray());
+                        }
+                        else if (type == 0x03) {
+                            _rstReceived.TrySetResult(true);
+                        }
+
+                        // Everything else (WINDOW_UPDATE, HEADERS in tarpit mode…) is ignored
+                    }
+                }
+                catch {
+                    // Connection torn down
+                }
+            }
+
+            private static async Task<(byte Type, byte Flags, int StreamId, byte[] Payload)>
+                ReadFrameAsync(Stream stream)
+            {
+                var header = new byte[9];
+                await ReadExactAsync(stream, header);
+
+                var length = (header[0] << 16) | (header[1] << 8) | header[2];
+                var type = header[3];
+                var flags = header[4];
+                var streamId = ((header[5] & 0x7F) << 24) | (header[6] << 16) | (header[7] << 8) | header[8];
+
+                var payload = new byte[length];
+                await ReadExactAsync(stream, payload);
+
+                return (type, flags, streamId, payload);
+            }
+
+            private static async Task ReadExactAsync(Stream stream, byte[] buffer)
+            {
+                var total = 0;
+
+                while (total < buffer.Length) {
+                    var read = await stream.ReadAsync(buffer.AsMemory(total));
+
+                    if (read == 0)
+                        throw new IOException("Peer closed the connection");
+
+                    total += read;
+                }
+            }
+
+            private static async Task WriteFrameAsync(
+                Stream stream, byte type, byte flags, int streamId, byte[] payload)
+            {
+                var frame = new byte[9 + payload.Length];
+
+                frame[0] = (byte) ((payload.Length >> 16) & 0xFF);
+                frame[1] = (byte) ((payload.Length >> 8) & 0xFF);
+                frame[2] = (byte) (payload.Length & 0xFF);
+                frame[3] = type;
+                frame[4] = flags;
+                frame[5] = (byte) ((streamId >> 24) & 0x7F);
+                frame[6] = (byte) ((streamId >> 16) & 0xFF);
+                frame[7] = (byte) ((streamId >> 8) & 0xFF);
+                frame[8] = (byte) (streamId & 0xFF);
+
+                payload.CopyTo(frame, 9);
+
+                await stream.WriteAsync(frame);
+                await stream.FlushAsync();
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+
+                try {
+                    await _acceptLoop;
+                }
+                catch {
+                }
+
+                _certificate.Dispose();
+                _cts.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #721. ResponseHeaderTimeout now covers HTTP/2 upstreams: the header wait uses a timed semaphore acquire that keeps waiting while the request body is still uploading, then resets the stream and surfaces the same 528 with response_header_timeout. The reset stays per stream, other exchanges on the same connection are unaffected.

Also adds an opt-in ResponseBodyIdleTimeout for both protocols, bounding the time between two successive response body reads. On expiry the h1 connection is aborted and the h2 stream is reset. Off by default since SSE and long polling can legitimately stay quiet for long periods.

Writing the tests surfaced a few mid body failure bugs, fixed here: a truncated response now closes the downstream connection instead of leaving the client hanging, and the completion continuation no longer skips connection teardown when the exchange faults or the caller has cancelled. The h1 hard close now covers the whole exchange instead of only the header read.

Tests include a raw HTTP/2 tarpit origin asserting the 528 error code and the RST_STREAM. Throughput bench is within noise of baseline on both h1 and h2.