### PR TITLE
Optimize chunked transfer size parsing

### DIFF
--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
@@ -98,9 +98,7 @@ namespace Fluxzy.Misc.Streams
                         throw new IOException("Error while reading chunked stream: Chunk size too large.");
                     }
 
-                    var hex = GetHexValue(b);
-
-                    if (hex < 0)
+                    if (GetHexValue(b) is var hex and < 0)
                     {
                         throw new IOException(
                             $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
@@ -204,9 +202,7 @@ namespace Fluxzy.Misc.Streams
                         throw new IOException("Error while reading chunked stream: Chunk size too large.");
                     }
 
-                    var hex = GetHexValue(b);
-
-                    if (hex < 0)
+                    if (GetHexValue(b) is var hex and < 0)
                     {
                         throw new IOException(
                             $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
@@ -285,19 +281,13 @@ namespace Fluxzy.Misc.Streams
             throw new NotSupportedException();
         }
 
-        private static int GetHexValue(byte value)
+        private static int GetHexValue(byte value) => value switch
         {
-            if (value >= '0' && value <= '9')
-                return value - '0';
-
-            if (value >= 'A' && value <= 'F')
-                return value - 'A' + 10;
-
-            if (value >= 'a' && value <= 'f')
-                return value - 'a' + 10;
-
-            return -1;
-        }
+            >= (byte)'0' and <= (byte)'9' => value - '0',
+            >= (byte)'A' and <= (byte)'F' => value - 'A' + 10,
+            >= (byte)'a' and <= (byte)'f' => value - 'a' + 10,
+            _ => -1
+        };
 
         /// <summary>
         ///     Reads trailer headers (or just the terminating CRLF) after the final 0-length chunk.

--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
@@ -17,8 +17,7 @@ namespace Fluxzy.Misc.Streams
     {
         private readonly bool _closeOnDone;
         private readonly Stream _innerStream;
-        private readonly byte[] _lengthHolderBytes = new byte[64];
-        private readonly byte[] _singleByte = new byte[1];
+        private readonly byte[] _scratch = new byte[2];
 
         private long _nextChunkSize;
 
@@ -63,7 +62,7 @@ namespace Fluxzy.Misc.Streams
         {
             if (_nextChunkSize == 0)
             {
-                Memory<byte> singleByte = _singleByte;
+                Memory<byte> singleByte = _scratch.AsMemory(0, 1);
 
                 var chunkSize = 0L;
                 var hexCount = 0;
@@ -144,7 +143,7 @@ namespace Fluxzy.Misc.Streams
             if (_nextChunkSize == 0)
             {
                 // Read trailing CRLF after chunk data
-                await _innerStream.ReadExactAsync(new Memory<byte>(_lengthHolderBytes, 0, 2), cancellationToken).ConfigureAwait(false);
+                await _innerStream.ReadExactAsync(_scratch.AsMemory(0, 2), cancellationToken).ConfigureAwait(false);
             }
 
             return read;
@@ -156,7 +155,7 @@ namespace Fluxzy.Misc.Streams
 
             if (_nextChunkSize == 0)
             {
-                Span<byte> singleByte = _singleByte;
+                Span<byte> singleByte = _scratch.AsSpan(0, 1);
 
                 var chunkSize = 0L;
                 var hexCount = 0;
@@ -236,7 +235,7 @@ namespace Fluxzy.Misc.Streams
             if (_nextChunkSize == 0)
             {
                 // Read trailing CRLF after chunk data
-                _innerStream.ReadExact(new Span<byte>(_lengthHolderBytes, 0, 2));
+                _innerStream.ReadExact(_scratch.AsSpan(0, 2));
             }
 
             return read;
@@ -272,11 +271,11 @@ namespace Fluxzy.Misc.Streams
         /// </summary>
         private ValueTask ParseTrailersAsync(CancellationToken ct)
         {
-            var readTask = _innerStream.ReadExactAsync(_lengthHolderBytes.AsMemory(0, 2), ct);
+            var readTask = _innerStream.ReadExactAsync(_scratch.AsMemory(0, 2), ct);
 
             if (readTask.IsCompletedSuccessfully) {
                 // Synchronous completion — check for common case inline
-                if (_lengthHolderBytes[0] == 0x0D && _lengthHolderBytes[1] == 0x0A)
+                if (_scratch[0] == 0x0D && _scratch[1] == 0x0A)
                     return default; // No trailers — zero overhead
 
                 return ParseTrailersSlowPathAsync(ct);
@@ -289,7 +288,7 @@ namespace Fluxzy.Misc.Streams
         {
             await readTask.ConfigureAwait(false);
 
-            if (_lengthHolderBytes[0] == 0x0D && _lengthHolderBytes[1] == 0x0A)
+            if (_scratch[0] == 0x0D && _scratch[1] == 0x0A)
                 return;
 
             await ParseTrailersSlowPathAsync(ct).ConfigureAwait(false);
@@ -303,20 +302,22 @@ namespace Fluxzy.Misc.Streams
 
             for (var i = 0; i < 2; i++)
             {
-                if (_lengthHolderBytes[i] != 0x0A && _lengthHolderBytes[i] != 0x0D)
-                    lineBuilder.Append((char)_lengthHolderBytes[i]);
+                if (_scratch[i] != 0x0A && _scratch[i] != 0x0D)
+                    lineBuilder.Append((char)_scratch[i]);
             }
+
+            Memory<byte> singleByte = _scratch.AsMemory(0, 1);
 
             while (true)
             {
-                if (!await _innerStream.ReadExactAsync(_singleByte, ct).ConfigureAwait(false))
+                if (!await _innerStream.ReadExactAsync(singleByte, ct).ConfigureAwait(false))
                     break;
 
-                var b = _singleByte[0];
+                var b = singleByte.Span[0];
 
                 if (b == 0x0D) // CR
                 {
-                    await _innerStream.ReadExactAsync(_singleByte, ct).ConfigureAwait(false);
+                    await _innerStream.ReadExactAsync(singleByte, ct).ConfigureAwait(false);
 
                     if (lineBuilder.Length == 0)
                         break; // Empty line = end of trailers
@@ -339,19 +340,19 @@ namespace Fluxzy.Misc.Streams
         private void ParseTrailers()
         {
             // Fast path: read 2 bytes. If \r\n → no trailers.
-            _innerStream.ReadExact(new Span<byte>(_lengthHolderBytes, 0, 2));
+            _innerStream.ReadExact(_scratch.AsSpan(0, 2));
 
-            if (_lengthHolderBytes[0] == 0x0D && _lengthHolderBytes[1] == 0x0A)
+            if (_scratch[0] == 0x0D && _scratch[1] == 0x0A)
                 return;
 
             var trailerList = new List<HeaderField>();
             var lineBuilder = new StringBuilder();
-            Span<byte> single = _singleByte;
+            Span<byte> single = _scratch.AsSpan(0, 1);
 
             for (var i = 0; i < 2; i++)
             {
-                if (_lengthHolderBytes[i] != 0x0A && _lengthHolderBytes[i] != 0x0D)
-                    lineBuilder.Append((char)_lengthHolderBytes[i]);
+                if (_scratch[i] != 0x0A && _scratch[i] != 0x0D)
+                    lineBuilder.Append((char)_scratch[i]);
             }
 
             while (true)

--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
@@ -92,20 +92,8 @@ namespace Fluxzy.Misc.Streams
                                && singleByte.Span[0] != 0x0D) { }
                         break;
                     }
-
-                    if (hexCount >= 16)
-                    { // Max hex digits for long
-                        throw new IOException("Error while reading chunked stream: Chunk size too large.");
-                    }
-
-                    if (GetHexValue(b) is var hex and < 0)
-                    {
-                        throw new IOException(
-                            $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
-                    }
-
-                    chunkSize = (chunkSize << 4) + hex;
-                    hexCount++;
+                    
+                    AppendChunkSizeHexDigit(b, ref chunkSize, ref hexCount);
                 }
 
                 // Skip LF after CR
@@ -197,19 +185,7 @@ namespace Fluxzy.Misc.Streams
                         break;
                     }
 
-                    if (hexCount >= 16)
-                    { // Max hex digits for long
-                        throw new IOException("Error while reading chunked stream: Chunk size too large.");
-                    }
-
-                    if (GetHexValue(b) is var hex and < 0)
-                    {
-                        throw new IOException(
-                            $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
-                    }
-
-                    chunkSize = (chunkSize << 4) + hex;
-                    hexCount++;
+                    AppendChunkSizeHexDigit(b, ref chunkSize, ref hexCount);
                 }
 
                 // Skip LF after CR
@@ -417,6 +393,23 @@ namespace Fluxzy.Misc.Streams
                     line.Substring(0, colonIdx).Trim(),
                     line.Substring(colonIdx + 1).Trim()));
             }
+        }
+
+        private static void AppendChunkSizeHexDigit(byte value, ref long chunkSize, ref int hexCount)
+        {
+            if (hexCount >= 16)
+            {
+                throw new IOException("Error while reading chunked stream: Chunk size too large.");
+            }
+        
+            if (GetHexValue(value) is var hex and < 0)
+            {
+                throw new IOException(
+                    $"Error while reading chunked stream: Invalid chunk size character: {(char)value}.");
+            }
+        
+            chunkSize = (chunkSize << 4) + hex;
+            hexCount++;
         }
     }
 }

--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
@@ -403,7 +403,8 @@ namespace Fluxzy.Misc.Streams
                 throw new IOException("Error while reading chunked stream: Chunk size too large.");
             }
         
-            if (GetHexValue(value) is var hex and < 0)
+            var hex = GetHexValue(value);
+            if (hex < 0)
             {
                 throw new IOException(
                     $"Error while reading chunked stream: Invalid chunk size character: {(char)value}.");

--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferReadStream.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -19,7 +18,6 @@ namespace Fluxzy.Misc.Streams
         private readonly bool _closeOnDone;
         private readonly Stream _innerStream;
         private readonly byte[] _lengthHolderBytes = new byte[64];
-        private readonly char[] _lengthHolderChar = new char[64];
         private readonly byte[] _singleByte = new byte[1];
 
         private long _nextChunkSize;
@@ -65,11 +63,10 @@ namespace Fluxzy.Misc.Streams
         {
             if (_nextChunkSize == 0)
             {
-                Memory<byte> textBufferBytes = _lengthHolderBytes;
-                Memory<char> textBufferChars = _lengthHolderChar;
                 Memory<byte> singleByte = _singleByte;
 
-                var textCount = 0;
+                var chunkSize = 0L;
+                var hexCount = 0;
 
                 // Read chunk size until CR
                 while (await _innerStream.ReadAsync(singleByte, cancellationToken).ConfigureAwait(false) > 0)
@@ -96,12 +93,21 @@ namespace Fluxzy.Misc.Streams
                         break;
                     }
 
-                    if (textCount >= 16)
+                    if (hexCount >= 16)
                     { // Max hex digits for long
                         throw new IOException("Error while reading chunked stream: Chunk size too large.");
                     }
 
-                    textBufferBytes.Span[textCount++] = b;
+                    var hex = GetHexValue(b);
+
+                    if (hex < 0)
+                    {
+                        throw new IOException(
+                            $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
+                    }
+
+                    chunkSize = (chunkSize << 4) + hex;
+                    hexCount++;
                 }
 
                 // Skip LF after CR
@@ -115,19 +121,14 @@ namespace Fluxzy.Misc.Streams
                     throw new IOException("Expected LF after CR in chunk size line");
                 }
 
-                if (textCount == 0)
+                if (hexCount == 0)
                 {
                     throw new IOException("Error while reading chunked stream: Empty chunk size.");
                 }
 
-                Encoding.ASCII.GetChars(textBufferBytes.Span.Slice(0, textCount), textBufferChars.Span);
-
-                if (!long.TryParse(textBufferChars.Slice(0, textCount).Span,
-                        NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                        out var chunkSize) || chunkSize < 0)
+                if (chunkSize < 0)
                 {
-                    throw new IOException(
-                        $"Error while reading chunked stream: Invalid chunk size: {textBufferChars.Slice(0, textCount).ToString()}.");
+                    throw new IOException("Error while reading chunked stream: Chunk size too large.");
                 }
 
                 if (chunkSize == 0)
@@ -169,11 +170,10 @@ namespace Fluxzy.Misc.Streams
 
             if (_nextChunkSize == 0)
             {
-                Span<byte> textBufferBytes = _lengthHolderBytes;
-                Span<char> textBufferChars = _lengthHolderChar;
                 Span<byte> singleByte = _singleByte;
 
-                var textCount = 0;
+                var chunkSize = 0L;
+                var hexCount = 0;
 
                 // Read chunk size until CR
                 while (_innerStream.Read(singleByte) > 0)
@@ -199,12 +199,21 @@ namespace Fluxzy.Misc.Streams
                         break;
                     }
 
-                    if (textCount >= 16)
+                    if (hexCount >= 16)
                     { // Max hex digits for long
                         throw new IOException("Error while reading chunked stream: Chunk size too large.");
                     }
 
-                    textBufferBytes[textCount++] = b;
+                    var hex = GetHexValue(b);
+
+                    if (hex < 0)
+                    {
+                        throw new IOException(
+                            $"Error while reading chunked stream: Invalid chunk size character: {(char)b}.");
+                    }
+
+                    chunkSize = (chunkSize << 4) + hex;
+                    hexCount++;
                 }
 
                 // Skip LF after CR
@@ -218,19 +227,14 @@ namespace Fluxzy.Misc.Streams
                     throw new IOException("Expected LF after CR in chunk size line");
                 }
 
-                if (textCount == 0)
+                if (hexCount == 0)
                 {
                     throw new IOException("Error while reading chunked stream: Empty chunk size.");
                 }
 
-                Encoding.ASCII.GetChars(textBufferBytes.Slice(0, textCount), textBufferChars);
-
-                if (!long.TryParse(textBufferChars.Slice(0, textCount),
-                        NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                        out var chunkSize) || chunkSize < 0)
+                if (chunkSize < 0)
                 {
-                    throw new IOException(
-                        $"Error while reading chunked stream: Invalid chunk size: {new string(textBufferChars.Slice(0, textCount))}.");
+                    throw new IOException("Error while reading chunked stream: Chunk size too large.");
                 }
 
                 if (chunkSize == 0)
@@ -279,6 +283,20 @@ namespace Fluxzy.Misc.Streams
         public override void Write(byte[] buffer, int offset, int count)
         {
             throw new NotSupportedException();
+        }
+
+        private static int GetHexValue(byte value)
+        {
+            if (value >= '0' && value <= '9')
+                return value - '0';
+
+            if (value >= 'A' && value <= 'F')
+                return value - 'A' + 10;
+
+            if (value >= 'a' && value <= 'f')
+                return value - 'a' + 10;
+
+            return -1;
         }
 
         /// <summary>

--- a/test/Fluxzy.Benchmarks/ChunkedTransferReadStreamBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/ChunkedTransferReadStreamBenchmark.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Misc.Streams;
+
+namespace Fluxzy.Benchmarks;
+
+/// <summary>
+///     Measures the HTTP/1.1 chunked body reader header parser. This exercises
+///     the chunk-size line parsing path before each chunk body read.
+///
+///     Run: dotnet run -c Release -- --filter *ChunkedTransferReadStreamBenchmark*
+/// </summary>
+[MemoryDiagnoser]
+public class ChunkedTransferReadStreamBenchmark
+{
+    private byte[] _chunkedPayload = null!;
+    private byte[] _readBuffer = null!;
+
+    [Params(10 * 1024 * 1024)]
+    public int PayloadBytes { get; set; }
+
+    [Params(1024, 16 * 1024)]
+    public int ChunkBytes { get; set; }
+
+    [Params(false, true)]
+    public bool Extensions { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var payload = new byte[PayloadBytes];
+        Random.Shared.NextBytes(payload);
+        _chunkedPayload = BuildChunkedPayload(payload);
+        _readBuffer = new byte[ChunkBytes];
+    }
+
+    [Benchmark]
+    public async Task<long> ReadChunkedBodyAsync()
+    {
+        await using var source = new MemoryStream(_chunkedPayload, writable: false);
+        await using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+
+        long totalRead = 0;
+        int read;
+
+        while ((read = await chunked.ReadAsync(_readBuffer, CancellationToken.None)) > 0) {
+            totalRead += read;
+        }
+
+        return totalRead;
+    }
+
+    private byte[] BuildChunkedPayload(byte[] payload)
+    {
+        using var destination = new MemoryStream(payload.Length + payload.Length / ChunkBytes * 16 + 16);
+
+        for (var offset = 0; offset < payload.Length;) {
+            var count = Math.Min(ChunkBytes, payload.Length - offset);
+            var header = Extensions
+                ? $"{count:X};foo=bar\r\n"
+                : $"{count:X}\r\n";
+
+            var headerBytes = Encoding.ASCII.GetBytes(header);
+            destination.Write(headerBytes);
+            destination.Write(payload, offset, count);
+            destination.Write("\r\n"u8);
+            offset += count;
+        }
+
+        destination.Write("0\r\n\r\n"u8);
+        return destination.ToArray();
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferReadStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferReadStreamTests.cs
@@ -59,5 +59,69 @@ namespace Fluxzy.Tests.UnitTests.Misc
             await Assert.ThrowsAsync<IOException>(async () =>
                 await chunked.ReadExactlyAsync(buffer.AsMemory(0, 1), CancellationToken.None));
         }
+
+        [Theory]
+        [InlineData("a\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        [InlineData("A\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        [InlineData("000000000000000A\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        public async Task ReadAsync_ParsesValidHexChunkSizes(string payload, string expected)
+        {
+            await using var source = new MemoryStream(Encoding.ASCII.GetBytes(payload));
+            await using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+            var buffer = new byte[expected.Length];
+
+            await chunked.ReadExactlyAsync(buffer, CancellationToken.None);
+
+            Assert.Equal(expected, Encoding.ASCII.GetString(buffer));
+        }
+
+        [Theory]
+        [InlineData("\r\nhello\r\n0\r\n\r\n")]
+        [InlineData(" 5\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("5 \r\nhello\r\n0\r\n\r\n")]
+        [InlineData("8000000000000000\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("10000000000000000\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("5\rhello\r\n0\r\n\r\n")]
+        public async Task ReadAsync_InvalidChunkSizeLines_Throw(string payload)
+        {
+            await using var source = new MemoryStream(Encoding.ASCII.GetBytes(payload));
+            await using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+            var buffer = new byte[8];
+
+            await Assert.ThrowsAsync<IOException>(async () =>
+                await chunked.ReadExactlyAsync(buffer.AsMemory(0, 1), CancellationToken.None));
+        }
+
+        [Theory]
+        [InlineData("a\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        [InlineData("A\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        [InlineData("000000000000000A\r\nhellohello\r\n0\r\n\r\n", "hellohello")]
+        public void Read_ParsesValidHexChunkSizes(string payload, string expected)
+        {
+            using var source = new MemoryStream(Encoding.ASCII.GetBytes(payload));
+            using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+            var buffer = new byte[expected.Length];
+
+            var read = chunked.Read(buffer, 0, buffer.Length);
+
+            Assert.Equal(expected.Length, read);
+            Assert.Equal(expected, Encoding.ASCII.GetString(buffer));
+        }
+
+        [Theory]
+        [InlineData("\r\nhello\r\n0\r\n\r\n")]
+        [InlineData(" 5\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("5 \r\nhello\r\n0\r\n\r\n")]
+        [InlineData("8000000000000000\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("10000000000000000\r\nhello\r\n0\r\n\r\n")]
+        [InlineData("5\rhello\r\n0\r\n\r\n")]
+        public void Read_InvalidChunkSizeLines_Throw(string payload)
+        {
+            using var source = new MemoryStream(Encoding.ASCII.GetBytes(payload));
+            using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+            var buffer = new byte[8];
+
+            Assert.Throws<IOException>(() => chunked.Read(buffer, 0, 1));
+        }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferReadStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferReadStreamTests.cs
@@ -1,0 +1,63 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.IO;
+using System.Text;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class ChunkedTransferReadStreamTests
+    {
+        [Fact]
+        public async Task ReadAsync_ParsesChunkExtensionsAndTrailers()
+        {
+            await using var source = new MemoryStream(
+                Encoding.ASCII.GetBytes("5;foo=bar\r\nhello\r\n0\r\nx-one: 1\r\n\r\n"));
+            await using var chunked = new ChunkedTransferReadStream(source, closeOnDone: false);
+            var buffer = new byte[8];
+
+            await chunked.ReadExactlyAsync(buffer.AsMemory(0, 5), CancellationToken.None);
+
+            Assert.Equal("hello", Encoding.ASCII.GetString(buffer, 0, 5));
+            Assert.Equal(0, await chunked.ReadAsync(buffer, CancellationToken.None));
+            Assert.NotNull(chunked.Trailers);
+            Assert.Single(chunked.Trailers!);
+            Assert.Equal("x-one", chunked.Trailers![0].Name.ToString());
+            Assert.Equal("1", chunked.Trailers[0].Value.ToString());
+        }
+
+        [Fact]
+        public void Read_ParsesChunkExtensionsAndTrailers()
+        {
+            using var source = new MemoryStream(
+                Encoding.ASCII.GetBytes("A;foo=bar\r\nhellohello\r\n0\r\nx-one: 1\r\n\r\n"));
+            using var chunked = new ChunkedTransferReadStream(source, closeOnDone: false);
+            var buffer = new byte[16];
+
+            var read = chunked.Read(buffer, 0, buffer.Length);
+
+            Assert.Equal(10, read);
+            Assert.Equal("hellohello", Encoding.ASCII.GetString(buffer, 0, read));
+            Assert.Equal(0, chunked.Read(buffer, 0, buffer.Length));
+            Assert.NotNull(chunked.Trailers);
+            Assert.Single(chunked.Trailers!);
+            Assert.Equal("x-one", chunked.Trailers![0].Name.ToString());
+            Assert.Equal("1", chunked.Trailers[0].Value.ToString());
+        }
+
+        [Fact]
+        public async Task ReadAsync_InvalidChunkSize_ThrowsIOException()
+        {
+            await using var source = new MemoryStream(Encoding.ASCII.GetBytes("Z\r\nhello\r\n0\r\n\r\n"));
+            await using var chunked = new ChunkedTransferReadStream(source, closeOnDone: true);
+            var buffer = new byte[8];
+
+            await Assert.ThrowsAsync<IOException>(async () =>
+                await chunked.ReadExactlyAsync(buffer.AsMemory(0, 1), CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse HTTP/1.1 chunk-size hex digits directly from bytes
- remove byte-to-char conversion and `long.TryParse` from chunked read hot paths
- remove the per-stream chunk-size char buffer allocation
- add focused tests for extensions, trailers, invalid chunk sizes, hex case, overflow, empty size, missing LF, and whitespace strictness

## Semantics
- hexadecimal chunk sizes remain case-insensitive
- chunk extensions are still ignored after `;`
- trailers are still parsed after the final zero-size chunk
- invalid chunk-size characters, empty chunk sizes, overflow, and malformed CRLF are rejected
- parser remains strict about whitespace in the chunk-size line

## Benchmarks
- 10 MiB, 1 KiB chunks, no extensions: 1.684 ms -> 1.418 ms (~16% faster)
- 10 MiB, 1 KiB chunks, extensions: 2.534 ms -> 2.287 ms (~10% faster)
- 10 MiB, 16 KiB chunks, no extensions: 310.2 us -> 299.5 us (~3.5% faster)
- 10 MiB, 16 KiB chunks, extensions: 386.0 us -> 363.9 us (~6% faster)

## Validation
- `dotnet build -c Release test/Fluxzy.Tests/Fluxzy.Tests.csproj -nr:false`
- `dotnet test -c Release --no-restore --filter 'FullyQualifiedName~ChunkedTransferReadStreamTests|FullyQualifiedName~ChunkedTransferWriteStreamTests' test/Fluxzy.Tests/Fluxzy.Tests.csproj`
- `dotnet build -c Release test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -nr:false`
