### PR TITLE
Optimize Http11HeaderBlockReader timestamp handling

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11HeaderBlockReader.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11HeaderBlockReader.cs
@@ -56,10 +56,8 @@ namespace Fluxzy.Clients.H11
             var indexFound = -1;
             var firstBytes = true;
 
-            var stopWatch = new Stopwatch();
-
             while (totalRead < buffer.Buffer.Length) {
-                stopWatch.Restart();
+                var readStartTimestamp = dontThrowIfEarlyClosed ? Stopwatch.GetTimestamp() : 0;
 
                 int currentRead; 
 
@@ -69,7 +67,7 @@ namespace Fluxzy.Clients.H11
                 catch (Exception) {
 
                     if (dontThrowIfEarlyClosed && 
-                        stopWatch.ElapsedTicks < ConnectionDisposeDetectionThreshHold)
+                        Stopwatch.GetElapsedTime(readStartTimestamp).Ticks < ConnectionDisposeDetectionThreshHold)
                     {
                         //  OpenSSL and SecureTransport throw an exception instead of returning 0 with .NET 
 
@@ -80,7 +78,7 @@ namespace Fluxzy.Clients.H11
                 }
 
                 if (currentRead == 0) {
-                    if (dontThrowIfEarlyClosed && stopWatch.ElapsedTicks < ConnectionDisposeDetectionThreshHold) {
+                    if (dontThrowIfEarlyClosed && Stopwatch.GetElapsedTime(readStartTimestamp).Ticks < ConnectionDisposeDetectionThreshHold) {
                         return new(-1, 0, true); 
                     }
 

--- a/test/Fluxzy.Benchmarks/Http11HeaderBlockReaderBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/Http11HeaderBlockReaderBenchmark.cs
@@ -1,0 +1,87 @@
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Clients.H11;
+using Fluxzy.Misc.ResizableBuffers;
+
+namespace Fluxzy.Benchmarks;
+
+/// <summary>
+///     Measures production HTTP/1.1 header block scanning.
+///
+///     Run: dotnet run -c Release -- --filter *Http11HeaderBlockReaderBenchmark*
+/// </summary>
+[MemoryDiagnoser]
+public class Http11HeaderBlockReaderBenchmark
+{
+    private byte[] _headerBlock = null!;
+
+    [Params(1, 16, 1024)]
+    public int MaxReadBytes { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _headerBlock = System.Text.Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\r\n" +
+            "Server: benchmark\r\n" +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: 2\r\n" +
+            "Connection: keep-alive\r\n" +
+            "\r\n{}");
+    }
+
+    [Benchmark]
+    public async ValueTask<int> ReadHeaderBlock()
+    {
+        using var stream = new FragmentedReadStream(_headerBlock, MaxReadBytes);
+        using var buffer = RsBuffer.Allocate(1024);
+
+        var result = await Http11HeaderBlockReader.GetNext(
+            stream,
+            buffer,
+            firstByteReceived: null,
+            headerBlockReceived: null,
+            throwOnError: true,
+            token: CancellationToken.None,
+            dontThrowIfEarlyClosed: false);
+
+        return result.HeaderLength;
+    }
+
+    private sealed class FragmentedReadStream : Stream
+    {
+        private readonly byte[] _buffer;
+        private readonly int _maxReadBytes;
+        private int _offset;
+
+        public FragmentedReadStream(byte[] buffer, int maxReadBytes)
+        {
+            _buffer = buffer;
+            _maxReadBytes = maxReadBytes;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _buffer.Length;
+        public override long Position { get => _offset; set => throw new NotSupportedException(); }
+
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (_offset >= _buffer.Length)
+                return new ValueTask<int>(0);
+
+            var count = Math.Min(Math.Min(buffer.Length, _maxReadBytes), _buffer.Length - _offset);
+            _buffer.AsMemory(_offset, count).CopyTo(buffer);
+            _offset += count;
+            return new ValueTask<int>(count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

| Change | Details |
|---|---|
| Reader timing | Replace the per-call `Stopwatch` allocation in `Http11HeaderBlockReader` with `Stopwatch.GetTimestamp()` / `Stopwatch.GetElapsedTime()` |
| Fast path | Skip timestamp reads entirely unless `dontThrowIfEarlyClosed` is enabled |
| Benchmark coverage | Add `Http11HeaderBlockReaderBenchmark` over the production reader with complete and fragmented reads |

## Benchmarks

- **Base:** `perf-combined-h2-chunked-optimizations`
- **Candidate:** `perf-h1-header-reader-timestamp`
- **Command:** `dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter 'Http11HeaderBlockReaderBenchmark' --job Short --warmupCount 3 --iterationCount 10`

| MaxReadBytes | Base | Candidate | Alloc Base | Alloc Candidate |
|---:|---:|---:|---:|---:|
| 1 | 3.887 us | 1.733 us | 104 B | 64 B |
| 16 | 340.5 ns | 176.2 ns | 104 B | 64 B |
| 1024 | 92.68 ns | 71.43 ns | 104 B | 64 B |
