### PR TITLE
Avoid activity creation when no listener is attached

### DIFF
--- a/src/Fluxzy.Core/Logging/FluxzyActivitySource.cs
+++ b/src/Fluxzy.Core/Logging/FluxzyActivitySource.cs
@@ -21,6 +21,9 @@ namespace Fluxzy.Logging
 
         public static Activity? StartExchangeActivity(Exchange exchange, Guid proxyInstanceId)
         {
+            if (!Instance.HasListeners())
+                return null;
+
             var traceparent = exchange.GetRequestHeaderValue("traceparent");
             var tracestate = exchange.GetRequestHeaderValue("tracestate");
 

--- a/test/Fluxzy.Benchmarks/ActivitySourceBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/ActivitySourceBenchmark.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Logging;
+
+namespace Fluxzy.Benchmarks;
+
+/// <summary>
+///     Measures the default ActivitySource path when no ActivityListener is attached.
+///
+///     Run: dotnet run -c Release -- --filter *ActivitySourceBenchmark*
+/// </summary>
+[MemoryDiagnoser]
+public class ActivitySourceBenchmark
+{
+    private Exchange _exchange = null!;
+    private Guid _proxyInstanceId;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var authority = new Authority("example.test", 443, true);
+        var requestHeader =
+            "GET /api/data HTTP/1.1\r\n" +
+            "Host: example.test\r\n" +
+            "User-Agent: benchmark\r\n" +
+            "Accept: application/json\r\n" +
+            "\r\n";
+
+        _exchange = new Exchange(
+            IIdProvider.FromZero,
+            authority,
+            requestHeader.AsMemory(),
+            "HTTP/1.1",
+            DateTime.UtcNow);
+        _proxyInstanceId = Guid.NewGuid();
+    }
+
+    [Benchmark]
+    public object? StartExchangeActivity_NoListener()
+    {
+        return FluxzyActivitySource.StartExchangeActivity(_exchange, _proxyInstanceId);
+    }
+}


### PR DESCRIPTION
## Summary
- return immediately from FluxzyActivitySource.StartExchangeActivity when ActivitySource has no listeners
- avoids traceparent/tracestate/User-Agent header enumeration and activity name/tag setup on default no-listener runs
- add ActivitySourceBenchmark for the production no-listener path
- When not needing to monitor activities, reduces GC churn

## Benchmarks
Base: perf-combined-h2-chunked-optimizations
Candidate: perf-activity-source-listener-guard
Command: dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter '*ActivitySourceBenchmark*' --job Short --warmupCount 3 --iterationCount 10

| Benchmark | Base | Candidate | Alloc Base | Alloc Candidate |
| --- | ---: | ---: | ---: | ---: |
| StartExchangeActivity_NoListener | 1.256 us | 0.621 ns | 1.82 KB | 0 B |

## Validation
- dotnet build -c Release src/Fluxzy.Core/Fluxzy.Core.csproj -nr:false
- dotnet test -c Release --no-restore --filter 'FullyQualifiedName~FluxzyActivitySource' test/Fluxzy.Tests/Fluxzy.Tests.csproj
