### PR TITLE
Bound upstream connection establishment and release authority lock waiters on client abort

### DIFF
--- a/src/Fluxzy.Core.Pcap/CapturableConnection.cs
+++ b/src/Fluxzy.Core.Pcap/CapturableConnection.cs
@@ -49,8 +49,12 @@ namespace Fluxzy.Core.Pcap
         public Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress remoteAddress, int remotePort)
             => ConnectAsync(remoteAddress, remotePort, UpstreamConnectOptions.None);
 
-        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+        public Task<ITcpConnectionConnectResult> ConnectAsync(
             IPAddress remoteAddress, int remotePort, UpstreamConnectOptions options)
+            => ConnectAsync(remoteAddress, remotePort, options, CancellationToken.None);
+
+        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+            IPAddress remoteAddress, int remotePort, UpstreamConnectOptions options, CancellationToken token)
         {
             if (_stream != null)
                 throw new InvalidOperationException("A previous connect attempt was already made");
@@ -70,7 +74,7 @@ namespace Fluxzy.Core.Pcap
             _captureContext.Include(remoteAddress, remotePort);
 
             try {
-                await _innerTcpClient.ConnectAsync(remoteAddress, remotePort).ConfigureAwait(false);
+                await _innerTcpClient.ConnectAsync(remoteAddress, remotePort, token).ConfigureAwait(false);
             }
             catch {
                 connectError = true;

--- a/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
+++ b/src/Fluxzy.Core/Clients/IRemoteConnectionBuilder.cs
@@ -52,6 +52,50 @@ namespace Fluxzy.Clients
             ProxyConfiguration? proxyConfiguration,
             CancellationToken token)
         {
+            var connectionTimeout = setting.ConnectionTimeout;
+
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+            if (connectionTimeout > TimeSpan.Zero && connectionTimeout != Timeout.InfiniteTimeSpan)
+                connectCts.CancelAfter(connectionTimeout);
+
+            var connectToken = connectCts.Token;
+
+            DisposeEventNotifierStream? openedStream = null;
+
+            try {
+                return await OpenConnectionToRemoteInternal(
+                        exchange, resolutionResult, httpProtocols, setting, proxyConfiguration,
+                        s => openedStream = s, connectToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) {
+                if (openedStream != null) {
+                    try {
+                        await openedStream.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch {
+                    }
+                }
+
+                if (token.IsCancellationRequested)
+                    throw;
+
+                throw new ClientErrorException(0,
+                    $"The connection to {exchange.Authority.HostName}:{exchange.Authority.Port} " +
+                    $"could not be established within {connectionTimeout.TotalSeconds:F0} seconds",
+                    networkErrorCode: NetworkErrorCodes.ConnectionTimeout);
+            }
+        }
+
+        private async ValueTask<RemoteConnectionResult> OpenConnectionToRemoteInternal(
+            Exchange exchange, DnsResolutionResult resolutionResult,
+            List<SslApplicationProtocol> httpProtocols,
+            ProxyRuntimeSetting setting,
+            ProxyConfiguration? proxyConfiguration,
+            Action<DisposeEventNotifierStream> onStreamOpened,
+            CancellationToken token)
+        {
             exchange.Connection = new Connection(exchange.Authority, setting.IdProvider) {
                 TcpConnectionOpening = _timeProvider.Instant(),
 
@@ -67,13 +111,15 @@ namespace Fluxzy.Clients
                                            setting.ArchiveWriter != null!
                                            ? setting.ArchiveWriter.GetDumpfilePath(exchange.Connection.Id)!
                                            : string.Empty);
-            
+
             var connectOptions = new UpstreamConnectOptions(
                 exchange.Authority.HostName, exchange.Authority.Port, setting.ConfigureUpstreamSocket);
 
             var connectResult = await tcpConnection.ConnectAsync(
                 resolutionResult.EndPoint.Address,
-                resolutionResult.EndPoint.Port, connectOptions).ConfigureAwait(false);
+                resolutionResult.EndPoint.Port, connectOptions, token).ConfigureAwait(false);
+
+            onStreamOpened(connectResult.Stream);
 
             exchange.Connection.TcpConnectionOpened = _timeProvider.Instant();
             exchange.Connection.LocalPort = connectResult.Stream.LocalEndPoint.Port;
@@ -93,7 +139,8 @@ namespace Fluxzy.Clients
                         exchange.Authority.Port, proxyConfiguration.ProxyAuthorizationHeader);
 
                     var proxyOpenResult =
-                        await UpstreamProxyManager.Connect(connectConfiguration, newlyOpenedStream, newlyOpenedStream);
+                        await UpstreamProxyManager.Connect(connectConfiguration, newlyOpenedStream, newlyOpenedStream)
+                                                  .AsTask().WaitAsync(token).ConfigureAwait(false);
 
                     if (proxyOpenResult != UpstreamProxyConnectResult.Ok)
                         throw new InvalidOperationException($"Failed to connect to upstream proxy {proxyOpenResult}");

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -131,7 +131,10 @@ namespace Fluxzy.Clients
             }
 
             // Slow path: acquire per-authority semaphore for pool creation
-            using var syncGuard = await _synchronizer.LockAsync(exchange.Authority);
+            using var syncGuard = await _synchronizer.LockAsync(exchange.Authority, cancellationToken)
+                                                     .ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             // Double-check after acquiring semaphore — another thread may have
             // created the pool while we waited.

--- a/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BouncyCastleConnectionBuilder.cs
+++ b/src/Fluxzy.Core/Clients/Ssl/BouncyCastle/BouncyCastleConnectionBuilder.cs
@@ -59,12 +59,18 @@ namespace Fluxzy.Clients.Ssl.BouncyCastle
 
             var protocol = new FluxzyClientProtocol(innerStream, fingerPrintEnforcer, nssWriter);
 
+            // BC's ConnectAsync does not take a token: closing the inner stream is the
+            // only way to abort a pending handshake read.
+            using var tokenRegistration = token.Register(s => ((Stream) s!).Close(), innerStream);
+
             try
             {
                 await protocol.ConnectAsync(client).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
+                token.ThrowIfCancellationRequested();
+
                 var networkErrorCode = MapTlsAlert(ex);
 
                 throw new ClientErrorException(0,

--- a/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
+++ b/src/Fluxzy.Core/Core/DownStreamAbortWatchdog.cs
@@ -9,13 +9,14 @@ namespace Fluxzy.Core
 {
     /// <summary>
     ///     Detects a downstream client abort (FIN/RST) while a sequential exchange is parked
-    ///     on upstream I/O and cancels the connection token source so the upstream work is
-    ///     released. One instance lives per downstream connection; exchanges are armed and
-    ///     disarmed via <see cref="Watch"/>/<see cref="Unwatch"/>, so the per-request cost is
-    ///     two uncontended lock operations and no allocation. The poll only runs once the
-    ///     request body has been fully consumed, so nothing else reads the client socket
-    ///     during the check (data still readable then means a pipelined request, not an
-    ///     abort). The gate guarantees no cancel can fire after Unwatch returns.
+    ///     on upstream work (pool acquisition, connect, TLS handshake or response wait) and
+    ///     cancels the connection token source so that work is released. One instance lives
+    ///     per downstream connection; exchanges are armed and disarmed via
+    ///     <see cref="Watch"/>/<see cref="Unwatch"/>. The poll only runs while nothing else
+    ///     reads the client socket: either before anything has been sent upstream, or once
+    ///     the request body has been fully forwarded (data still readable then means a
+    ///     pipelined request, not an abort). The gate guarantees no cancel can fire after
+    ///     Unwatch returns.
     /// </summary>
     internal sealed class DownStreamAbortWatchdog : IAsyncDisposable
     {
@@ -64,7 +65,7 @@ namespace Fluxzy.Core
                     lock (_gate) {
                         var exchange = _watched;
 
-                        if (exchange == null || exchange.Metrics.RequestBodySent == default)
+                        if (exchange == null || !IsPollSafe(exchange))
                             continue;
 
                         if (!IsSocketAborted(_socket))
@@ -79,6 +80,17 @@ namespace Fluxzy.Core
             }
             catch (ObjectDisposedException) {
             }
+        }
+
+        private static bool IsPollSafe(Exchange exchange)
+        {
+            if (exchange.Metrics.RequestBodySent != default)
+                return true;
+
+            // Before the upstream send starts, only a request body substitution may
+            // read the client socket.
+            return exchange.Metrics.RequestHeaderSending == default
+                   && !exchange.Context.HasRequestBodySubstitution;
         }
 
         private static bool IsSocketAborted(Socket socket)

--- a/src/Fluxzy.Core/Core/ITcpConnection.cs
+++ b/src/Fluxzy.Core/Core/ITcpConnection.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Misc.Streams;
 
@@ -14,6 +15,10 @@ namespace Fluxzy.Core
 
         Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port, UpstreamConnectOptions options)
             => ConnectAsync(address, port);
+
+        Task<ITcpConnectionConnectResult> ConnectAsync(
+            IPAddress address, int port, UpstreamConnectOptions options, CancellationToken token)
+            => ConnectAsync(address, port, options);
     }
 
     public interface ITcpConnectionConnectResult

--- a/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
+++ b/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Misc.Streams;
 
@@ -28,8 +29,12 @@ namespace Fluxzy.Core
         public Task<ITcpConnectionConnectResult> ConnectAsync(IPAddress address, int port)
             => ConnectAsync(address, port, UpstreamConnectOptions.None);
 
-        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+        public Task<ITcpConnectionConnectResult> ConnectAsync(
             IPAddress address, int port, UpstreamConnectOptions options)
+            => ConnectAsync(address, port, options, CancellationToken.None);
+
+        public async Task<ITcpConnectionConnectResult> ConnectAsync(
+            IPAddress address, int port, UpstreamConnectOptions options, CancellationToken token)
         {
             TcpClient? client = null;
 
@@ -37,7 +42,7 @@ namespace Fluxzy.Core
                 client = new TcpClient(address.AddressFamily);
                 client.NoDelay = true;
                 options.Apply(client.Client, new IPEndPoint(address, port));
-                await client.ConnectAsync(address, port).ConfigureAwait(false);
+                await client.ConnectAsync(address, port, token).ConfigureAwait(false);
                 var stream = new DisposeEventNotifierStream(client, null);
                 return new DefaultTcpConnectionConnectResult(stream);
             }

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -53,6 +53,7 @@ namespace Fluxzy.Core
             UserAgentProvider = userAgentProvider;
             ConcurrentConnection = startupSetting.ConnectionPerHost;
             ExpectContinueTimeout = startupSetting.ExpectContinueTimeout;
+            ConnectionTimeout = startupSetting.ConnectionTimeout;
             ResponseHeaderTimeout = startupSetting.ResponseHeaderTimeout;
             ResponseBodyIdleTimeout = startupSetting.ResponseBodyIdleTimeout;
             ActionMapping = new SetUserAgentActionMapping(startupSetting.UserAgentActionConfigurationFile);
@@ -102,6 +103,12 @@ namespace Fluxzy.Core
         ///     Matches .NET's default `Expect100ContinueTimeout` of 1 second.
         /// </summary>
         public TimeSpan ExpectContinueTimeout { get; set; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        ///     Maximum time to fully establish an upstream connection (TCP connect,
+        ///     upstream proxy CONNECT, TLS handshake). Non-positive or infinite disables it.
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(45);
 
         /// <summary>
         ///     Maximum time to wait for the upstream response header after the request has

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -241,6 +241,20 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Configure how long the proxy waits for an upstream connection to be fully
+        ///     established (TCP connect, optional upstream proxy CONNECT and TLS handshake).
+        ///     When the delay expires, the attempt is aborted and the client receives a 528
+        ///     carrying the network error code `connection_timeout`. A value of
+        ///     <see cref="TimeSpan.Zero"/>, negative or
+        ///     <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> disables the timeout.
+        /// </summary>
+        public FluxzySetting SetConnectionTimeout(TimeSpan timeout)
+        {
+            ConnectionTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
         ///     Configure how long the proxy waits for the upstream response header once the
         ///     request has been fully sent. When the delay expires, the upstream connection
         ///     is aborted and the client receives a 528 carrying the network error code

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -68,6 +68,17 @@ namespace Fluxzy
         public TimeSpan ExpectContinueTimeout { get; internal set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
+        ///     Maximum time fluxzy waits for an upstream connection to be fully established:
+        ///     TCP connect, optional upstream proxy CONNECT and TLS handshake. When exceeded,
+        ///     the attempt is aborted and a 528 with network error code `connection_timeout`
+        ///     is returned. Zero, negative or
+        ///     <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> disables the timeout.
+        ///     Default: 45 seconds.
+        /// </summary>
+        [JsonInclude]
+        public TimeSpan ConnectionTimeout { get; internal set; } = TimeSpan.FromSeconds(45);
+
+        /// <summary>
         ///     Maximum time fluxzy waits for the upstream response header after the request
         ///     has been fully sent. When exceeded, the upstream connection is aborted and a
         ///     528 with network error code `response_header_timeout` is returned. Zero,

--- a/src/Fluxzy.Core/Utils/Synchronizer.cs
+++ b/src/Fluxzy.Core/Utils/Synchronizer.cs
@@ -20,7 +20,7 @@ namespace Fluxzy.Utils
             _preserve = preserve;
         }
 
-        public async ValueTask<IDisposable> LockAsync(T key)
+        public async ValueTask<IDisposable> LockAsync(T key, CancellationToken token = default)
         {
             LockInfo lockInfo;
 
@@ -40,7 +40,16 @@ namespace Fluxzy.Utils
                 }
             }
 
-            await lockInfo.Semaphore.WaitAsync();
+            try
+            {
+                await lockInfo.Semaphore.WaitAsync(token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                Interlocked.Decrement(ref lockInfo.WaitingCount);
+                TryCleanup(key, lockInfo);
+                throw;
+            }
 
             Interlocked.Increment(ref lockInfo.OwnerCount);
             Interlocked.Decrement(ref lockInfo.WaitingCount);
@@ -55,6 +64,11 @@ namespace Fluxzy.Utils
             lockInfo.Semaphore.Release();
             Interlocked.Decrement(ref lockInfo.OwnerCount);
 
+            TryCleanup(key, lockInfo);
+        }
+
+        private void TryCleanup(T key, LockInfo lockInfo)
+        {
             if (_preserve)
                 return;
 

--- a/test/Fluxzy.Tests/Cases/UpstreamTlsHandshakeHangTests.cs
+++ b/test/Fluxzy.Tests/Cases/UpstreamTlsHandshakeHangTests.cs
@@ -1,0 +1,174 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.Cases
+{
+    /// <summary>
+    ///     Regression tests for upstream hosts that accept the TCP connection but never
+    ///     answer the TLS ClientHello (haga-rak/fluxzy.core#634). Before the fix, the
+    ///     handshake read parked forever while holding the per-authority pool creation
+    ///     lock, wedging every further exchange to the same authority.
+    /// </summary>
+    public class UpstreamTlsHandshakeHangTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Handshake_Tarpit_Times_Out_With_Connection_Timeout(bool useBouncyCastle)
+        {
+            await using var server = HandshakeTarpitServer.Start();
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            if (useBouncyCastle)
+                setting.UseBouncyCastleSslEngine();
+
+            setting.SetConnectionTimeout(TimeSpan.FromSeconds(2));
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(40);
+
+            var watch = Stopwatch.StartNew();
+
+            using var response = await client.GetAsync($"https://local.fluxzy.io:{server.Port}/");
+
+            watch.Stop();
+
+            Assert.Equal(528, (int) response.StatusCode);
+
+            Assert.True(response.Headers.TryGetValues("x-fluxzy-network-error", out var errorCodes));
+            Assert.Equal(NetworkErrorCodes.ConnectionTimeout, errorCodes!.First());
+
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20),
+                $"Timeout was configured at 2s but the response took {watch.Elapsed}");
+
+            Assert.True(await server.WaitForTeardown(TimeSpan.FromSeconds(10)),
+                "The hung upstream connection should be aborted when the timeout fires");
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task Client_Abort_Tears_Down_Hung_Handshake(bool useBouncyCastle)
+        {
+            await using var server = HandshakeTarpitServer.Start();
+
+            var setting = FluxzySetting.CreateLocalRandomPort();
+
+            if (useBouncyCastle)
+                setting.UseBouncyCastleSslEngine();
+
+            setting.SetConnectionTimeout(TimeSpan.FromSeconds(120));
+
+            await using var proxy = new Proxy(setting);
+
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting);
+            client.Timeout = TimeSpan.FromSeconds(2);
+
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => client.GetAsync($"https://local.fluxzy.io:{server.Port}/"));
+
+            Assert.True(await server.WaitForTeardown(TimeSpan.FromSeconds(10)),
+                "The hung handshake should be torn down shortly after the downstream " +
+                "client aborts, instead of parking until the connection timeout");
+        }
+
+        /// <summary>
+        ///     Accepts connections, reads and discards everything, never writes a byte.
+        ///     Signals when its first connection is torn down.
+        /// </summary>
+        private sealed class HandshakeTarpitServer : IAsyncDisposable
+        {
+            private readonly TcpListener _listener;
+            private readonly CancellationTokenSource _cts = new();
+            private readonly Task _acceptLoop;
+
+            private readonly TaskCompletionSource<bool> _tornDown =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private HandshakeTarpitServer()
+            {
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                Port = ((IPEndPoint) _listener.LocalEndpoint).Port;
+                _acceptLoop = AcceptLoopAsync();
+            }
+
+            public int Port { get; }
+
+            public static HandshakeTarpitServer Start()
+            {
+                return new HandshakeTarpitServer();
+            }
+
+            public async Task<bool> WaitForTeardown(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_tornDown.Task, Task.Delay(timeout, _cts.Token));
+
+                return completed == _tornDown.Task;
+            }
+
+            private async Task AcceptLoopAsync()
+            {
+                try {
+                    while (!_cts.IsCancellationRequested) {
+                        var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                        _ = HandleClientAsync(client);
+                    }
+                }
+                catch {
+                    // listener stopped
+                }
+            }
+
+            private async Task HandleClientAsync(TcpClient client)
+            {
+                try {
+                    using var _ = client;
+
+                    var stream = client.GetStream();
+                    var buffer = new byte[16 * 1024];
+
+                    while (true) {
+                        var read = await stream.ReadAsync(buffer, _cts.Token);
+
+                        if (read == 0)
+                            return;
+                    }
+                }
+                catch {
+                    // FIN/RST/abort observed
+                }
+                finally {
+                    _tornDown.TrySetResult(true);
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _cts.Cancel();
+                _listener.Stop();
+
+                try {
+                    await _acceptLoop;
+                }
+                catch {
+                }
+
+                _cts.Dispose();
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/SynchronizerTests.cs
@@ -133,6 +133,78 @@ namespace Fluxzy.Tests.UnitTests.Util
         }
 
         [Fact]
+        public async Task DefaultMode_CancelledWaiterLeavesQueue()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            var authority = new Authority("host.example.com", 443, true);
+
+            var holder = await synchronizer.LockAsync(authority);
+
+            using var cts = new CancellationTokenSource();
+            var waiterTask = synchronizer.LockAsync(authority, cts.Token).AsTask();
+
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiterTask);
+
+            // The holder still owns the entry
+            Assert.Equal(1, GetRegistryCount(synchronizer));
+
+            holder.Dispose();
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+
+            // The lock stays usable after a cancelled wait
+            (await synchronizer.LockAsync(authority)).Dispose();
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public async Task DefaultMode_PreCancelledTokenDoesNotLeakEntry()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            var authority = new Authority("host.example.com", 443, true);
+
+            var token = new CancellationToken(true);
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await synchronizer.LockAsync(authority, token));
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
+        public async Task DefaultMode_CancelledWaitersDoNotBlockRemainingWaiters()
+        {
+            var synchronizer = new Synchronizer<Authority>();
+            var authority = new Authority("host.example.com", 443, true);
+
+            var holder = await synchronizer.LockAsync(authority);
+
+            using var cts = new CancellationTokenSource();
+
+            var cancelledWaiters = Enumerable.Range(0, 16)
+                .Select(_ => synchronizer.LockAsync(authority, cts.Token).AsTask())
+                .ToList();
+
+            var survivingWaiter = synchronizer.LockAsync(authority).AsTask();
+
+            cts.Cancel();
+
+            foreach (var waiter in cancelledWaiters)
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiter);
+
+            Assert.False(survivingWaiter.IsCompleted);
+
+            holder.Dispose();
+
+            (await survivingWaiter).Dispose();
+
+            Assert.Equal(0, GetRegistryCount(synchronizer));
+        }
+
+        [Fact]
         public void PoolBuilder_UsesSelfCleaningSynchronizer()
         {
             // Guards against reintroducing the unbounded per-authority lock registry


### PR DESCRIPTION
Fixes the third wedge reported in #634: a TLS handshake that never completes holds the per authority pool creation lock indefinitely, and waiters cannot be cancelled, so abandoned exchanges pile up behind it until the proxy wedges.

- Synchronizer.LockAsync accepts a CancellationToken; a cancelled waiter leaves the queue and cleans up its registry entry. PoolBuilder passes the exchange token and rechecks it after acquiring the lock.
- New ConnectionTimeout setting (default 45 seconds, SetConnectionTimeout, disabled with zero, negative or infinite) bounding TCP connect, upstream proxy CONNECT and TLS handshake. On expiry the socket is disposed and the client receives a 528 with the connection_timeout error code.
- ITcpConnection gets a cancellable ConnectAsync overload (default interface method, no breaking change).
- The BouncyCastle handshake aborts on cancellation by closing the inner stream, since the BC API takes no token. SChannel already honored the token.
- DownStreamAbortWatchdog also polls while nothing has been sent upstream, so a client abort releases exchanges parked in pool acquisition, connect or handshake. Polling stays disabled during the request body substitution window.

Tests: handshake tarpit integration tests on both SSL engines (timeout path and client abort path) plus Synchronizer cancellation unit tests.