### PR TITLE
Fix unknown network error code on abrupt upstream close

### DIFF
--- a/src/Fluxzy.Core.Pcap/CapturableConnection.cs
+++ b/src/Fluxzy.Core.Pcap/CapturableConnection.cs
@@ -93,7 +93,8 @@ namespace Fluxzy.Core.Pcap
                     await Task.Delay(1000).ConfigureAwait(false);
             }
 
-            _stream = new DisposeEventNotifierStream(_innerTcpClient, DisposeAsync);
+            _stream = new DisposeEventNotifierStream(_innerTcpClient, DisposeAsync,
+                new IPEndPoint(remoteAddress, remotePort));
             return new CapturableConnectionConnectResult(_captureContext, _stream);
         }
         

--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -266,7 +266,16 @@ namespace Fluxzy.Clients.H11
             }
 
             if (headerBlockDetectResult.CloseNotify) {
-                throw new ConnectionCloseException("Relaunch");
+                if (exchange.RecycledConnection)
+                    throw new ConnectionCloseException("Relaunch");
+
+                // Fresh connection torn down before any response byte: relaunching
+                // would meet the same fate and loop unboundedly against a host that
+                // closes or resets on accept. Surface as 528, same as the
+                // recycled-and-no-response gate does for read exceptions above.
+                throw new ClientErrorException(0,
+                    "The connection was closed while trying to read the response header",
+                    networkErrorCode: NetworkErrorCodes.ConnectionClosed);
             }
 
             Memory<char> headerContent = exchangeScope.RegisterForReturn(headerBlockDetectResult.HeaderLength);

--- a/src/Fluxzy.Core/Core/ConnectionErrorHandler.cs
+++ b/src/Fluxzy.Core/Core/ConnectionErrorHandler.cs
@@ -252,6 +252,12 @@ namespace Fluxzy.Core
                     $"The connection was reset by remote peer {remoteIpAddress}.",
                     NetworkErrorCodes.ConnectionReset),
 
+                // ENOTCONN: the socket was torn down by a peer reset before the
+                // operation (getpeername, shutdown, …) could run.
+                SocketError.NotConnected => (
+                    $"The connection was reset by remote peer {remoteIpAddress}.",
+                    NetworkErrorCodes.ConnectionReset),
+
                 SocketError.TimedOut => (
                     $"The remote peer ({remoteIpAddress}) " +
                     $"could not be contacted within the configured timeout on the port {port}.",

--- a/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
+++ b/src/Fluxzy.Core/Core/Impl/DefaultTcpConnection.cs
@@ -43,7 +43,7 @@ namespace Fluxzy.Core
                 client.NoDelay = true;
                 options.Apply(client.Client, new IPEndPoint(address, port));
                 await client.ConnectAsync(address, port, token).ConfigureAwait(false);
-                var stream = new DisposeEventNotifierStream(client, null);
+                var stream = new DisposeEventNotifierStream(client, null, new IPEndPoint(address, port));
                 return new DefaultTcpConnectionConnectResult(stream);
             }
             catch (Exception ex) {

--- a/src/Fluxzy.Core/Misc/Streams/DisposeEventNotifierStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/DisposeEventNotifierStream.cs
@@ -20,12 +20,21 @@ namespace Fluxzy.Misc.Streams
         private int _totalRead;
 
         public DisposeEventNotifierStream(TcpClient sourceClient, Func<ValueTask>?  cleanupProcedure)
+            : this(sourceClient, cleanupProcedure, (IPEndPoint) sourceClient.Client.RemoteEndPoint!)
         {
+        }
+
+        public DisposeEventNotifierStream(
+            TcpClient sourceClient, Func<ValueTask>? cleanupProcedure, IPEndPoint remoteEndPoint)
+        {
+            // The remote endpoint must be provided by the caller: querying
+            // Socket.RemoteEndPoint throws ENOTCONN when the peer resets the
+            // connection between connect and this constructor.
             _sourceClient = sourceClient;
             _cleanupProcedure = cleanupProcedure;
             InnerStream = sourceClient.GetStream();
             LocalEndPoint = (IPEndPoint) sourceClient.Client.LocalEndPoint;
-            RemoteEndPoint = (IPEndPoint) sourceClient.Client.RemoteEndPoint;
+            RemoteEndPoint = remoteEndPoint;
         }
 
         public IPEndPoint RemoteEndPoint { get; }


### PR DESCRIPTION
Validate_Abrupt_Close was flaky on CI: when the peer resets right after connect, Socket.RemoteEndPoint throws ENOTCONN on Linux, which had no mapping and came out as unknown. Pass the known remote endpoint instead, map NotConnected to connection_reset, and stop relaunching a fresh connection that dies before any response byte, since that could loop until the client timeout against a host that resets on accept. Local repro loop went from 23 bad outcomes out of 300 to 0 out of 600.