### PR TITLE
Render readable Unicode in formatted JSON response body

### DIFF
--- a/src/Fluxzy.Core/Formatters/Producers/Responses/ResponseBodyJsonProducer.cs
+++ b/src/Fluxzy.Core/Formatters/Producers/Responses/ResponseBodyJsonProducer.cs
@@ -1,9 +1,12 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Fluxzy.Formatters.Producers.Responses
 {
@@ -17,18 +20,7 @@ namespace Fluxzy.Formatters.Producers.Responses
                 if (context.ResponseBodyText == null)
                     return null;
 
-                
-                using var document = JsonDocument.Parse(context.ResponseBodyText);
-
-                var outStream = new MemoryStream();
-
-                using (var jsonWriter = new Utf8JsonWriter(outStream, new JsonWriterOptions {
-                           Indented = true
-                       })) {
-                    document.WriteTo(jsonWriter);
-                }
-
-                var formattedValue = Encoding.UTF8.GetString(outStream.GetBuffer(), 0, (int) outStream.Length);
+                var formattedValue = Format(context.ResponseBodyText);
 
                 return new ResponseJsonResult(ResultTitle, formattedValue);
             }
@@ -38,6 +30,47 @@ namespace Fluxzy.Formatters.Producers.Responses
 
                 throw;
             }
+        }
+
+        internal static string Format(string rawJson)
+        {
+            using var document = JsonDocument.Parse(rawJson);
+
+            var outStream = new MemoryStream();
+
+            // The relaxed encoder keeps non ASCII characters readable instead of \uXXXX,
+            // safe here as the output is displayed as plain text, never as HTML
+            using (var jsonWriter = new Utf8JsonWriter(outStream, new JsonWriterOptions {
+                       Indented = true,
+                       Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                   })) {
+                document.WriteTo(jsonWriter);
+            }
+
+            var formattedValue = Encoding.UTF8.GetString(outStream.GetBuffer(), 0, (int) outStream.Length);
+
+            return UnescapeSurrogatePairs(formattedValue);
+        }
+
+        // JavaScriptEncoder allow lists only cover the basic multilingual plane,
+        // characters above U+FFFF stay escaped by the writer and are restored here.
+        // The lookbehind requires an even number of preceding backslashes so that
+        // a literal backslash followed by "uXXXX" text is never decoded.
+        private static readonly Regex SurrogatePairRegex = new(
+            @"(?<=(?:^|[^\\])(?:\\\\)*)\\u(?<high>[Dd][89ABab][0-9A-Fa-f]{2})\\u(?<low>[Dd][C-Fc-f][0-9A-Fa-f]{2})",
+            RegexOptions.Compiled);
+
+        private static string UnescapeSurrogatePairs(string formattedJson)
+        {
+            return SurrogatePairRegex.Replace(formattedJson, match => {
+                var high = (char) ushort.Parse(match.Groups["high"].Value, NumberStyles.HexNumber,
+                    CultureInfo.InvariantCulture);
+
+                var low = (char) ushort.Parse(match.Groups["low"].Value, NumberStyles.HexNumber,
+                    CultureInfo.InvariantCulture);
+
+                return new string(new[] { high, low });
+            });
         }
     }
 

--- a/test/Fluxzy.Tests/UnitTests/Formatters/ResponseBodyJsonFormattingTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Formatters/ResponseBodyJsonFormattingTests.cs
@@ -1,0 +1,124 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Text.Json;
+using Fluxzy.Formatters.Producers.Responses;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Formatters
+{
+    public class ResponseBodyJsonFormattingTests
+    {
+        [Fact]
+        public void Decode_Unicode_Escapes()
+        {
+            var result = ResponseBodyJsonProducer.Format(
+                "{\"hebrew\":\"\\u05E9\\u05DC\\u05D5\\u05DD\"}");
+
+            Assert.Contains("\"שלום\"", result);
+        }
+
+        [Fact]
+        public void Combine_Surrogate_Pairs()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"emoji\":\"\\uD83D\\uDE00\"}");
+
+            Assert.Contains("\"😀\"", result);
+        }
+
+        [Fact]
+        public void Combine_Consecutive_Surrogate_Pairs()
+        {
+            var result = ResponseBodyJsonProducer.Format(
+                "{\"emoji\":\"\\uD83D\\uDE00\\uD83D\\uDE01\"}");
+
+            Assert.Contains("\"😀😁\"", result);
+        }
+
+        [Fact]
+        public void Keep_Raw_Non_Ascii_Readable()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"hebrew\":\"שלום\",\"emoji\":\"😀\"}");
+
+            Assert.Contains("\"שלום\"", result);
+            Assert.Contains("\"😀\"", result);
+        }
+
+        [Fact]
+        public void Decode_Escaped_Html_Characters()
+        {
+            var result = ResponseBodyJsonProducer.Format(
+                "{\"html\":\"\\u003Cspan class=\\u0022em\\u0022\\u003E\\u05E9\\u003C/span\\u003E\"}");
+
+            Assert.Contains("\"<span class=\\\"em\\\">ש</span>\"", result);
+        }
+
+        [Fact]
+        public void Preserve_Escaped_Backslash_Literal()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"literal\":\"\\\\u05E9\"}");
+
+            Assert.Contains("\"\\\\u05E9\"", result);
+        }
+
+        [Fact]
+        public void Preserve_Escaped_Backslash_Before_Surrogate_Digits()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"literal\":\"\\\\uD83D\\\\uDE00\"}");
+
+            Assert.Contains("\"\\\\uD83D\\\\uDE00\"", result);
+            Assert.DoesNotContain("😀", result);
+        }
+
+        [Fact]
+        public void Combine_Surrogate_Pair_After_Literal_Backslash()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"mixed\":\"\\\\\\uD83D\\uDE00\"}");
+
+            Assert.Contains("\"\\\\😀\"", result);
+        }
+
+        [Fact]
+        public void Keep_Control_Characters_Escaped()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"control\":\"\\u0001\"}");
+
+            Assert.Contains("\\u0001", result, StringComparison.Ordinal);
+            Assert.DoesNotContain("\u0001", result, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void Preserve_Large_Number_Literals()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"large\":9007199254740993123456789}");
+
+            Assert.Contains("9007199254740993123456789", result);
+        }
+
+        [Fact]
+        public void Preserve_Duplicate_Keys_And_Order()
+        {
+            var result = ResponseBodyJsonProducer.Format("{\"dup\":1,\"dup\":2}");
+
+            var firstIndex = result.IndexOf("\"dup\": 1", StringComparison.Ordinal);
+            var secondIndex = result.IndexOf("\"dup\": 2", StringComparison.Ordinal);
+
+            Assert.True(firstIndex >= 0);
+            Assert.True(secondIndex > firstIndex);
+        }
+
+        [Fact]
+        public void Output_Remains_Valid_Json()
+        {
+            var result = ResponseBodyJsonProducer.Format(
+                "{\"hebrew\":\"\\u05E9\",\"emoji\":\"\\uD83D\\uDE00\",\"literal\":\"\\\\u05E9\",\"quote\":\"\\\"\"}");
+
+            using var document = JsonDocument.Parse(result);
+
+            Assert.Equal("ש", document.RootElement.GetProperty("hebrew").GetString());
+            Assert.Equal("😀", document.RootElement.GetProperty("emoji").GetString());
+            Assert.Equal("\\u05E9", document.RootElement.GetProperty("literal").GetString());
+            Assert.Equal("\"", document.RootElement.GetProperty("quote").GetString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes the escaping part of #740.

The JSON formatter escaped every non ASCII character as \uXXXX because Utf8JsonWriter uses JavaScriptEncoder.Default. Switch to UnsafeRelaxedJsonEscaping and restore supplementary characters, which the encoder cannot allow list, through a surrogate pair aware pass. Control characters, quotes and backslashes remain escaped and the output stays valid JSON.

Covered by new offline unit tests in ResponseBodyJsonFormattingTests.
