### PR TITLE
Use case-insensitive string hashing for header names

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/Encoder/Utils/SpanCharactersComparer.cs
+++ b/src/Fluxzy.Core/Clients/H2/Encoder/Utils/SpanCharactersComparer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 
 namespace Fluxzy.Clients.H2.Encoder.Utils
@@ -20,21 +19,7 @@ namespace Fluxzy.Clients.H2.Encoder.Utils
 
         public int GetHashCode(ReadOnlyMemory<char> obj)
         {
-            char[]? heapBuffer = null;
-
-            try {
-                var buffer1 = obj.Span.Length < 1024
-                    ? stackalloc char[obj.Span.Length]
-                    : heapBuffer = ArrayPool<char>.Shared.Rent(obj.Span.Length);
-
-                obj.Span.ToLowerInvariant(buffer1);
-
-                return buffer1.GetHashCodeArray();
-            }
-            finally {
-                if (heapBuffer != null)
-                    ArrayPool<char>.Shared.Return(heapBuffer);
-            }
+            return string.GetHashCode(obj.Span, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/test/Fluxzy.Benchmarks/HeaderNameLookupBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/HeaderNameLookupBenchmark.cs
@@ -1,0 +1,55 @@
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Clients.H2.Encoder.Utils;
+
+namespace Fluxzy.Benchmarks;
+
+/// <summary>
+///     Measures production H2/H1 header-name set lookups used while translating headers.
+///
+///     Run: dotnet run -c Release -- --filter *HeaderNameLookupBenchmark*
+/// </summary>
+[MemoryDiagnoser]
+public class HeaderNameLookupBenchmark
+{
+    private readonly ReadOnlyMemory<char>[] _headers = {
+        "connection".AsMemory(),
+        "keep-alive".AsMemory(),
+        "proxy-authenticate".AsMemory(),
+        "trailer".AsMemory(),
+        "upgrade".AsMemory(),
+        "alt-svc".AsMemory(),
+        "expect".AsMemory(),
+        "x-fluxzy-live-edit".AsMemory(),
+        "content-type".AsMemory(),
+        "user-agent".AsMemory(),
+        "accept".AsMemory(),
+        "cookie".AsMemory(),
+        "x-custom-header".AsMemory(),
+    };
+
+    [Benchmark]
+    public int NonForwardableLookup()
+    {
+        var count = 0;
+
+        foreach (var header in _headers) {
+            if (Http11Constants.IsNonForwardableHeader(header))
+                count++;
+        }
+
+        return count;
+    }
+
+    [Benchmark]
+    public int HopByHopLookup()
+    {
+        var count = 0;
+
+        foreach (var header in _headers) {
+            if (Http11Constants.IsH1HopByHopHeader(header))
+                count++;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary
- replace lowercasing-copy hash in SpanCharactersIgnoreCaseComparer with allocation-free ordinal-ignore-case span hashing. Reduces Array pool churn
- add HeaderNameLookupBenchmark for production H2/H1 header-name set lookups

## Benchmarks
Base: perf-combined-h2-chunked-optimizations
Candidate: perf-header-comparer-hash
Command: dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter '*HeaderNameLookupBenchmark*' --job Short --warmupCount 3 --iterationCount 10

| Benchmark | Base | Candidate | Delta |
| --- | ---: | ---: | ---: |
| NonForwardableLookup | 451.4 ns | 274.0 ns | +39.3% |
| HopByHopLookup | 458.0 ns | 267.4 ns | +41.6% |

HeaderEncoderBenchmark spot check:
- Small: 338.2 ns -> 314.0 ns
- Typical: 1,945.1 ns -> 1,891.0 ns
- Large: 4,772.0 ns -> 4,821.0 ns (slight noisy regression in full encoder path)

## Validation
- dotnet build -c Release test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -nr:false
- dotnet test -c Release --no-restore --filter 'FullyQualifiedName~HPack|FullyQualifiedName~Http11Parser' test/Fluxzy.Tests/Fluxzy.Tests.csproj

Note: broader H2/header filter had known local cert trust failure in H2ServeTests.SimpleH2Request; 141 other filtered tests passed.