### PR TITLE
Optimize chunked write header formatting

### DIFF
--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferWriteStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferWriteStream.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -21,6 +23,7 @@ namespace Fluxzy.Misc.Streams
 
         private static readonly byte[] LineTerminator = { (byte) '\r', (byte) '\n' };
         private readonly Stream _innerStream;
+        private byte[]? _asyncHeaderBuffer;
 
         private bool _eof;
 
@@ -86,17 +89,21 @@ namespace Fluxzy.Misc.Streams
             ReadOnlyMemory<byte> buffer,
             CancellationToken cancellationToken = new())
         {
-            var poolBuffer = ArrayPool<byte>.Shared.Rent(64);
+            var headerBuffer = _asyncHeaderBuffer ??= new byte[10];
+            var headerLength = FormatChunkHeader(buffer.Length, headerBuffer);
+            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(headerBuffer, 0, headerLength), cancellationToken).ConfigureAwait(false);
+            await _innerStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(LineTerminator), cancellationToken).ConfigureAwait(false);
+        }
 
-            try {
-                var cs = Encoding.ASCII.GetBytes($"{buffer.Length:X}\r\n", poolBuffer);
-                await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(poolBuffer, 0, cs), cancellationToken).ConfigureAwait(false);
-                await _innerStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-                await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(LineTerminator), cancellationToken).ConfigureAwait(false);
-            }
-            finally {
-                ArrayPool<byte>.Shared.Return(poolBuffer);
-            }
+        private static int FormatChunkHeader(int count, Span<byte> destination)
+        {
+            if (!Utf8Formatter.TryFormat(count, destination, out var written, 'X'))
+                throw new InvalidOperationException("Chunk header buffer too small.");
+
+            BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(written), 0x0D0A);
+
+            return written + 2;
         }
 
         public ValueTask WriteEof()


### PR DESCRIPTION
## Summary
- reuse a lazy per-stream async chunk header buffer in `ChunkedTransferWriteStream.WriteAsync`
- format async chunk headers with `Utf8Formatter` + `BinaryPrimitives` instead of interpolated strings and `Encoding.ASCII.GetBytes`
- removes per-chunk `ArrayPool<byte>.Rent(64)` / `Return` traffic from the async chunked writer path
- leaves sync write path and trailer handling unchanged from `master`

## Safety Notes
- Buffer is lazy and only allocated after the first async body write.
- EOF/trailer-only paths do not allocate the header buffer.
- 10 bytes is enough for the largest `int` chunk length as hex plus CRLF.
- This assumes normal sequential stream writes. Concurrent writes to the same `ChunkedTransferWriteStream` are still not supported because chunk header/body/terminator sequences can interleave.

## Benchmarks
Base: `master`
Candidate: `perf-chunked-header-buffer-only`
Command:
`dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter '*ChunkedTransferWriteStreamBenchmark*' --job Short --warmupCount 3 --iterationCount 10`

| Benchmark | Base | Candidate | Base Alloc | Candidate Alloc |
| --- | ---: | ---: | ---: | ---: |
| WriteChunkedBodyMemory, 16 KiB chunks | 36.734 us | 11.076 us | 25,744 B | 192 B |
| WriteChunkedBodyMemory, 64 KiB chunks | 9.738 us | 2.935 us | 6,544 B | 192 B |
| WriteTrailerEof, 16 KiB param | 190.6 ns | 188.9 ns | 536 B | 544 B |
| WriteTrailerEof, 64 KiB param | 181.5 ns | 191.5 ns | 536 B | 544 B |

Notes:
- `WriteTrailerEof` does not write body chunks; the lazy async header buffer is not allocated there.
- Trailer EOF timings/allocations are effectively unchanged/noisy.

## Relationship To Existing PR
This isolates the async chunk writer hot-path pieces from stacked PR 8 (`perf-chunked-writer-header-buffer`), which is based on `perf-combined-h2-chunked-optimizations`.

## Validation
- `dotnet build -c Release src/Fluxzy.Core/Fluxzy.Core.csproj -nr:false`
- `dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter '*ChunkedTransferWriteStreamBenchmark*' --job Short --warmupCount 3 --iterationCount 10`
