### PR TITLE
Drop client certificate test relying on external servers

### DIFF
--- a/test/Fluxzy.Tests/Cli/WithRuleOptionClientCertificate.cs
+++ b/test/Fluxzy.Tests/Cli/WithRuleOptionClientCertificate.cs
@@ -65,53 +65,5 @@ namespace Fluxzy.Tests.Cli
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(expectedThumbPrint, thumbPrint, StringComparer.OrdinalIgnoreCase);
         }
-
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public async Task Validate_ClientCertificate_Cryptomix(bool forceH11, bool useBouncyCastle)
-        {
-            var requestMessage =
-                new HttpRequestMessage(HttpMethod.Get, $"https://certauth.cryptomix.com/json/");
-
-            requestMessage.Headers.Add("X-Test-Header-256", "That value");
-            
-            File.WriteAllBytes("cc2.pfx", StorageContext.client_cert);
-            File.WriteAllBytes("cc.pfx", StorageContext.client_cert);
-
-            var yamlContent = $"""
-                              rules:
-                                - filter:
-                                    typeKind: AnyFilter
-                                  action :
-                                    typeKind: SetClientCertificateAction
-                                    clientCertificate:
-                                      pkcs12File: cc2.pfx
-                                      pkcs12Password: {CertificateContext.DefaultPassword}
-                                      retrieveMode: FromPkcs12
-                              """;
-
-            var yamlContentForceHttp11 = $"""
-                                         rules:
-                                           - filter:
-                                               typeKind: AnyFilter
-                                             action :
-                                               typeKind: SetClientCertificateAction
-                                               clientCertificate:
-                                                 pkcs12File: cc.pfx
-                                                 pkcs12Password: {CertificateContext.DefaultPassword}
-                                                 retrieveMode: FromPkcs12
-                                           - filter:
-                                               typeKind: AnyFilter
-                                             action :
-                                               typeKind: ForceHttp11Action
-                                         """;
-            
-            using var response = await Exec(forceH11 ? yamlContentForceHttp11 : yamlContent, 
-                requestMessage, useBouncyCastle: useBouncyCastle);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
     }
 }


### PR DESCRIPTION
`certauth.cryptomix.com` is unreachable (TCP connect timeout), causing all four `Validate_ClientCertificate_Cryptomix` cases to fail with a synthesized 528 on CI. 
The client certificate feature remains covered by `Validate_ClientCertificate_Fluxzy_Server`, which runs against the self-hosted test server.