### PR TITLE
Harden downstream accept loop against transient failures

### DIFF
--- a/src/Fluxzy.Core/Core/Impl/DownStreamConnectionProvider.cs
+++ b/src/Fluxzy.Core/Core/Impl/DownStreamConnectionProvider.cs
@@ -38,18 +38,25 @@ namespace Fluxzy.Core
             if (!_listeners.Any())
                 return null;
 
-            try {
-                var available = await _pendingClientConnections.Reader.WaitToReadAsync(_token); 
+            while (true) {
+                try {
+                    var available = await _pendingClientConnections.Reader.WaitToReadAsync(_token);
 
-                if (!available)
+                    if (!available)
+                        return null;
+                }
+                catch (Exception) {
+                    // Listener Stop was probably called
                     return null;
+                }
 
                 while (_pendingClientConnections.Reader.TryRead(out var asyncState)) {
+                    try {
+                        var listener = (TcpListener?) asyncState.AsyncState;
 
-                    var listener = (TcpListener?)asyncState.AsyncState;
+                        if (listener == null)
+                            continue;
 
-                    if (listener != null)
-                    {
                         var tcpClient = listener.EndAcceptTcpClient(asyncState);
 
                         tcpClient.NoDelay = true;
@@ -61,13 +68,11 @@ namespace Fluxzy.Core
 
                         return tcpClient;
                     }
+                    catch (Exception) {
+                        // Faulted accept, skip and try the next one
+                    }
                 }
             }
-            catch (Exception) {
-                // Listener Stop was probably called 
-            }
-
-            return null;
         }
 
         public IReadOnlyCollection<IPEndPoint> ListenEndpoints { get; private set; } = Array.Empty<IPEndPoint>();
@@ -144,9 +149,21 @@ namespace Fluxzy.Core
             try {
                 var listener = (TcpListener?) ar.AsyncState;
 
-                if (!_pendingClientConnections.Writer.TryWrite(ar) || _disposed)
-                    return; 
-                
+                if (!_pendingClientConnections.Writer.TryWrite(ar)) {
+                    // Writer completed, release the accepted client
+                    try {
+                        listener?.EndAcceptTcpClient(ar).Dispose();
+                    }
+                    catch (Exception) {
+                        // ignored
+                    }
+
+                    return;
+                }
+
+                if (_disposed)
+                    return;
+
                 listener?.BeginAcceptTcpClient(Callback, listener);
             }
             catch (Exception) {

--- a/src/Fluxzy.Core/Proxy.cs
+++ b/src/Fluxzy.Core/Proxy.cs
@@ -321,14 +321,22 @@ namespace Fluxzy
             }
 
             while (true) {
-                var client =
-                    await _downStreamConnectionProvider.GetNextPendingConnection().ConfigureAwait(false);
+                TcpClient? client = null;
 
-                if (client == null) {
-                    break;
+                try {
+                    client = await _downStreamConnectionProvider.GetNextPendingConnection().ConfigureAwait(false);
+
+                    if (client == null) {
+                        break;
+                    }
+
+                    // Detaches at the first await, no dedicated thread needed
+                    ProcessingConnection(client);
                 }
-
-                _ = Task.Factory.StartNew(() => ProcessingConnection(client), TaskCreationOptions.LongRunning);
+                catch (Exception) {
+                    // A single connection failure must not stop the accept loop
+                    client?.Dispose();
+                }
             }
         }
 
@@ -413,7 +421,7 @@ namespace Fluxzy
             _runTimeSetting.EndPoints = endPoints.ToHashSet();
             _runTimeSetting.ProxyListenPort = endPoints.FirstOrDefault()?.Port ?? 0;
 
-            _loopTask = Task.Factory.StartNew(MainLoop, TaskCreationOptions.LongRunning);
+            _loopTask = MainLoop().AsTask();
 
             EndPoints = endPoints;
 


### PR DESCRIPTION
The downstream accept loop could stop permanently and silently after a single transient failure. MainLoop spawned one dedicated thread per accepted connection via Task.Factory.StartNew with TaskCreationOptions.LongRunning, so a failed thread creation threw into a loop that had no error handling. Run did not unwrap the async delegate either, so the fault was never observable, while the listener callback kept accepting and queueing sockets that no consumer would ever read.

- process accepted connections without a dedicated thread, detaching at the existing Task.Yield
- keep the accept loop alive on per connection errors
- assign the real MainLoop task to _loopTask so faults can be awaited and observed
- skip a faulted accept instead of ending the dequeue loop
- dispose the accepted client when the pending channel refuses the write