### PR TITLE
Improve HTTP/1.1 downstream response-copy throughput and reduce MetricsStream read overhead

### DIFF
--- a/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
@@ -146,7 +146,21 @@ namespace Fluxzy.Core
                 stream = chunkedWriter;
             }
 
-            await responseBodyStream.CopyDetailed(stream, rsBuffer.Buffer, _ => { }, token).ConfigureAwait(false);
+            if (chunked) {
+                await responseBodyStream
+                    .CopyDetailed(stream, rsBuffer.Buffer, _ => { }, flushAfterEachWrite: true, token)
+                    .ConfigureAwait(false);
+            }
+            else {
+                await responseBodyStream
+                    .CopyDetailed(
+                        stream,
+                        FluxzySharedSetting.ResponseBodyCopyBuffer,
+                        _ => { },
+                        flushAfterEachWrite: false,
+                        token)
+                    .ConfigureAwait(false);
+            }
 
             if (chunkedWriter != null) {
                 // After body is drained, trailers are available on the Response object

--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -40,6 +40,12 @@ namespace Fluxzy
         public static int RequestProcessingBuffer { get; set; } = 1024 * 4;
 
         /// <summary>
+        ///     Buffer size used when copying non-chunked response bodies in HTTP/1.1 downstream writes.
+        /// </summary>
+        public static int ResponseBodyCopyBuffer { get; set; } =
+            EnvironmentUtility.GetInt32("FLUXZY_RESPONSE_BODY_COPY_BUFFER", 64 * 1024);
+
+        /// <summary>
         ///     The maximum number of concurrent connections allowed
         /// </summary>
         public static int OverallMaxConcurrentConnections { get; } = 102400;

--- a/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
@@ -105,14 +105,11 @@ namespace Fluxzy.Misc.Streams
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = new())
         {
             try {
-                using var combinedTokenSource =
-                    CancellationTokenSource.CreateLinkedTokenSource(_parentToken, cancellationToken);
-
                 int read;
 
                 try {
-                    read = await InnerStream.ReadAsync(buffer, combinedTokenSource.Token)
-                                                .ConfigureAwait(false);
+                    using var linkedTokenSource = CreateLinkedReadToken(cancellationToken, out var readToken);
+                    read = await InnerStream.ReadAsync(buffer, readToken).ConfigureAwait(false);
                 }
                 catch (Exception e) {
                     if (EndConnection && e is Org.BouncyCastle.Tls.TlsNoCloseNotifyException) {
@@ -146,6 +143,27 @@ namespace Fluxzy.Misc.Streams
 
                 throw;
             }
+        }
+
+        private CancellationTokenSource? CreateLinkedReadToken(
+            CancellationToken cancellationToken,
+            out CancellationToken readToken)
+        {
+            if (!_parentToken.CanBeCanceled)
+            {
+                readToken = cancellationToken;
+                return null;
+            }
+
+            if (!cancellationToken.CanBeCanceled || cancellationToken == _parentToken)
+            {
+                readToken = _parentToken;
+                return null;
+            }
+
+            var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_parentToken, cancellationToken);
+            readToken = linkedTokenSource.Token;
+            return linkedTokenSource;
         }
 
         private void NotifyFirstRead()

--- a/src/Fluxzy.Core/Misc/Streams/StreamExtensions.cs
+++ b/src/Fluxzy.Core/Misc/Streams/StreamExtensions.cs
@@ -15,6 +15,21 @@ namespace Fluxzy.Misc.Streams
             this Stream source,
             Stream destination,
             int bufferSize, Action<int> onContentCopied, CancellationToken cancellationToken)
+            => await source.CopyDetailed(
+                         destination,
+                         bufferSize,
+                         onContentCopied,
+                         flushAfterEachWrite: true,
+                         cancellationToken)
+                    .ConfigureAwait(false);
+
+        public static async ValueTask<long> CopyDetailed(
+            this Stream source,
+            Stream destination,
+            int bufferSize,
+            Action<int> onContentCopied,
+            bool flushAfterEachWrite,
+            CancellationToken cancellationToken)
         {
             if (source.CanSeek && source.Length == 0) {
                 return 0;
@@ -23,7 +38,12 @@ namespace Fluxzy.Misc.Streams
             var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
 
             try {
-                return await source.CopyDetailed(destination, buffer, onContentCopied, cancellationToken)
+                return await source.CopyDetailed(
+                                   destination,
+                                   buffer,
+                                   onContentCopied,
+                                   flushAfterEachWrite,
+                                   cancellationToken)
                                    .ConfigureAwait(false);
             }
             finally {
@@ -175,6 +195,21 @@ namespace Fluxzy.Misc.Streams
             this Stream source,
             Stream destination,
             byte[] buffer, Action<int> onContentCopied, CancellationToken cancellationToken)
+            => await source.CopyDetailed(
+                         destination,
+                         buffer,
+                         onContentCopied,
+                         flushAfterEachWrite: true,
+                         cancellationToken)
+                    .ConfigureAwait(false);
+
+        public static async ValueTask<long> CopyDetailed(
+            this Stream source,
+            Stream destination,
+            byte[] buffer,
+            Action<int> onContentCopied,
+            bool flushAfterEachWrite,
+            CancellationToken cancellationToken)
         {
             if (source.CanSeek && source.Length == 0)
             {
@@ -189,7 +224,9 @@ namespace Fluxzy.Misc.Streams
                 await destination.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
                 onContentCopied(read);
 
-                await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+                if (flushAfterEachWrite) {
+                    await destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
 
                 totalCopied += read;
             }

--- a/test/Fluxzy.Benchmarks/MetricsStreamOverheadBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/MetricsStreamOverheadBenchmark.cs
@@ -52,26 +52,37 @@ public class MetricsStreamOverheadBenchmark
     }
 
     /// <summary>
-    ///     Read through MetricsStream — each ReadAsync creates a linked CTS.
+    ///     Read through MetricsStream where no linked CTS is needed.
     /// </summary>
     [Benchmark]
-    public async Task<long> ReadWithMetricsStream()
+    public async Task<long> ReadWithMetricsStream_NoLinkedToken()
     {
-        using var inner = new MemoryStream(_data);
-
-        var metrics = new MetricsStream(
-            inner,
-            firstBytesRead: static () => { },
-            endRead: static (_, _) => { },
-            onReadError: static _ => { },
-            endConnection: false,
-            expectedLength: TotalPayload,
-            parentToken: CancellationToken.None);
+        using var metrics = CreateMetricsStream(CancellationToken.None);
 
         long total = 0;
         int read;
 
         while ((read = await metrics.ReadAsync(_readBuffer.AsMemory())) > 0) {
+            total += read;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    ///     Read through MetricsStream where linked CTS is required on every read.
+    /// </summary>
+    [Benchmark]
+    public async Task<long> ReadWithMetricsStream_LinkedToken()
+    {
+        using var parentCts = new CancellationTokenSource();
+        using var requestCts = new CancellationTokenSource();
+        using var metrics = CreateMetricsStream(parentCts.Token);
+
+        long total = 0;
+        int read;
+
+        while ((read = await metrics.ReadAsync(_readBuffer.AsMemory(), requestCts.Token)) > 0) {
             total += read;
         }
 
@@ -98,5 +109,19 @@ public class MetricsStreamOverheadBenchmark
         parentCts.Dispose();
 
         return count;
+    }
+
+    private MetricsStream CreateMetricsStream(CancellationToken parentToken)
+    {
+        var inner = new MemoryStream(_data);
+
+        return new MetricsStream(
+            inner,
+            firstBytesRead: static () => { },
+            endRead: static (_, _) => { },
+            onReadError: static _ => { },
+            endConnection: false,
+            expectedLength: TotalPayload,
+            parentToken: parentToken);
     }
 }

--- a/test/Fluxzy.Benchmarks/StreamExtensionsCopyDetailedBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/StreamExtensionsCopyDetailedBenchmark.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Misc.Streams;
+
+namespace Fluxzy.Benchmarks;
+
+[MemoryDiagnoser]
+public class StreamExtensionsCopyDetailedBenchmark
+{
+    private byte[] _payload = null!;
+
+    [Params(8192, 65536, 524288)]
+    public int PayloadSize { get; set; }
+
+    [Params(4096, 65536)]
+    public int BufferSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _payload = new byte[PayloadSize];
+        Random.Shared.NextBytes(_payload);
+    }
+
+    [Benchmark(Baseline = true)]
+    public async Task<long> CopyWithFlushAfterEachWrite()
+    {
+        using var source = new MemoryStream(_payload);
+        using var destination = new WriteOnlyStream();
+
+        return await source.CopyDetailed(
+                   destination,
+                   bufferSize: BufferSize,
+                   _ => { },
+                   flushAfterEachWrite: true,
+                   CancellationToken.None)
+               .ConfigureAwait(false);
+    }
+
+    [Benchmark]
+    public async Task<long> CopyWithoutFlushAfterEachWrite()
+    {
+        using var source = new MemoryStream(_payload);
+        using var destination = new WriteOnlyStream();
+
+        return await source.CopyDetailed(
+                   destination,
+                   bufferSize: BufferSize,
+                   _ => { },
+                   flushAfterEachWrite: false,
+                   CancellationToken.None)
+               .ConfigureAwait(false);
+    }
+
+    private sealed class WriteOnlyStream : Stream
+    {
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/MetricsStreamCancellationTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/MetricsStreamCancellationTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class MetricsStreamCancellationTests
+    {
+        [Fact]
+        public async Task ReadAsync_UsesParentTokenWhenRequestTokenNotCancelable()
+        {
+            using var parentCts = new CancellationTokenSource();
+            parentCts.Cancel();
+
+            var metricsStream = CreateMetricsStream(parentCts.Token);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await metricsStream.ReadAsync(new byte[1], CancellationToken.None).ConfigureAwait(false));
+        }
+
+        [Fact]
+        public async Task ReadAsync_UsesRequestTokenWhenParentTokenNotCancelable()
+        {
+            using var requestCts = new CancellationTokenSource();
+            requestCts.Cancel();
+
+            var metricsStream = CreateMetricsStream(CancellationToken.None);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await metricsStream.ReadAsync(new byte[1], requestCts.Token).ConfigureAwait(false));
+        }
+
+        [Fact]
+        public async Task ReadAsync_LinksTokensWhenBothAreCancelableAndDifferent()
+        {
+            using var parentCts = new CancellationTokenSource();
+            using var requestCts = new CancellationTokenSource();
+            parentCts.Cancel();
+
+            var metricsStream = CreateMetricsStream(parentCts.Token);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await metricsStream.ReadAsync(new byte[1], requestCts.Token).ConfigureAwait(false));
+        }
+
+        private static MetricsStream CreateMetricsStream(CancellationToken parentToken)
+        {
+            return new MetricsStream(
+                new PendingReadStream(),
+                firstBytesRead: static () => { },
+                endRead: static (_, _) => { },
+                onReadError: static _ => { },
+                endConnection: false,
+                expectedLength: null,
+                parentToken: parentToken);
+        }
+
+        private sealed class PendingReadStream : Stream
+        {
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush()
+            {
+                throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override async ValueTask<int> ReadAsync(
+                Memory<byte> buffer,
+                CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+                return 0;
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/StreamExtensionsCopyDetailedTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/StreamExtensionsCopyDetailedTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class StreamExtensionsCopyDetailedTests
+    {
+        [Fact]
+        public async Task CopyDetailed_BufferOverload_DefaultsToFlushAfterEachWrite()
+        {
+            await VerifyFlushBehavior(
+                copy: (source, destination, onCopied) =>
+                    source.CopyDetailed(destination, new byte[4], onCopied, CancellationToken.None),
+                expectedFlushCount: 2);
+        }
+
+        [Fact]
+        public async Task CopyDetailed_BufferOverload_AllowsDisablingFlushAfterEachWrite()
+        {
+            await VerifyFlushBehavior(
+                copy: (source, destination, onCopied) =>
+                    source.CopyDetailed(
+                        destination,
+                        new byte[4],
+                        onCopied,
+                        flushAfterEachWrite: false,
+                        CancellationToken.None),
+                expectedFlushCount: 0);
+        }
+
+        [Fact]
+        public async Task CopyDetailed_BufferSizeOverload_AllowsDisablingFlushAfterEachWrite()
+        {
+            await VerifyFlushBehavior(
+                copy: (source, destination, onCopied) =>
+                    source.CopyDetailed(
+                        destination,
+                        bufferSize: 4,
+                        onCopied,
+                        flushAfterEachWrite: false,
+                        CancellationToken.None),
+                expectedFlushCount: 0);
+        }
+
+        private static async Task VerifyFlushBehavior(
+            Func<Stream, FlushCountingStream, Action<int>, ValueTask<long>> copy,
+            int expectedFlushCount)
+        {
+            using var source = new MemoryStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+            using var destination = new FlushCountingStream();
+            var copiedBytes = 0;
+
+            var totalCopied = await copy(source, destination, copied => copiedBytes += copied).ConfigureAwait(false);
+
+            Assert.Equal(8, totalCopied);
+            Assert.Equal(8, copiedBytes);
+            Assert.Equal(8, destination.TotalWritten);
+            Assert.Equal(expectedFlushCount, destination.FlushCount);
+        }
+
+        private sealed class FlushCountingStream : Stream
+        {
+            public int FlushCount { get; private set; }
+
+            public int TotalWritten { get; private set; }
+
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => true;
+
+            public override long Length => TotalWritten;
+
+            public override long Position {
+                get => TotalWritten;
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush()
+            {
+                FlushCount++;
+            }
+
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                FlushCount++;
+                return Task.CompletedTask;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                TotalWritten += count;
+            }
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                TotalWritten += buffer.Length;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change applies the requested HTTP/1.1 downstream response-copy optimizations: keep chunked behavior flush-safe, optimize non-chunked copies for throughput, and reduce avoidable cancellation-token allocation overhead in `MetricsStream`. It also adds focused benchmarks for both hot paths and includes baseline vs changed benchmark comparisons.

- **HTTP/1.1 downstream body copy path**
  - `Http11DownStreamPipe.WriteResponseBody` now branches by transfer mode:
    - **chunked**: keeps reusable response buffer and flushes after each write.
    - **non-chunked**: uses a larger configurable buffer and disables per-write flush.
  - Existing chunked trailer emission flow is preserved.

- **Shared config for non-chunked copy**
  - Added `FluxzySharedSetting.ResponseBodyCopyBuffer` (default `64 * 1024`) from:
    - `FLUXZY_RESPONSE_BODY_COPY_BUFFER`

- **`StreamExtensions.CopyDetailed` API expansion (backward-compatible)**
  - Added overloads for both `int bufferSize` and `byte[] buffer` variants with:
    - `bool flushAfterEachWrite`
  - Existing public overloads remain unchanged in behavior by delegating with `flushAfterEachWrite: true`.
  - Core copy loop now conditionally calls `FlushAsync(...)` only when requested.

- **`MetricsStream.ReadAsync` allocation reduction**
  - Replaced unconditional per-read linked CTS creation with conditional linking:
    - no parent cancel token → use request token directly
    - request token absent or same as parent → use parent directly
    - only create linked CTS when both cancelable and distinct

- **Benchmarks added/updated**
  - Added: `StreamExtensionsCopyDetailedBenchmark`
    - compares `flushAfterEachWrite: true` vs `false` across payload/buffer sizes.
  - Updated: `MetricsStreamOverheadBenchmark`
    - separates `ReadWithMetricsStream_NoLinkedToken` and `ReadWithMetricsStream_LinkedToken`.
  - Baseline/changed command (Metrics):
    - `dotnet run -c Release -- --filter "*MetricsStreamOverheadBenchmark*" --job short --warmupCount 1 --iterationCount 3`
  - New copy benchmark command:
    - `dotnet run -c Release -- --filter "*StreamExtensionsCopyDetailedBenchmark*" --job short --warmupCount 1 --iterationCount 3`

- **Benchmark highlights (baseline vs changed where applicable)**
  - `MetricsStream` no-link path improved:
    - `ReadSize=16384, TotalPayload=65536`: **1480.71 ns / 472 B → 1403.89 ns / 232 B**
    - `ReadSize=16384, TotalPayload=524288`: **12867.18 ns / 1816 B → 12729.06 ns / 232 B**
  - `CopyDetailed` flush control (new benchmark, same run comparison):
    - `PayloadSize=65536, BufferSize=65536`:
      - flush each write: **14968.51 ns**
      - no flush each write: **1125.03 ns**
