### PR TITLE
Stop nesting downstream read stream wrappers on header overshoot

### DIFF
--- a/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
@@ -85,10 +85,18 @@ namespace Fluxzy.Core
 
             var remainingLength = blockReadResult.TotalReadLength - blockReadResult.HeaderLength;
 
-            if (remainingLength > 0) 
+            if (remainingLength > 0)
             {
-                _readStream = new CombinedReadonlyStream(false,
-                    buffer.Buffer.AsSpan(blockReadResult.HeaderLength, remainingLength), _readStream);
+                // Push leftover bytes back into a single reusable buffer.
+                // Nesting a new stream wrapper per request grows without bound
+                // on keep-alive connections and ends in a stack overflow (#744)
+                if (_readStream is not PushbackReadStream pushbackStream)
+                {
+                    pushbackStream = new PushbackReadStream(_readStream);
+                    _readStream = pushbackStream;
+                }
+
+                pushbackStream.Push(buffer.Buffer.AsSpan(blockReadResult.HeaderLength, remainingLength));
             }
 
             var authority = RequestedAuthority;

--- a/src/Fluxzy.Core/Misc/Streams/PushbackReadStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/PushbackReadStream.cs
@@ -1,0 +1,186 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Misc.Streams
+{
+    /// <summary>
+    ///     Readonly stream allowing already read bytes to be pushed back and served
+    ///     before the inner stream. The pushback buffer is reused across pushes so
+    ///     repeated pushes never nest streams.
+    /// </summary>
+    public class PushbackReadStream : Stream
+    {
+        private readonly Stream _innerStream;
+
+        private byte[]? _pushback;
+        private int _offset;
+        private int _length;
+        private long _position;
+
+        public PushbackReadStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+        }
+
+        public int PendingLength => _length - _offset;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position {
+            get => _position;
+
+            set
+            {
+                if (value != _position) {
+                    throw new NotSupportedException();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Queue bytes to be served before the inner stream. Pushed bytes were read
+        ///     ahead of any pending ones, so they are served first.
+        /// </summary>
+        public void Push(ReadOnlySpan<byte> data)
+        {
+            if (data.IsEmpty) {
+                return;
+            }
+
+            var pendingLength = _length - _offset;
+
+            if (pendingLength == 0) {
+                if (_pushback == null || _pushback.Length < data.Length) {
+                    ReturnBuffer();
+                    _pushback = ArrayPool<byte>.Shared.Rent(data.Length);
+                }
+
+                data.CopyTo(_pushback);
+                _offset = 0;
+                _length = data.Length;
+
+                return;
+            }
+
+            var totalLength = data.Length + pendingLength;
+            var nextBuffer = ArrayPool<byte>.Shared.Rent(totalLength);
+
+            data.CopyTo(nextBuffer);
+            _pushback.AsSpan(_offset, pendingLength).CopyTo(nextBuffer.AsSpan(data.Length));
+
+            ReturnBuffer();
+
+            _pushback = nextBuffer;
+            _offset = 0;
+            _length = totalLength;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return Read(buffer.AsSpan(offset, count));
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var pendingLength = _length - _offset;
+
+            if (pendingLength > 0) {
+                var read = Math.Min(pendingLength, buffer.Length);
+
+                _pushback.AsSpan(_offset, read).CopyTo(buffer);
+                _offset += read;
+                _position += read;
+
+                return read;
+            }
+
+            var innerRead = _innerStream.Read(buffer);
+            _position += innerRead;
+
+            return innerRead;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var pendingLength = _length - _offset;
+
+            if (pendingLength > 0) {
+                var read = Math.Min(pendingLength, buffer.Length);
+
+                _pushback.AsMemory(_offset, read).CopyTo(buffer);
+                _offset += read;
+                _position += read;
+
+                return new ValueTask<int>(read);
+            }
+
+            return ReadInnerAsync(buffer, cancellationToken);
+        }
+
+        private async ValueTask<int> ReadInnerAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var read = await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            _position += read;
+
+            return read;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        private void ReturnBuffer()
+        {
+            if (_pushback != null) {
+                ArrayPool<byte>.Shared.Return(_pushback);
+                _pushback = null;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) {
+                _offset = 0;
+                _length = 0;
+                ReturnBuffer();
+            }
+
+            // Inner stream is left open, matching the previous
+            // CombinedReadonlyStream(closeStreams: false) behavior
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/PushbackReadStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/PushbackReadStreamTests.cs
@@ -1,0 +1,112 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class PushbackReadStreamTests
+    {
+        [Fact]
+        public void Reads_Pass_Through_When_Nothing_Pushed()
+        {
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("abcdef"));
+            using var stream = new PushbackReadStream(inner);
+
+            Assert.Equal("abcdef", stream.ReadToEndGreedy());
+        }
+
+        [Fact]
+        public void Pushed_Bytes_Are_Served_Before_Inner_Stream()
+        {
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("world"));
+            using var stream = new PushbackReadStream(inner);
+
+            stream.Push(Encoding.ASCII.GetBytes("hello "));
+
+            Assert.Equal("hello world", stream.ReadToEndGreedy());
+        }
+
+        [Fact]
+        public async Task Pushed_Bytes_Are_Served_Before_Inner_Stream_Async()
+        {
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("world"));
+            await using var stream = new PushbackReadStream(inner);
+
+            stream.Push(Encoding.ASCII.GetBytes("hello "));
+
+            var result = await stream.ReadToEndGreedyAsync();
+
+            Assert.Equal("hello world", result);
+        }
+
+        [Fact]
+        public void Push_Reuses_Buffer_Across_Multiple_Rounds()
+        {
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("!"));
+            using var stream = new PushbackReadStream(inner);
+
+            var builder = new StringBuilder();
+            var readBuffer = new byte[64];
+
+            for (var i = 0; i < 1000; i++) {
+                stream.Push(Encoding.ASCII.GetBytes($"{i};"));
+
+                var read = stream.Read(readBuffer, 0, readBuffer.Length);
+                builder.Append(Encoding.ASCII.GetString(readBuffer, 0, read));
+
+                Assert.Equal(0, stream.PendingLength);
+            }
+
+            builder.Append(stream.ReadToEndGreedy());
+
+            var expected = new StringBuilder();
+
+            for (var i = 0; i < 1000; i++) {
+                expected.Append($"{i};");
+            }
+
+            expected.Append('!');
+
+            Assert.Equal(expected.ToString(), builder.ToString());
+        }
+
+        [Fact]
+        public void Push_With_Pending_Bytes_Serves_New_Bytes_First()
+        {
+            // Pushed bytes were read ahead of the pending ones,
+            // so stream order is new push then pending remainder
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("D"));
+            using var stream = new PushbackReadStream(inner);
+
+            stream.Push(Encoding.ASCII.GetBytes("BC"));
+            stream.Push(Encoding.ASCII.GetBytes("A"));
+
+            Assert.Equal(3, stream.PendingLength);
+            Assert.Equal("ABCD", stream.ReadToEndGreedy());
+        }
+
+        [Fact]
+        public void Partial_Reads_Consume_Pending_Bytes_In_Order()
+        {
+            var inner = new MemoryStream(Encoding.ASCII.GetBytes("efgh"));
+            using var stream = new PushbackReadStream(inner);
+
+            stream.Push(Encoding.ASCII.GetBytes("abcd"));
+
+            var buffer = new byte[2];
+
+            Assert.Equal(2, stream.Read(buffer, 0, 2));
+            Assert.Equal("ab", Encoding.ASCII.GetString(buffer));
+
+            Assert.Equal(2, stream.Read(buffer, 0, 2));
+            Assert.Equal("cd", Encoding.ASCII.GetString(buffer));
+
+            Assert.Equal(0, stream.PendingLength);
+            Assert.Equal("efgh", stream.ReadToEndGreedy());
+        }
+    }
+}


### PR DESCRIPTION
Http11DownStreamPipe wrapped its read stream in a new CombinedReadonlyStream on every header overshoot (request body or pipelined bytes read past the header terminator). On long lived keep-alive connections, notably plain proxy mode, the nesting grew one layer per request and every subsequent read traversed the whole chain. After enough requests the inline continuation unwind through the nested state machines crashed the process with a StackOverflowException.

Leftover bytes now go through a single reusable pushback buffer (PushbackReadStream) created once per connection, so stream depth stays constant for the connection lifetime. Unit tests cover byte ordering, buffer reuse across rounds and partial reads.

Fixes #744 