### PR TITLE
Tune HTTP/2 stream window update cadence

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/H2StreamSetting.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2StreamSetting.cs
@@ -48,6 +48,15 @@ namespace Fluxzy.Clients.H2
             SettingIdentifier.SettingsMaxHeaderListSize,
         };
 
+        /// <summary>
+        ///     Stream window as seen by the peer: RFC 9113 default applies when
+        ///     SettingsInitialWindowSize is not advertised.
+        /// </summary>
+        internal int EffectiveLocalStreamWindow =>
+            AdvertiseSettings.Contains(SettingIdentifier.SettingsInitialWindowSize)
+                ? Local.WindowSize
+                : 65535;
+
         public IEnumerable<(SettingIdentifier SettingIdentifier, int Value)> GetAnnouncementSettings()
         {
             if (AdvertiseSettings.Contains(SettingIdentifier.SettingsHeaderTableSize))

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -40,6 +40,8 @@ namespace Fluxzy.Clients.H2
 
         private int _totalSendOnStream;
 
+        private readonly int _streamWindowUpdateThreshold;
+
         public StreamWorker(
             int streamIdentifier,
             StreamPool parent,
@@ -49,6 +51,7 @@ namespace Fluxzy.Clients.H2
             Parent = parent;
             _exchange = exchange;
             _resetTokenSource = resetTokenSource;
+            _streamWindowUpdateThreshold = Math.Max(1, parent.Context.Setting.Local.WindowSize / 2);
 
             RemoteWindowSize = new WindowSizeHolder(parent.Context.Setting.Remote.WindowSize,
                 streamIdentifier);
@@ -551,7 +554,7 @@ namespace Fluxzy.Clients.H2
 
             _totalSendOnStream += dataSize;
 
-            if (_totalSendOnStream > 1024 * 16) {
+            if (_totalSendOnStream >= _streamWindowUpdateThreshold) {
                 SendWindowUpdate(_totalSendOnStream, StreamIdentifier);
                 _totalSendOnStream = 0;
             }

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -51,7 +51,7 @@ namespace Fluxzy.Clients.H2
             Parent = parent;
             _exchange = exchange;
             _resetTokenSource = resetTokenSource;
-            _streamWindowUpdateThreshold = Math.Max(1, parent.Context.Setting.Local.WindowSize / 2);
+            _streamWindowUpdateThreshold = Math.Max(1, parent.Context.Setting.EffectiveLocalStreamWindow / 2);
 
             RemoteWindowSize = new WindowSizeHolder(parent.Context.Setting.Remote.WindowSize,
                 streamIdentifier);

--- a/test/Fluxzy.Benchmarks/H2WindowUpdateCadenceBenchmark.cs
+++ b/test/Fluxzy.Benchmarks/H2WindowUpdateCadenceBenchmark.cs
@@ -1,0 +1,107 @@
+using BenchmarkDotNet.Attributes;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Core;
+
+namespace Fluxzy.Benchmarks;
+
+/// <summary>
+///     Measures how often the H2 response-body path emits WINDOW_UPDATE write tasks.
+///
+///     Run: dotnet run -c Release -- --filter *H2WindowUpdateCadenceBenchmark*
+/// </summary>
+[MemoryDiagnoser]
+public class H2WindowUpdateCadenceBenchmark
+{
+    private const int FrameSize = 16 * 1024;
+
+    private H2StreamSetting _setting = null!;
+    private Authority _authority;
+    private IHeaderEncoder _headerEncoder = null!;
+    private Exchange _exchange = null!;
+    private int _streamWindowUpdates;
+    private int _connectionWindowUpdates;
+    private int _streamUpdateBytes;
+    private int _connectionUpdateBytes;
+
+    [Params(64 * 1024, 1024 * 1024, 10 * 1024 * 1024)]
+    public int ResponseBytes { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _authority = new Authority("bench.local", 443, true);
+        _setting = new H2StreamSetting();
+
+        var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
+        var hpackEncoder = new HPackEncoder(new EncodingContext(memoryProvider));
+        var hpackDecoder = new HPackDecoder(new DecodingContext(_authority, memoryProvider));
+        _headerEncoder = new HeaderEncoder(hpackEncoder, hpackDecoder, _setting);
+        _exchange = MakeExchange();
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _streamWindowUpdates = 0;
+        _connectionWindowUpdates = 0;
+        _streamUpdateBytes = 0;
+        _connectionUpdateBytes = 0;
+    }
+
+    [Benchmark]
+    public int ConsumeResponseBody()
+    {
+        using var overallWindow = new WindowSizeHolder(_setting.OverallWindowSize, 0);
+
+        UpStreamChannel upStreamChannel = (ref WriteTask writeTask) => {
+            if (writeTask.StreamIdentifier == 0) {
+                _connectionWindowUpdates++;
+                _connectionUpdateBytes += writeTask.WindowUpdateSize;
+                return;
+            }
+
+            _streamWindowUpdates++;
+            _streamUpdateBytes += writeTask.WindowUpdateSize;
+        };
+
+        var context = new StreamContext(
+            connectionId: 1,
+            authority: _authority,
+            setting: _setting,
+            headerEncoder: _headerEncoder,
+            upStreamChannel: upStreamChannel,
+            overallWindowSizeHolder: overallWindow);
+
+        using var resetTokenSource = new CancellationTokenSource();
+        using var streamPool = new StreamPool(context);
+        using var streamWorker = new StreamWorker(1, streamPool, _exchange, resetTokenSource);
+
+        var remaining = ResponseBytes;
+
+        while (remaining > 0) {
+            var dataSize = Math.Min(FrameSize, remaining);
+            streamWorker.OnDataConsumedByCaller(dataSize);
+            remaining -= dataSize;
+        }
+
+        return _streamWindowUpdates ^ _connectionWindowUpdates ^ _streamUpdateBytes ^ _connectionUpdateBytes;
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        Console.WriteLine(
+            $"ResponseBytes={ResponseBytes}, StreamWindowUpdates={_streamWindowUpdates}, " +
+            $"ConnectionWindowUpdates={_connectionWindowUpdates}, " +
+            $"StreamUpdateBytes={_streamUpdateBytes}, ConnectionUpdateBytes={_connectionUpdateBytes}");
+    }
+
+    private Exchange MakeExchange()
+    {
+        var header = "GET / HTTP/2.0\r\nhost: bench.local\r\n\r\n".AsMemory();
+        return new Exchange(IIdProvider.FromZero, _authority, header, "HTTP/2", DateTime.UtcNow);
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerWindowUpdateTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerWindowUpdateTests.cs
@@ -1,0 +1,152 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Threading;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    public class StreamWorkerWindowUpdateTests
+    {
+        private const int FrameSize = 16 * 1024;
+
+        [Fact]
+        public void ResponseConsumption_UsesHalfLocalWindowForStreamWindowUpdates()
+        {
+            var setting = new H2StreamSetting();
+            var recorder = new WindowUpdateRecorder();
+
+            using var fixture = CreateWorker(setting, recorder.Record);
+
+            Consume(fixture.Worker, 10 * 1024 * 1024);
+
+            Assert.Equal(3, recorder.StreamWindowUpdates);
+            Assert.Equal(9 * 1024 * 1024, recorder.StreamWindowUpdateBytes);
+        }
+
+        [Fact]
+        public void ResponseConsumption_PreservesSmallWindowReplenishment()
+        {
+            var setting = new H2StreamSetting();
+            setting.Local.WindowSize = 64 * 1024;
+
+            var recorder = new WindowUpdateRecorder();
+
+            using var fixture = CreateWorker(setting, recorder.Record);
+
+            Consume(fixture.Worker, 64 * 1024);
+
+            Assert.Equal(2, recorder.StreamWindowUpdates);
+            Assert.Equal(64 * 1024, recorder.StreamWindowUpdateBytes);
+        }
+
+        [Fact]
+        public void ResponseConsumption_PreservesOneKiBWindowReplenishment()
+        {
+            var setting = new H2StreamSetting();
+            setting.Local.WindowSize = 1024;
+
+            var recorder = new WindowUpdateRecorder();
+
+            using var fixture = CreateWorker(setting, recorder.Record);
+
+            Consume(fixture.Worker, 4 * 1024, frameSize: 1024);
+
+            Assert.Equal(4, recorder.StreamWindowUpdates);
+            Assert.Equal(4 * 1024, recorder.StreamWindowUpdateBytes);
+        }
+
+        private static WorkerFixture CreateWorker(H2StreamSetting setting, UpStreamChannel upStreamChannel)
+        {
+            var authority = new Authority("test.local", 443, true);
+            var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
+            var hpackEncoder = new HPackEncoder(new EncodingContext(memoryProvider));
+            var hpackDecoder = new HPackDecoder(new DecodingContext(authority, memoryProvider));
+            var headerEncoder = new HeaderEncoder(hpackEncoder, hpackDecoder, setting);
+            var overallWindow = new WindowSizeHolder(setting.OverallWindowSize, 0);
+
+            var context = new StreamContext(
+                connectionId: 1,
+                authority: authority,
+                setting: setting,
+                headerEncoder: headerEncoder,
+                upStreamChannel: upStreamChannel,
+                overallWindowSizeHolder: overallWindow);
+
+            var streamPool = new StreamPool(context);
+            var resetTokenSource = new CancellationTokenSource();
+            var exchange = MakeExchange(authority);
+
+            var worker = new StreamWorker(1, streamPool, exchange, resetTokenSource);
+
+            return new WorkerFixture(worker, streamPool, overallWindow, resetTokenSource);
+        }
+
+        private static void Consume(StreamWorker worker, int responseBytes, int frameSize = FrameSize)
+        {
+            var remaining = responseBytes;
+
+            while (remaining > 0) {
+                var dataSize = Math.Min(frameSize, remaining);
+                worker.OnDataConsumedByCaller(dataSize);
+                remaining -= dataSize;
+            }
+        }
+
+        private static Exchange MakeExchange(Authority authority)
+        {
+            var header = "GET / HTTP/2.0\r\nhost: test.local\r\n\r\n".AsMemory();
+            return new Exchange(IIdProvider.FromZero, authority, header, "HTTP/2", DateTime.UtcNow);
+        }
+
+        private class WindowUpdateRecorder
+        {
+            public int StreamWindowUpdates { get; private set; }
+
+            public int StreamWindowUpdateBytes { get; private set; }
+
+            public void Record(ref WriteTask writeTask)
+            {
+                if (writeTask.FrameType != H2FrameType.WindowUpdate || writeTask.StreamIdentifier == 0)
+                    return;
+
+                StreamWindowUpdates++;
+                StreamWindowUpdateBytes += writeTask.WindowUpdateSize;
+            }
+        }
+
+        private sealed class WorkerFixture : IDisposable
+        {
+            private readonly StreamPool _streamPool;
+            private readonly WindowSizeHolder _overallWindow;
+            private readonly CancellationTokenSource _resetTokenSource;
+
+            public WorkerFixture(
+                StreamWorker worker,
+                StreamPool streamPool,
+                WindowSizeHolder overallWindow,
+                CancellationTokenSource resetTokenSource)
+            {
+                Worker = worker;
+                _streamPool = streamPool;
+                _overallWindow = overallWindow;
+                _resetTokenSource = resetTokenSource;
+            }
+
+            public StreamWorker Worker { get; }
+
+            public void Dispose()
+            {
+                Worker.Dispose();
+                _streamPool.Dispose();
+                _overallWindow.Dispose();
+                _resetTokenSource.Dispose();
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerWindowUpdateTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerWindowUpdateTests.cs
@@ -6,6 +6,7 @@ using Fluxzy.Clients;
 using Fluxzy.Clients.H2;
 using Fluxzy.Clients.H2.Encoder;
 using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Clients.H2.Frames;
 using Fluxzy.Core;
 using Xunit;
 
@@ -59,6 +60,22 @@ namespace Fluxzy.Tests.UnitTests.H2Client
 
             Assert.Equal(4, recorder.StreamWindowUpdates);
             Assert.Equal(4 * 1024, recorder.StreamWindowUpdateBytes);
+        }
+
+        [Fact]
+        public void ResponseConsumption_UsesRfcDefaultWindowWhenInitialWindowSizeNotAdvertised()
+        {
+            var setting = new H2StreamSetting();
+            setting.AdvertiseSettings.Remove(SettingIdentifier.SettingsInitialWindowSize);
+
+            var recorder = new WindowUpdateRecorder();
+
+            using var fixture = CreateWorker(setting, recorder.Record);
+
+            Consume(fixture.Worker, 128 * 1024);
+
+            Assert.Equal(4, recorder.StreamWindowUpdates);
+            Assert.Equal(128 * 1024, recorder.StreamWindowUpdateBytes);
         }
 
         private static WorkerFixture CreateWorker(H2StreamSetting setting, UpStreamChannel upStreamChannel)


### PR DESCRIPTION
## Summary
- reduce stream-level H2 WINDOW_UPDATE cadence from a fixed ~16 KiB threshold to half the advertised local stream window
- cache the stream update threshold per StreamWorker
- add a focused benchmark and tests for default and small-window behavior

## Why
The response-body path emitted stream-level WINDOW_UPDATE frames very frequently for large H2 responses. With 16 KiB DATA frames, a 10 MiB response produced 320 stream-level updates even though the default advertised local stream window is 6 MiB.

## Benchmarks
Command:
`dotnet run -c Release --project test/Fluxzy.Benchmarks/Fluxzy.Benchmarks.csproj -- --filter '*H2WindowUpdateCadenceBenchmark*' --job Short --warmupCount 3 --iterationCount 10`

Baseline `origin/master`:

| Response | Stream updates | Mean | Allocated |
|---:|---:|---:|---:|
| 64 KiB | 2 | 5.311 us | 2.41 KB |
| 1 MiB | 32 | 9.823 us | 5.23 KB |
| 10 MiB | 320 | 67.270 us | 32.51 KB |

Candidate:

| Response | Stream updates | Mean | Allocated |
|---:|---:|---:|---:|
| 64 KiB | 0 | 4.952 us | 2.23 KB |
| 1 MiB | 0 | 7.168 us | 2.23 KB |
| 10 MiB | 3 | 22.681 us | 2.79 KB |


## Validation
- `dotnet build -c Release src/Fluxzy.Core/Fluxzy.Core.csproj -nr:false`
- `dotnet test test/Fluxzy.Tests/Fluxzy.Tests.csproj -c Release --filter StreamWorkerWindowUpdateTests --no-restore`

Both passed with existing warnings.