### PR TITLE
Release expired pooled HTTP/1.1 connections on dequeue

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -180,19 +180,11 @@ namespace Fluxzy.Clients.H11
                 // connection dying before any response byte relaunches unboundedly.
                 exchange.RecycledConnection = false;
 
-                while (_pendingConnections.Reader.TryRead(out var state)) {
+                var recycledConnection = DequeueReusableConnection(requestDate);
 
-                    if (HasConnectionExpired(requestDate, state))
-                    {
-                        // The connection pool exceeds timing connection ..
-                        //  TODO: Gracefully release connection
-
-                        continue;
-                    }
-
-                    exchange.Connection = state.Connection;
+                if (recycledConnection != null) {
+                    exchange.Connection = recycledConnection;
                     exchange.RecycledConnection = true;
-                    break;
                 }
 
                 if (exchange.Connection == null) {
@@ -332,6 +324,26 @@ namespace Fluxzy.Clients.H11
                 //_semaphoreSlim.Release();
                 ITimingProvider.Default.Instant();
             }
+        }
+
+        /// <summary>
+        ///     Pops the next reusable pooled connection, releasing expired ones on the way.
+        ///     Expired connections used to be dropped without disposal, leaking one socket,
+        ///     its streams and its timeout CTS per expiry (haga-rak/fluxzy.core#744).
+        /// </summary>
+        internal Connection? DequeueReusableConnection(DateTime instantNow)
+        {
+            while (_pendingConnections.Reader.TryRead(out var state)) {
+                if (HasConnectionExpired(instantNow, state)) {
+                    FreeConnectionStreams(state.Connection);
+
+                    continue;
+                }
+
+                return state.Connection;
+            }
+
+            return null;
         }
 
         private static void FreeConnectionStreams(Connection connection)

--- a/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
@@ -75,6 +75,47 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             Assert.Equal(0, faulted);
         }
 
+        /// <summary>
+        ///     Reproducer for the socket/handle accumulation reported in
+        ///     haga-rak/fluxzy.core#744: an expired keep-alive connection popped during
+        ///     <c>Send</c> was dropped without disposal, leaking its transport.
+        /// </summary>
+        [Fact]
+        public void ExpiredPooledConnection_IsReleased_OnDequeue()
+        {
+            var pool = BuildPool(onFaulted: _ => { });
+
+            var (connection, readStream, writeStream) = MakePooledConnection();
+            Assert.True(EnqueuePooledConnection(pool, connection, DateTime.UtcNow.AddMinutes(-5)),
+                "precondition: expired pooled connection enqueued");
+
+            var dequeued = pool.DequeueReusableConnection(DateTime.UtcNow);
+
+            Assert.Null(dequeued);
+            Assert.True(readStream.Disposed, "expired connection read stream must be disposed");
+            Assert.True(writeStream.Disposed, "expired connection write stream must be disposed");
+        }
+
+        [Fact]
+        public void Dequeue_ReleasesExpired_AndReturnsFreshConnection()
+        {
+            var pool = BuildPool(onFaulted: _ => { });
+
+            var (expired, expiredRead, expiredWrite) = MakePooledConnection();
+            var (fresh, freshRead, freshWrite) = MakePooledConnection();
+
+            Assert.True(EnqueuePooledConnection(pool, expired, DateTime.UtcNow.AddMinutes(-5)));
+            Assert.True(EnqueuePooledConnection(pool, fresh, DateTime.UtcNow));
+
+            var dequeued = pool.DequeueReusableConnection(DateTime.UtcNow);
+
+            Assert.Same(fresh, dequeued);
+            Assert.True(expiredRead.Disposed, "expired connection read stream must be disposed");
+            Assert.True(expiredWrite.Disposed, "expired connection write stream must be disposed");
+            Assert.False(freshRead.Disposed, "reusable connection must not be disposed");
+            Assert.False(freshWrite.Disposed, "reusable connection must not be disposed");
+        }
+
         // ==================================================================
         // Helpers
         // ==================================================================
@@ -105,13 +146,14 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             return (connection, read, write);
         }
 
-        private static bool EnqueuePooledConnection(Http11ConnectionPool pool, Connection connection)
+        private static bool EnqueuePooledConnection(
+            Http11ConnectionPool pool, Connection connection, DateTime? lastUsed = null)
         {
             var field = typeof(Http11ConnectionPool).GetField(
                 "_pendingConnections", BindingFlags.Instance | BindingFlags.NonPublic);
 
             var channel = (Channel<Http11ProcessingState>) field!.GetValue(pool)!;
-            return channel.Writer.TryWrite(new Http11ProcessingState(connection, DateTime.UtcNow));
+            return channel.Writer.TryWrite(new Http11ProcessingState(connection, lastUsed ?? DateTime.UtcNow));
         }
 
         private static void SetActiveRequestCount(Http11ConnectionPool pool, int count)


### PR DESCRIPTION
Fixes the connection and handle accumulation reported in #744.

Expired keep-alive connections popped from the HTTP/1.1 pool during Send were dropped without disposal, leaking one established socket, its streams and its timeout CTS per expiry. Over long uptime this exhausts connections and wedges the proxy.

The expired drain loop is extracted into DequeueReusableConnection, which now frees each expired connection it skips. Two regression tests added.