### PR TITLE
Support connection-oriented auth (NTLM/Negotiate) through the proxy

### DIFF
--- a/src/Fluxzy.Core/Clients/ConnectionAuthHeuristic.cs
+++ b/src/Fluxzy.Core/Clients/ConnectionAuthHeuristic.cs
@@ -1,0 +1,61 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Core;
+
+namespace Fluxzy.Clients
+{
+    /// <summary>
+    ///     Detects connection-oriented authentication (NTLM and Negotiate/Kerberos as
+    ///     issued by SSPI). Such schemes authenticate the TCP connection rather than the
+    ///     request, so an exchange carrying their markers must ride a pinned upstream
+    ///     connection and must never let that connection be recycled for another client.
+    /// </summary>
+    internal static class ConnectionAuthHeuristic
+    {
+        private static readonly string[] Schemes = { "NTLM", "Negotiate", "Kerberos" };
+
+        public static bool RequestCarriesConnectionAuth(Exchange exchange)
+        {
+            var header = exchange.Request?.Header;
+
+            if (header == null)
+                return false;
+
+            return HasConnectionScheme(header["Authorization"]) ||
+                   HasConnectionScheme(header["Proxy-Authorization"]);
+        }
+
+        public static bool ResponseCarriesConnectionAuth(Exchange exchange)
+        {
+            var header = exchange.Response?.Header;
+
+            if (header == null)
+                return false;
+
+            return HasConnectionScheme(header["WWW-Authenticate"]) ||
+                   HasConnectionScheme(header["Proxy-Authenticate"]);
+        }
+
+        public static bool InvolvesConnectionAuth(Exchange exchange)
+        {
+            return RequestCarriesConnectionAuth(exchange) || ResponseCarriesConnectionAuth(exchange);
+        }
+
+        private static bool HasConnectionScheme(IEnumerable<HeaderField> fields)
+        {
+            foreach (var field in fields) {
+                var value = field.Value.Span;
+
+                foreach (var scheme in Schemes) {
+                    if (value.StartsWith(scheme.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Fluxzy.Core/Clients/DotNetBridge/FluxzyDefaultHandler.cs
+++ b/src/Fluxzy.Core/Clients/DotNetBridge/FluxzyDefaultHandler.cs
@@ -80,7 +80,7 @@ namespace Fluxzy.Clients.DotNetBridge
                 ConfigureContext(exchange.Context);
             }
 
-            var connection = await _poolBuilder.GetPool(exchange, _runtimeSetting, cancellationToken).ConfigureAwait(false);
+            var connection = await _poolBuilder.GetPool(exchange, _runtimeSetting, cancellationToken: cancellationToken).ConfigureAwait(false);
             
             await connection.Send(exchange, null!, RsBuffer.Allocate(32 * 1024), _exchangeScope,
                 cancellationToken).ConfigureAwait(false);

--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -190,11 +190,21 @@ namespace Fluxzy.Clients.H11
 
             var leaseAcquired = false;
             var leaseHandedToContinuation = false;
+            var activityHandedToContinuation = false;
 
             try {
                 if (_pinnedLease != null) {
                     await _pinnedLease.WaitAsync(cancellationToken).ConfigureAwait(false);
                     leaseAcquired = true;
+
+                    // Disposal can race a waiter that entered Send before the pool was
+                    // completed. Do not let that waiter open a new connection on an evicted
+                    // pinned pool after the preceding exchange releases the lease.
+                    lock (_idleGate) {
+                        if (_complete)
+                            throw new ConnectionCloseException(
+                                "HTTP/1.1 connection pool was disposed while waiting for its pinned lease");
+                    }
                 }
 
                 var requestDate = _timingProvider.Instant();
@@ -249,8 +259,6 @@ namespace Fluxzy.Clients.H11
                     if (exchange.Response.Header != null)
                         exchange.Connection.TimeoutIdleSeconds = exchange.Response.Header.TimeoutIdleSeconds;
 
-                    var lastUsed = _timingProvider.Instant();
-
                     void OnExchangeCompleteFunction(Task<bool> completeTask)
                     {
                         try {
@@ -284,6 +292,12 @@ namespace Fluxzy.Clients.H11
                             }
                             else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { //
 
+                                // Idle age starts when the response body has been consumed, not
+                                // when its headers arrived. With connection-oriented auth, using
+                                // the header timestamp can make a slow response recycle an
+                                // already-expired authenticated connection.
+                                var lastUsed = _timingProvider.Instant();
+
                                 if (_pendingConnections.Writer.TryWrite(
                                         new Http11ProcessingState(exchange.Connection, lastUsed)))
                                 {
@@ -297,6 +311,15 @@ namespace Fluxzy.Clients.H11
                             FreeConnectionStreams(exchange.Connection);
                         }
                         finally {
+                            // Send returns after response headers, while the connection remains
+                            // occupied until the response body completes. Keep the pool active
+                            // through that whole lifetime so idle teardown cannot remove the pin
+                            // or dispose the pool underneath this continuation.
+                            lock (_idleGate) {
+                                _activeRequestCount--;
+                                _lastActivity = _timingProvider.Instant();
+                            }
+
                             // Released only here on the success path: the connection is now
                             // back in the channel (or freed), so the next pinned Send can
                             // dequeue it instead of racing ahead and opening a fresh one.
@@ -307,8 +330,9 @@ namespace Fluxzy.Clients.H11
                     // CancellationToken.None: the cleanup must run even when the caller
                     // has already cancelled, otherwise an aborted exchange leaks its
                     // connection (the continuation would be cancelled instead of run).
-                    leaseHandedToContinuation = true;
                     var _ = exchange.Complete.ContinueWith(OnExchangeCompleteFunction, CancellationToken.None);
+                    activityHandedToContinuation = true;
+                    leaseHandedToContinuation = leaseAcquired;
                 }
                 catch (Exception ex) {
 
@@ -356,9 +380,11 @@ namespace Fluxzy.Clients.H11
                 }
             }
             finally {
-                lock (_idleGate) {
-                    _activeRequestCount--;
-                    _lastActivity = _timingProvider.Instant();
+                if (!activityHandedToContinuation) {
+                    lock (_idleGate) {
+                        _activeRequestCount--;
+                        _lastActivity = _timingProvider.Instant();
+                    }
                 }
 
                 // Every exit that did not hand the lease to the completion continuation
@@ -439,7 +465,11 @@ namespace Fluxzy.Clients.H11
             }
 
             _idleTimer?.Dispose();
-            _pinnedLease?.Dispose();
+
+            // Do not dispose _pinnedLease here. DisposeAsync can race the asynchronously
+            // scheduled exchange-completion continuation after a downstream connection ends.
+            // The pool is already marked complete, so no new Send can acquire it; leaving this
+            // small managed semaphore for GC lets the owner continuation release it safely.
 
             if (_idleMonitorTask != null) {
                 try {

--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -45,6 +45,15 @@ namespace Fluxzy.Clients.H11
         // keep a connection that carried connection-oriented auth. Shared pools must drop it.
         private readonly bool _dedicated;
 
+        // A dedicated pool must use exactly one upstream connection. Recycling back into
+        // _pendingConnections happens in an async continuation on exchange.Complete
+        // (RunContinuationsAsynchronously), which races the next Send's dequeue: losing that
+        // race opens a second connection and breaks the connection-bound auth handshake.
+        // This lease serialises Send and is released only after the connection is recycled,
+        // so the next leg always finds the same connection. Also serialises concurrent
+        // (HTTP/2 downstream) exchanges, which must not fan out onto multiple sockets.
+        private readonly SemaphoreSlim? _pinnedLease;
+
         internal Http11ConnectionPool(
             Authority authority,
             RemoteConnectionBuilder remoteConnectionBuilder,
@@ -62,6 +71,7 @@ namespace Fluxzy.Clients.H11
             _resolutionResult = resolutionResult;
             _onConnectionFaulted = onConnectionFaulted;
             _dedicated = dedicated;
+            _pinnedLease = dedicated ? new SemaphoreSlim(1, 1) : null;
             Authority = authority;
             _lastActivity = timingProvider.Instant();
 
@@ -178,7 +188,15 @@ namespace Fluxzy.Clients.H11
                 _lastActivity = _timingProvider.Instant();
             }
 
+            var leaseAcquired = false;
+            var leaseHandedToContinuation = false;
+
             try {
+                if (_pinnedLease != null) {
+                    await _pinnedLease.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    leaseAcquired = true;
+                }
+
                 var requestDate = _timingProvider.Instant();
 
                 // May still be true from a previous relaunched attempt: it must reflect
@@ -235,52 +253,61 @@ namespace Fluxzy.Clients.H11
 
                     void OnExchangeCompleteFunction(Task<bool> completeTask)
                     {
-                        abortRegistration.Dispose();
+                        try {
+                            abortRegistration.Dispose();
 
-                        // A faulted or cancelled completion means the body read failed:
-                        // never recycle, always free. Reading .Result unguarded would
-                        // rethrow here and skip the teardown entirely.
-                        var closeConnectionRequest =
-                            !completeTask.IsCompletedSuccessfully || completeTask.Result;
+                            // A faulted or cancelled completion means the body read failed:
+                            // never recycle, always free. Reading .Result unguarded would
+                            // rethrow here and skip the teardown entirely.
+                            var closeConnectionRequest =
+                                !completeTask.IsCompletedSuccessfully || completeTask.Result;
 
-                        if (exchange.Response.Header!.MaxConnection != -1 &&
-                            exchange.Response.Header!.MaxConnection <= exchange.Connection.RequestProcessed) {
-                            closeConnectionRequest = true;
-                        }
-
-                        // Leakage guard: a shared connection that carried NTLM/Negotiate auth
-                        // is bound to one client's identity. Never return it to the shared pool.
-                        // Dedicated (pinned) pools keep it since they serve a single client.
-                        if (!_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange)) {
-                            closeConnectionRequest = true;
-                        }
-
-                        if (exchange.Metrics.ResponseBodyEnd == default)
-                            exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
-
-                        if (completeTask.Exception != null && completeTask.Exception.InnerExceptions.Any()) {
-                            foreach (var exception in completeTask.Exception.InnerExceptions) {
-                                exchange.Errors.Add(new Error("Error while reading response", exception));
+                            if (exchange.Response.Header!.MaxConnection != -1 &&
+                                exchange.Response.Header!.MaxConnection <= exchange.Connection.RequestProcessed) {
+                                closeConnectionRequest = true;
                             }
-                        }
-                        else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { //
 
-                            if (_pendingConnections.Writer.TryWrite(
-                                    new Http11ProcessingState(exchange.Connection, lastUsed)))
-                            {
-                                return;
+                            // Leakage guard: a shared connection that carried NTLM/Negotiate auth
+                            // is bound to one client's identity. Never return it to the shared pool.
+                            // Dedicated (pinned) pools keep it since they serve a single client.
+                            if (!_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange)) {
+                                closeConnectionRequest = true;
                             }
-                        }
-                        else {
-                            // should close connection
-                        }
 
-                        FreeConnectionStreams(exchange.Connection);
+                            if (exchange.Metrics.ResponseBodyEnd == default)
+                                exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
+
+                            if (completeTask.Exception != null && completeTask.Exception.InnerExceptions.Any()) {
+                                foreach (var exception in completeTask.Exception.InnerExceptions) {
+                                    exchange.Errors.Add(new Error("Error while reading response", exception));
+                                }
+                            }
+                            else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { //
+
+                                if (_pendingConnections.Writer.TryWrite(
+                                        new Http11ProcessingState(exchange.Connection, lastUsed)))
+                                {
+                                    return;
+                                }
+                            }
+                            else {
+                                // should close connection
+                            }
+
+                            FreeConnectionStreams(exchange.Connection);
+                        }
+                        finally {
+                            // Released only here on the success path: the connection is now
+                            // back in the channel (or freed), so the next pinned Send can
+                            // dequeue it instead of racing ahead and opening a fresh one.
+                            _pinnedLease?.Release();
+                        }
                     }
 
                     // CancellationToken.None: the cleanup must run even when the caller
                     // has already cancelled, otherwise an aborted exchange leaks its
                     // connection (the continuation would be cancelled instead of run).
+                    leaseHandedToContinuation = true;
                     var _ = exchange.Complete.ContinueWith(OnExchangeCompleteFunction, CancellationToken.None);
                 }
                 catch (Exception ex) {
@@ -334,7 +361,12 @@ namespace Fluxzy.Clients.H11
                     _lastActivity = _timingProvider.Instant();
                 }
 
-                //_semaphoreSlim.Release();
+                // Every exit that did not hand the lease to the completion continuation
+                // (early return, or an exception including the Relaunch retry) releases here,
+                // so a relaunch attempt does not deadlock against its own held lease.
+                if (leaseAcquired && !leaseHandedToContinuation)
+                    _pinnedLease!.Release();
+
                 ITimingProvider.Default.Instant();
             }
         }
@@ -407,6 +439,7 @@ namespace Fluxzy.Clients.H11
             }
 
             _idleTimer?.Dispose();
+            _pinnedLease?.Dispose();
 
             if (_idleMonitorTask != null) {
                 try {

--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -41,6 +41,10 @@ namespace Fluxzy.Clients.H11
         private PeriodicTimer? _idleTimer;
         private Task? _idleMonitorTask;
 
+        // Dedicated pools serve a single downstream connection (upstream pinning), so they
+        // keep a connection that carried connection-oriented auth. Shared pools must drop it.
+        private readonly bool _dedicated;
+
         internal Http11ConnectionPool(
             Authority authority,
             RemoteConnectionBuilder remoteConnectionBuilder,
@@ -48,7 +52,8 @@ namespace Fluxzy.Clients.H11
             ProxyRuntimeSetting proxyRuntimeSetting,
             RealtimeArchiveWriter archiveWriter,
             DnsResolutionResult resolutionResult,
-            Action<IHttpConnectionPool>? onConnectionFaulted = null)
+            Action<IHttpConnectionPool>? onConnectionFaulted = null,
+            bool dedicated = false)
         {
             _remoteConnectionBuilder = remoteConnectionBuilder;
             _timingProvider = timingProvider;
@@ -56,6 +61,7 @@ namespace Fluxzy.Clients.H11
             _archiveWriter = archiveWriter;
             _resolutionResult = resolutionResult;
             _onConnectionFaulted = onConnectionFaulted;
+            _dedicated = dedicated;
             Authority = authority;
             _lastActivity = timingProvider.Instant();
 
@@ -239,6 +245,13 @@ namespace Fluxzy.Clients.H11
 
                         if (exchange.Response.Header!.MaxConnection != -1 &&
                             exchange.Response.Header!.MaxConnection <= exchange.Connection.RequestProcessed) {
+                            closeConnectionRequest = true;
+                        }
+
+                        // Leakage guard: a shared connection that carried NTLM/Negotiate auth
+                        // is bound to one client's identity. Never return it to the shared pool.
+                        // Dedicated (pinned) pools keep it since they serve a single client.
+                        if (!_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange)) {
                             closeConnectionRequest = true;
                         }
 

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients.Dns;
@@ -43,6 +44,10 @@ namespace Fluxzy.Clients
 
         private readonly ConcurrentDictionary<Authority, IHttpConnectionPool> _connectionPools = new();
 
+        // Upstream connections pinned to a single downstream connection (connection-oriented
+        // auth). Keyed by the downstream pipe so the pins die with the client that owns them.
+        private readonly ConditionalWeakTable<IDownStreamPipe, PinnedPoolSet> _pinnedPools = new();
+
         private readonly RemoteConnectionBuilder _remoteConnectionBuilder;
         private readonly ITimingProvider _timingProvider;
         private readonly ILogger<PoolBuilder> _logger;
@@ -78,9 +83,10 @@ namespace Fluxzy.Clients
             GetPool(
                 Exchange exchange,
                 ProxyRuntimeSetting proxyRuntimeSetting,
+                IDownStreamPipe? downStreamPipe = null,
                 CancellationToken cancellationToken = default)
         {
-            var pool = await GetPoolCore(exchange, proxyRuntimeSetting, _logger, cancellationToken)
+            var pool = await GetPoolCore(exchange, proxyRuntimeSetting, downStreamPipe, _logger, cancellationToken)
                 .ConfigureAwait(false);
             FluxzyLogEvents.LogConnectionPoolResolved(_logger, exchange, pool);
             return pool;
@@ -90,6 +96,7 @@ namespace Fluxzy.Clients
             GetPoolCore(
                 Exchange exchange,
                 ProxyRuntimeSetting proxyRuntimeSetting,
+                IDownStreamPipe? downStreamPipe,
                 ILogger<PoolBuilder> logger,
                 CancellationToken cancellationToken)
         {
@@ -109,6 +116,20 @@ namespace Fluxzy.Clients
                     new MockedConnectionPool(exchange.Authority, exchange.Context.PreMadeResponse);
                 mockedConnectionPool.Init();
                 return mockedConnectionPool;
+            }
+
+            // Connection-oriented auth: serve the exchange from a pool dedicated to this
+            // downstream connection. The pin is sticky, so the requests that follow the
+            // handshake (which carry no Authorization header) keep the same connection.
+            if (downStreamPipe != null) {
+                var pinnedPool = GetPinnedPool(exchange, proxyRuntimeSetting, downStreamPipe, dnsResolutionResult);
+
+                if (pinnedPool != null) {
+                    if (exchange.Metrics.RetrievingPool == default)
+                        exchange.Metrics.RetrievingPool = ITimingProvider.Default.Instant();
+
+                    return pinnedPool;
+                }
             }
 
             var forceNewConnection = exchange.Context.ForceNewConnection;
@@ -275,6 +296,61 @@ namespace Fluxzy.Clients
             throw new NotSupportedException($"Unhandled protocol type {openingResult.Type}");
         }
 
+        /// <summary>
+        ///     Returns the pool pinned to <paramref name="downStreamPipe"/> for this authority when
+        ///     the exchange requires pinning or a pin already exists (stickiness), otherwise null.
+        ///     A pinned pool is a dedicated HTTP/1.1 pool: it opens H11-only ALPN and is never
+        ///     stored in the shared registry, so no other client can reuse its connection.
+        /// </summary>
+        private IHttpConnectionPool? GetPinnedPool(
+            Exchange exchange,
+            ProxyRuntimeSetting proxyRuntimeSetting,
+            IDownStreamPipe downStreamPipe,
+            DnsResolutionResult dnsResolutionResult)
+        {
+            if (!exchange.Context.RequireUpstreamPinning) {
+                // Stickiness: only the follow-up requests of an already pinned authority stay
+                // pinned. A pipe that never pinned anything allocates no set.
+                if (!_pinnedPools.TryGetValue(downStreamPipe, out var existing)
+                    || !existing.Pools.ContainsKey(exchange.Authority))
+                    return null;
+            }
+
+            var pinSet = _pinnedPools.GetValue(downStreamPipe, static _ => new PinnedPoolSet());
+
+            var pinnedPool = pinSet.Pools.GetOrAdd(exchange.Authority, authority => {
+                var pool = new Http11ConnectionPool(authority,
+                    _remoteConnectionBuilder, _timingProvider, proxyRuntimeSetting, _archiveWriter!,
+                    dnsResolutionResult, onConnectionFaulted: null, dedicated: true);
+
+                pool.Init();
+
+                return pool;
+            });
+
+            exchange.HttpVersion = "HTTP/1.1";
+
+            return pinnedPool;
+        }
+
+        /// <summary>
+        ///     Disposes every pool pinned to a downstream connection. Called when that
+        ///     connection ends so the dedicated upstream sockets close with it.
+        /// </summary>
+        public void ReleasePinnedPools(IDownStreamPipe? downStreamPipe)
+        {
+            if (downStreamPipe == null)
+                return;
+
+            if (!_pinnedPools.TryGetValue(downStreamPipe, out var pinSet))
+                return;
+
+            _pinnedPools.Remove(downStreamPipe);
+
+            foreach (var pool in pinSet.Pools.Values)
+                _ = ObserveDisposal(pool);
+        }
+
         private IDnsSolver ResolveDnsProvider(Exchange exchange, ProxyRuntimeSetting proxyRuntimeSetting)
         {
             return string.IsNullOrWhiteSpace(exchange.Context.DnsOverHttpsNameOrUrl) ? 
@@ -309,6 +385,11 @@ namespace Fluxzy.Clients
                 // Swallow: a faulted disposal is not actionable from this context.
                 // A structured logger hook can be added here once available.
             }
+        }
+
+        private sealed class PinnedPoolSet
+        {
+            public ConcurrentDictionary<Authority, IHttpConnectionPool> Pools { get; } = new();
         }
     }
 }

--- a/src/Fluxzy.Core/Clients/PoolBuilder.cs
+++ b/src/Fluxzy.Core/Clients/PoolBuilder.cs
@@ -300,7 +300,9 @@ namespace Fluxzy.Clients
         ///     Returns the pool pinned to <paramref name="downStreamPipe"/> for this authority when
         ///     the exchange requires pinning or a pin already exists (stickiness), otherwise null.
         ///     A pinned pool is a dedicated HTTP/1.1 pool: it opens H11-only ALPN and is never
-        ///     stored in the shared registry, so no other client can reuse its connection.
+        ///     stored in the shared registry, so no other client can reuse its connection. Pinned
+        ///     pools idle-evict themselves like shared ones; a stale one is transparently replaced,
+        ///     and the number of distinct pinned authorities per downstream connection is capped.
         /// </summary>
         private IHttpConnectionPool? GetPinnedPool(
             Exchange exchange,
@@ -308,7 +310,9 @@ namespace Fluxzy.Clients
             IDownStreamPipe downStreamPipe,
             DnsResolutionResult dnsResolutionResult)
         {
-            if (!exchange.Context.RequireUpstreamPinning) {
+            var wantsNewPin = exchange.Context.RequireUpstreamPinning;
+
+            if (!wantsNewPin) {
                 // Stickiness: only the follow-up requests of an already pinned authority stay
                 // pinned. A pipe that never pinned anything allocates no set.
                 if (!_pinnedPools.TryGetValue(downStreamPipe, out var existing)
@@ -318,19 +322,74 @@ namespace Fluxzy.Clients
 
             var pinSet = _pinnedPools.GetValue(downStreamPipe, static _ => new PinnedPoolSet());
 
-            var pinnedPool = pinSet.Pools.GetOrAdd(exchange.Authority, authority => {
-                var pool = new Http11ConnectionPool(authority,
-                    _remoteConnectionBuilder, _timingProvider, proxyRuntimeSetting, _archiveWriter!,
-                    dnsResolutionResult, onConnectionFaulted: null, dedicated: true);
+            while (true) {
+                if (pinSet.Pools.TryGetValue(exchange.Authority, out var current)) {
+                    if (!current.Complete) {
+                        exchange.HttpVersion = "HTTP/1.1";
 
-                pool.Init();
+                        return current;
+                    }
 
-                return pool;
-            });
+                    // Idle-evicted (or disposed) since last use: drop it and re-pin below.
+                    pinSet.Pools.TryRemove(
+                        new KeyValuePair<Authority, IHttpConnectionPool>(exchange.Authority, current));
 
-            exchange.HttpVersion = "HTTP/1.1";
+                    continue;
+                }
 
-            return pinnedPool;
+                // No live pin. A sticky follow-up whose pin has gone falls back to the shared
+                // pool, which re-triggers the auth handshake as a server idle-close would.
+                if (!wantsNewPin)
+                    return null;
+
+                if (pinSet.Pools.Count >= proxyRuntimeSetting.MaxPinnedConnectionsPerDownstream) {
+                    _logger.LogWarning(
+                        "Downstream connection reached its pinned-connection cap ({Cap}); " +
+                        "not pinning {Authority}, falling back to the shared pool",
+                        proxyRuntimeSetting.MaxPinnedConnectionsPerDownstream, exchange.Authority);
+
+                    return null;
+                }
+
+                var created = CreatePinnedPool(exchange.Authority, proxyRuntimeSetting, dnsResolutionResult, pinSet);
+
+                if (pinSet.Pools.TryAdd(exchange.Authority, created)) {
+                    exchange.HttpVersion = "HTTP/1.1";
+
+                    return created;
+                }
+
+                // Lost the race to another exchange on the same pipe: discard ours (stops its
+                // idle monitor) and loop to pick up the winner.
+                _ = ObserveDisposal(created);
+            }
+        }
+
+        private Http11ConnectionPool CreatePinnedPool(
+            Authority authority,
+            ProxyRuntimeSetting proxyRuntimeSetting,
+            DnsResolutionResult dnsResolutionResult,
+            PinnedPoolSet pinSet)
+        {
+            // The eviction callback removes only this exact pool (so a fresh pin created after an
+            // idle teardown survives) and disposes it to release its timer, lease and socket.
+            // Passing it (non-null) is also what makes Init() start the idle monitor. It is
+            // fire-and-forget by contract, so ObserveDisposal cannot deadlock against DisposeAsync
+            // awaiting the monitor task it runs on.
+            var pool = new Http11ConnectionPool(authority,
+                _remoteConnectionBuilder, _timingProvider, proxyRuntimeSetting, _archiveWriter!,
+                dnsResolutionResult,
+                onConnectionFaulted: evicted => {
+                    pinSet.Pools.TryRemove(
+                        new KeyValuePair<Authority, IHttpConnectionPool>(authority, evicted));
+
+                    _ = ObserveDisposal(evicted);
+                },
+                dedicated: true);
+
+            pool.Init();
+
+            return pool;
         }
 
         /// <summary>

--- a/src/Fluxzy.Core/Core/ExchangeContext.cs
+++ b/src/Fluxzy.Core/Core/ExchangeContext.cs
@@ -217,6 +217,14 @@ namespace Fluxzy.Core
         public bool ForceServeHttp11 { get; set; }
 
         /// <summary>
+        ///     When true, the upstream connection serving this exchange is dedicated to the
+        ///     originating downstream connection and never shared with another client. Required
+        ///     for connection-oriented authentication (NTLM, Negotiate/Kerberos) whose handshake
+        ///     and resulting identity are bound to a single TCP connection. Implies HTTP/1.1 upstream.
+        /// </summary>
+        public bool RequireUpstreamPinning { get; set; }
+
+        /// <summary>
         ///     Register a response body substitution
         /// </summary>
         /// <param name="substitution"></param>

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -149,6 +149,9 @@ namespace Fluxzy.Core
             }
             finally
             {
+                if (downStreamPipe != null)
+                    _poolBuilder.ReleasePinnedPools(downStreamPipe);
+
                 downStreamPipe?.Dispose();
             }
         }
@@ -534,7 +537,7 @@ namespace Fluxzy.Core
                         {
                             // get a connection pool for the current exchange
                             connectionPool = await _poolBuilder
-                                                   .GetPool(exchange, _proxyRuntimeSetting, token)
+                                                   .GetPool(exchange, _proxyRuntimeSetting, downStreamPipe, token)
                                                    .ConfigureAwait(false);
                         }
 

--- a/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
+++ b/src/Fluxzy.Core/Core/ProxyRuntimeSetting.cs
@@ -56,6 +56,7 @@ namespace Fluxzy.Core
             ConnectionTimeout = startupSetting.ConnectionTimeout;
             ResponseHeaderTimeout = startupSetting.ResponseHeaderTimeout;
             ResponseBodyIdleTimeout = startupSetting.ResponseBodyIdleTimeout;
+            MaxPinnedConnectionsPerDownstream = startupSetting.MaxPinnedConnectionsPerDownstream;
             ActionMapping = new SetUserAgentActionMapping(startupSetting.UserAgentActionConfigurationFile);
             LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             ProxyInstanceId = proxyInstanceId;
@@ -96,6 +97,14 @@ namespace Fluxzy.Core
         public int ConcurrentConnection { get; set; } = 16;
 
         public int TimeOutSecondsUnusedConnection { get; set; } = 4;
+
+        /// <summary>
+        ///     Maximum number of distinct authorities a single downstream connection may pin an
+        ///     upstream connection for (connection-oriented auth). Bounds the sockets a client can
+        ///     hold by sending NTLM/Negotiate credentials to many hosts. Extra authorities fall
+        ///     back to the shared pool instead of pinning.
+        /// </summary>
+        public int MaxPinnedConnectionsPerDownstream { get; set; } = 64;
 
         /// <summary>
         ///     Maximum time fluxzy waits for an upstream `100 Continue` (or a

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -90,6 +90,18 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Sets the maximum number of distinct authorities a single downstream connection may
+        ///     pin an upstream connection for (connection-oriented auth). Bounds the sockets a
+        ///     client can hold; extra authorities fall back to the shared pool.
+        /// </summary>
+        public FluxzySetting SetMaxPinnedConnectionsPerDownstream(int value)
+        {
+            MaxPinnedConnectionsPerDownstream = value;
+
+            return this;
+        }
+
+        /// <summary>
         ///     Add hosts that fluxzy should not decrypt
         /// </summary>
         /// <param name="hosts"></param>

--- a/src/Fluxzy.Core/FluxzySetting.Fluent.cs
+++ b/src/Fluxzy.Core/FluxzySetting.Fluent.cs
@@ -78,6 +78,18 @@ namespace Fluxzy
         }
 
         /// <summary>
+        ///     Disables the built-in rule that pins the upstream connection on exchanges carrying
+        ///     NTLM or Negotiate/Kerberos credentials. Pinning is on by default; disabling it makes
+        ///     connection-oriented authentication break through the proxy.
+        /// </summary>
+        public FluxzySetting SetDisableAutomaticConnectionAuthPinning(bool value)
+        {
+            DisableAutomaticConnectionAuthPinning = value;
+
+            return this;
+        }
+
+        /// <summary>
         ///     Add hosts that fluxzy should not decrypt
         /// </summary>
         /// <param name="hosts"></param>

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -334,6 +334,14 @@ namespace Fluxzy
         [JsonInclude]
         public bool DisableAutomaticConnectionAuthPinning { get; internal set; }
 
+        /// <summary>
+        ///     Maximum number of distinct authorities a single downstream connection may pin an
+        ///     upstream connection for. Bounds the sockets a client can hold by sending
+        ///     NTLM/Negotiate credentials to many hosts; extra authorities use the shared pool.
+        /// </summary>
+        [JsonInclude]
+        public int MaxPinnedConnectionsPerDownstream { get; internal set; } = 64;
+
         internal IEnumerable<Rule> FixedRules()
         {
             if (!DisableAutomaticConnectionAuthPinning) {

--- a/src/Fluxzy.Core/FluxzySetting.cs
+++ b/src/Fluxzy.Core/FluxzySetting.cs
@@ -326,8 +326,23 @@ namespace Fluxzy
         [JsonInclude]
         public bool SkipInternalRules { get; internal set; }
 
+        /// <summary>
+        ///     When true, disables the built-in rule that pins the upstream connection on
+        ///     exchanges carrying NTLM or Negotiate/Kerberos credentials. Pinning is on by
+        ///     default because such connection-oriented auth otherwise breaks through the proxy.
+        /// </summary>
+        [JsonInclude]
+        public bool DisableAutomaticConnectionAuthPinning { get; internal set; }
+
         internal IEnumerable<Rule> FixedRules()
         {
+            if (!DisableAutomaticConnectionAuthPinning) {
+                yield return new Rule(
+                    new PinUpstreamConnectionAction(),
+                    new RequestHeaderFilter("^(NTLM|Negotiate|Kerberos)",
+                        StringSelectorOperation.Regex, "Authorization"));
+            }
+
             if (GlobalSkipSslDecryption) {
                 yield return new Rule(new SkipSslTunnelingAction(), AnyFilter.Default);
             }

--- a/src/Fluxzy.Core/Rules/Actions/PinUpstreamConnectionAction.cs
+++ b/src/Fluxzy.Core/Rules/Actions/PinUpstreamConnectionAction.cs
@@ -1,0 +1,35 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Core.Breakpoints;
+
+namespace Fluxzy.Rules.Actions
+{
+    /// <summary>
+    ///     Pins the upstream connection serving the matching exchange to the originating
+    ///     downstream connection. The connection is dedicated to that single client and is
+    ///     never reused for another, which is what connection-oriented authentication schemes
+    ///     (NTLM, Negotiate/Kerberos) require: their handshake and the identity it establishes
+    ///     are bound to a single TCP connection. Pinned exchanges always use HTTP/1.1 upstream.
+    /// </summary>
+    [ActionMetadata(
+        "Pin the upstream connection to the originating client connection. " +
+        "Required for connection-oriented authentication (NTLM, Negotiate/Kerberos) to work " +
+        "through the proxy. Pinned exchanges always use HTTP/1.1 upstream.")]
+    public class PinUpstreamConnectionAction : Action
+    {
+        public override FilterScope ActionScope => FilterScope.RequestHeaderReceivedFromClient;
+
+        public override string DefaultDescription => "Pin upstream connection";
+
+        public override ValueTask InternalAlter(
+            ExchangeContext context, Exchange? exchange, Connection? connection, FilterScope scope,
+            BreakPointManager breakPointManager)
+        {
+            context.RequireUpstreamPinning = true;
+
+            return default;
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
@@ -1,0 +1,253 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Authentication
+{
+    /// <summary>
+    ///     Connection-oriented authentication (NTLM / Negotiate-Kerberos as done by SSPI on
+    ///     Windows) authenticates the TCP connection, not the request. Fluxzy supports it by
+    ///     pinning the upstream connection to the originating downstream connection: the
+    ///     multi-leg handshake of one client rides a single upstream connection, and that
+    ///     connection is never handed to another client.
+    ///
+    ///     <see cref="NtlmLikeTcpServer" /> emulates the server-side semantics; these tests
+    ///     drive the handshake through Fluxzy as an explicit plain proxy, which exercises the
+    ///     same Http11ConnectionPool path as an HTTPS MITM exchange. Pinning is on by default
+    ///     (built-in rule matching NTLM/Negotiate credentials), so no rule wiring is needed here.
+    /// </summary>
+    public class ConnectionOrientedAuthTests
+    {
+        [Fact]
+        public async Task Ntlm_handshake_completes_for_a_single_client()
+        {
+            await using var server = NtlmLikeTcpServer.Start();
+            await using var proxy = new Proxy(FluxzySetting.CreateLocalRandomPort());
+
+            var endPoint = proxy.Run().First();
+            using var client = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            var leg1 = await Send(client, url, null);
+            Assert.Equal(HttpStatusCode.Unauthorized, leg1.Status);
+            Assert.Equal("NTLM", leg1.WwwAuthenticate);
+
+            var leg2 = await Send(client, url, "NTLM TYPE1");
+            Assert.Equal(HttpStatusCode.Unauthorized, leg2.Status);
+            Assert.StartsWith("NTLM CH-", leg2.WwwAuthenticate);
+
+            var challenge = leg2.WwwAuthenticate!.Substring("NTLM ".Length);
+
+            var leg3 = await Send(client, url, $"NTLM TYPE3 {challenge} alice");
+
+            Assert.True(
+                leg3.Status == HttpStatusCode.OK,
+                $"TYPE3 leg was rejected: the challenge and the TYPE3 landed on different " +
+                $"upstream connections. Server log: {DumpLog(server)}");
+
+            Assert.Contains("user=alice", leg3.Body);
+        }
+
+        [Fact]
+        public async Task Ntlm_handshake_is_isolated_from_a_concurrent_client()
+        {
+            await using var server = NtlmLikeTcpServer.Start();
+            await using var proxy = new Proxy(FluxzySetting.CreateLocalRandomPort());
+
+            var endPoint = proxy.Run().First();
+
+            using var clientA = CreateProxiedClient(endPoint);
+            using var clientB = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            await Send(clientA, url, null);
+            var challengeLeg = await Send(clientA, url, "NTLM TYPE1");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, challengeLeg.Status);
+            Assert.StartsWith("NTLM CH-", challengeLeg.WwwAuthenticate);
+
+            var challenge = challengeLeg.WwwAuthenticate!.Substring("NTLM ".Length);
+
+            // an unrelated client hits the same host while A's handshake is half-open
+            await Send(clientB, url, null);
+
+            var finalLeg = await Send(clientA, url, $"NTLM TYPE3 {challenge} alice");
+
+            Assert.True(
+                finalLeg.Status == HttpStatusCode.OK,
+                $"Client B's request destroyed client A's half-authenticated security context. " +
+                $"Server log: {DumpLog(server)}");
+
+            Assert.Contains("user=alice", finalLeg.Body);
+        }
+
+        [Fact]
+        public async Task Authenticated_connection_stays_sticky_for_followup_requests()
+        {
+            await using var server = NtlmLikeTcpServer.Start();
+            await using var proxy = new Proxy(FluxzySetting.CreateLocalRandomPort());
+
+            var endPoint = proxy.Run().First();
+            using var client = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            await Send(client, url, null);
+            var challengeLeg = await Send(client, url, "NTLM TYPE1");
+            var challenge = challengeLeg.WwwAuthenticate!.Substring("NTLM ".Length);
+            var authenticated = await Send(client, url, $"NTLM TYPE3 {challenge} alice");
+
+            Assert.Equal(HttpStatusCode.OK, authenticated.Status);
+
+            // subsequent requests carry no Authorization header: the connection itself is the
+            // credential, so the pin must persist and keep returning the authenticated identity
+            var followUp = await Send(client, url, null);
+
+            Assert.True(
+                followUp.Status == HttpStatusCode.OK,
+                $"Follow-up request was not served over the pinned authenticated connection. " +
+                $"Server log: {DumpLog(server)}");
+
+            Assert.Contains("user=alice", followUp.Body);
+        }
+
+        [Fact]
+        public async Task Authenticated_connection_is_not_reused_for_another_client()
+        {
+            await using var server = NtlmLikeTcpServer.Start();
+            await using var proxy = new Proxy(FluxzySetting.CreateLocalRandomPort());
+
+            var endPoint = proxy.Run().First();
+
+            using var clientA = CreateProxiedClient(endPoint);
+            using var clientB = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            await Send(clientA, url, null);
+            var challengeLeg = await Send(clientA, url, "NTLM TYPE1");
+            var challenge = challengeLeg.WwwAuthenticate!.Substring("NTLM ".Length);
+            var authenticated = await Send(clientA, url, $"NTLM TYPE3 {challenge} alice");
+
+            Assert.Equal(HttpStatusCode.OK, authenticated.Status);
+
+            // let the pool have a chance to recycle A's connection
+            await Task.Delay(150);
+
+            var response = await Send(clientB, url, null);
+
+            Assert.True(
+                response.Status == HttpStatusCode.Unauthorized,
+                $"Client B inherited client A's authenticated identity ({response.Body}). " +
+                $"Server log: {DumpLog(server)}");
+        }
+
+        [Fact]
+        public async Task Pinned_connection_death_mid_handshake_restarts_cleanly()
+        {
+            await using var server = NtlmLikeTcpServer.Start(dropOnceAfterChallenge: true);
+            await using var proxy = new Proxy(FluxzySetting.CreateLocalRandomPort());
+
+            var endPoint = proxy.Run().First();
+            using var client = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            await Send(client, url, null);
+            var challengeLeg = await Send(client, url, "NTLM TYPE1");
+            var challenge = challengeLeg.WwwAuthenticate!.Substring("NTLM ".Length);
+
+            // the pinned connection was dropped by the server after this challenge; the TYPE3
+            // lands on a fresh connection that holds no context, so the server restarts the
+            // handshake. The proxy must surface a clean 401, not an exception or a hang.
+            var afterDeath = await Send(client, url, $"NTLM TYPE3 {challenge} alice");
+            Assert.Equal(HttpStatusCode.Unauthorized, afterDeath.Status);
+
+            // and a fresh handshake on the (now healthy) pinned connection completes
+            var retryChallenge = await Send(client, url, "NTLM TYPE1");
+            var retry = await Send(client, url,
+                $"NTLM TYPE3 {retryChallenge.WwwAuthenticate!.Substring("NTLM ".Length)} alice");
+
+            Assert.True(
+                retry.Status == HttpStatusCode.OK,
+                $"Handshake did not recover after the pinned connection died. " +
+                $"Server log: {DumpLog(server)}");
+        }
+
+        [Fact]
+        public async Task Identity_never_leaks_when_pinning_is_disabled()
+        {
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            setting.SetDisableAutomaticConnectionAuthPinning(true);
+
+            await using var server = NtlmLikeTcpServer.Start();
+            await using var proxy = new Proxy(setting);
+
+            var endPoint = proxy.Run().First();
+
+            using var clientA = CreateProxiedClient(endPoint);
+            using var clientB = CreateProxiedClient(endPoint);
+
+            var url = $"http://127.0.0.1:{server.Port}/resource";
+
+            // client A runs a full handshake. Without pinning it is not expected to succeed,
+            // but whatever happens, an unauthenticated client B must never see A's identity.
+            await Send(clientA, url, null);
+            var challengeLeg = await Send(clientA, url, "NTLM TYPE1");
+
+            if (challengeLeg.WwwAuthenticate?.StartsWith("NTLM CH-") == true) {
+                var challenge = challengeLeg.WwwAuthenticate.Substring("NTLM ".Length);
+                await Send(clientA, url, $"NTLM TYPE3 {challenge} alice");
+            }
+
+            await Task.Delay(150);
+
+            var response = await Send(clientB, url, null);
+
+            Assert.DoesNotContain("user=alice", response.Body);
+        }
+
+        private static HttpClient CreateProxiedClient(IPEndPoint proxyEndPoint)
+        {
+            return new HttpClient(new HttpClientHandler {
+                Proxy = new WebProxy($"http://127.0.0.1:{proxyEndPoint.Port}"),
+                UseProxy = true,
+                MaxConnectionsPerServer = 1
+            }) {
+                Timeout = TimeSpan.FromSeconds(15)
+            };
+        }
+
+        private static async Task<(HttpStatusCode Status, string? WwwAuthenticate, string Body)> Send(
+            HttpClient client, string url, string? authorization)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            if (authorization != null)
+                request.Headers.TryAddWithoutValidation("Authorization", authorization);
+
+            using var response = await client.SendAsync(request);
+
+            var wwwAuthenticate = response.Headers.TryGetValues("WWW-Authenticate", out var values)
+                ? values.First()
+                : null;
+
+            var body = await response.Content.ReadAsStringAsync();
+
+            return (response.StatusCode, wwwAuthenticate, body);
+        }
+
+        private static string DumpLog(NtlmLikeTcpServer server)
+        {
+            return string.Join(" | ", server.RequestLog);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
@@ -107,16 +107,19 @@ namespace Fluxzy.Tests.UnitTests.Authentication
 
             Assert.Equal(HttpStatusCode.OK, authenticated.Status);
 
-            // subsequent requests carry no Authorization header: the connection itself is the
-            // credential, so the pin must persist and keep returning the authenticated identity
-            var followUp = await Send(client, url, null);
+            // Subsequent requests carry no Authorization header: the connection itself is the
+            // credential, so the pin must persist and keep returning the authenticated identity.
+            // Fired repeatedly on purpose: the recycle of the pinned connection happens in an
+            // async continuation, so a single follow-up only catches the race intermittently.
+            for (var i = 0; i < 25; i++) {
+                var followUp = await Send(client, url, null);
 
-            Assert.True(
-                followUp.Status == HttpStatusCode.OK,
-                $"Follow-up request was not served over the pinned authenticated connection. " +
-                $"Server log: {DumpLog(server)}");
-
-            Assert.Contains("user=alice", followUp.Body);
+                Assert.True(
+                    followUp.Status == HttpStatusCode.OK && followUp.Body.Contains("user=alice"),
+                    $"Follow-up #{i} was not served over the pinned authenticated connection " +
+                    $"(status {followUp.Status}, body '{followUp.Body}'). A fresh upstream connection " +
+                    $"was opened instead of reusing the pinned one. Server log: {DumpLog(server)}");
+            }
         }
 
         [Fact]

--- a/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Authentication/ConnectionOrientedAuthTests.cs
@@ -186,6 +186,36 @@ namespace Fluxzy.Tests.UnitTests.Authentication
         }
 
         [Fact]
+        public async Task Pins_are_capped_per_downstream_connection()
+        {
+            // One client (one downstream connection) authenticates against two authorities with a
+            // cap of one pinned connection. The first pins and completes; the second is over the
+            // cap, so it cannot pin and its connection-bound handshake cannot complete. Bounds the
+            // sockets a client could hold by spraying NTLM credentials at many hosts.
+            await using var serverA = NtlmLikeTcpServer.Start();
+            await using var serverB = NtlmLikeTcpServer.Start();
+
+            var setting = FluxzySetting.CreateLocalRandomPort()
+                                       .SetMaxPinnedConnectionsPerDownstream(1);
+
+            await using var proxy = new Proxy(setting);
+
+            var endPoint = proxy.Run().First();
+            using var client = CreateProxiedClient(endPoint);
+
+            var statusA = await RunHandshake(client, $"http://127.0.0.1:{serverA.Port}/resource", "alice");
+            Assert.Equal(HttpStatusCode.OK, statusA);
+
+            // Immediately after A (well within the idle window, so A still holds the only pin).
+            var statusB = await RunHandshake(client, $"http://127.0.0.1:{serverB.Port}/resource", "bob");
+
+            Assert.True(
+                statusB == HttpStatusCode.Unauthorized,
+                $"Second authority was pinned despite the per-downstream cap. " +
+                $"A log: {DumpLog(serverA)} ; B log: {DumpLog(serverB)}");
+        }
+
+        [Fact]
         public async Task Identity_never_leaks_when_pinning_is_disabled()
         {
             var setting = FluxzySetting.CreateLocalRandomPort();
@@ -216,6 +246,21 @@ namespace Fluxzy.Tests.UnitTests.Authentication
             var response = await Send(clientB, url, null);
 
             Assert.DoesNotContain("user=alice", response.Body);
+        }
+
+        private static async Task<HttpStatusCode> RunHandshake(HttpClient client, string url, string user)
+        {
+            await Send(client, url, null);
+            var challengeLeg = await Send(client, url, "NTLM TYPE1");
+
+            if (challengeLeg.WwwAuthenticate?.StartsWith("NTLM CH-") != true)
+                return challengeLeg.Status;
+
+            var challenge = challengeLeg.WwwAuthenticate.Substring("NTLM ".Length);
+
+            var final = await Send(client, url, $"NTLM TYPE3 {challenge} {user}");
+
+            return final.Status;
         }
 
         private static HttpClient CreateProxiedClient(IPEndPoint proxyEndPoint)

--- a/test/Fluxzy.Tests/UnitTests/Authentication/UpstreamPinningRuleTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Authentication/UpstreamPinningRuleTests.cs
@@ -1,0 +1,48 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Linq;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Fluxzy.Rules;
+using Fluxzy.Rules.Actions;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Authentication
+{
+    public class UpstreamPinningRuleTests
+    {
+        [Fact]
+        public async Task Action_sets_require_pinning_flag()
+        {
+            var authority = new Authority("intranet.corp.test", 80, false);
+            var context = new ExchangeContext(authority, new VariableContext(), null,
+                SetUserAgentActionMapping.Default);
+
+            await new PinUpstreamConnectionAction().InternalAlter(
+                context, null, null, FilterScope.RequestHeaderReceivedFromClient, null!);
+
+            Assert.True(context.RequireUpstreamPinning);
+        }
+
+        [Fact]
+        public void Default_pinning_rule_is_registered()
+        {
+            var setting = FluxzySetting.CreateDefault();
+
+            var pinningRule = setting.FixedRules()
+                                     .FirstOrDefault(r => r.Action is PinUpstreamConnectionAction);
+
+            Assert.NotNull(pinningRule);
+        }
+
+        [Fact]
+        public void Default_pinning_rule_is_omitted_when_disabled()
+        {
+            var setting = FluxzySetting.CreateDefault()
+                                       .SetDisableAutomaticConnectionAuthPinning(true);
+
+            Assert.DoesNotContain(setting.FixedRules(), r => r.Action is PinUpstreamConnectionAction);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
@@ -1,0 +1,98 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H11;
+using Fluxzy.Core;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H11Client
+{
+    /// <summary>
+    ///     A dedicated (pinned) pool must use exactly one upstream connection so a
+    ///     connection-oriented auth handshake stays on a single socket. Recycling happens in
+    ///     an async continuation on <c>exchange.Complete</c>, so without serialization a second
+    ///     concurrent (or immediately following) exchange dequeues an empty channel and opens a
+    ///     second socket. These tests drive <see cref="Http11ConnectionPool.Send" /> directly
+    ///     against a loopback server and count the sockets it accepts.
+    /// </summary>
+    public class DedicatedPoolSingleConnectionTests
+    {
+        [Fact]
+        public async Task Dedicated_pool_serialises_concurrent_sends_onto_one_connection()
+        {
+            await using var server = CountingHttpServer.Start();
+
+            await using var pool = BuildPool(server.Port, dedicated: true);
+
+            await SendConcurrently(pool, server.Port);
+
+            Assert.Equal(1, server.AcceptedConnections);
+        }
+
+        [Fact]
+        public async Task Shared_pool_opens_a_connection_per_concurrent_send()
+        {
+            // Contrast case: the ordinary shared pool has no single-connection lease, so two
+            // concurrent sends fan out onto two sockets. This is what made simply dedicating a
+            // shared pool to one client insufficient for connection-oriented auth.
+            await using var server = CountingHttpServer.Start();
+
+            await using var pool = BuildPool(server.Port, dedicated: false);
+
+            await SendConcurrently(pool, server.Port);
+
+            Assert.Equal(2, server.AcceptedConnections);
+        }
+
+        private static Http11ConnectionPool BuildPool(int port, bool dedicated)
+        {
+            var authority = new Authority("127.0.0.1", port, false);
+            var setting = ProxyRuntimeSetting.CreateDefault;
+
+            var builder = new RemoteConnectionBuilder(ITimingProvider.Default, sslConnectionBuilder: null!);
+
+            var dns = new DnsResolutionResult(
+                new IPEndPoint(IPAddress.Loopback, port), DateTime.UtcNow, DateTime.UtcNow);
+
+            var pool = new Http11ConnectionPool(
+                authority, builder, ITimingProvider.Default, setting,
+                setting.ArchiveWriter, dns, onConnectionFaulted: null, dedicated: dedicated);
+
+            pool.Init();
+
+            return pool;
+        }
+
+        private static async Task SendConcurrently(Http11ConnectionPool pool, int port)
+        {
+            var authority = new Authority("127.0.0.1", port, false);
+
+            var exchange1 = MakeExchange(authority, port);
+            var exchange2 = MakeExchange(authority, port);
+
+            var task1 = pool.Send(exchange1, null!, Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32 * 1024),
+                new ExchangeScope(), CancellationToken.None).AsTask();
+            var task2 = pool.Send(exchange2, null!, Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32 * 1024),
+                new ExchangeScope(), CancellationToken.None).AsTask();
+
+            await Task.WhenAll(task1, task2);
+
+            // Content-Length: 0 responses complete synchronously inside Send, so awaiting here
+            // just observes the already-set result and any recycle exception.
+            await exchange1.Complete;
+            await exchange2.Complete;
+        }
+
+        private static Exchange MakeExchange(Authority authority, int port)
+        {
+            var request = $"GET / HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n";
+
+            return new Exchange(IIdProvider.FromZero, authority, request.AsMemory(), "HTTP/1.1", DateTime.Now);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,10 +50,54 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             Assert.Equal(2, server.AcceptedConnections);
         }
 
-        private static Http11ConnectionPool BuildPool(int port, bool dedicated)
+        [Fact]
+        public async Task Slow_response_body_keeps_pin_active_and_recycles_from_body_completion()
+        {
+            await using var server = CountingHttpServer.Start(gateResponseBodies: true);
+
+            var setting = ProxyRuntimeSetting.CreateDefault;
+            setting.TimeOutSecondsUnusedConnection = 1;
+
+            await using var pool = BuildPool(server.Port, dedicated: true, setting, onFaulted: _ => { });
+
+            var first = MakeExchange(new Authority("127.0.0.1", server.Port, false), server.Port);
+
+            await pool.Send(first, null!, Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32 * 1024),
+                new ExchangeScope(), CancellationToken.None);
+
+            Assert.False(first.Complete.IsCompleted,
+                "the response body must still own the pinned connection");
+
+            // Exceed the idle timeout while the body is in flight. This must not make the
+            // authenticated connection idle or age its eventual recycle timestamp.
+            await Task.Delay(TimeSpan.FromMilliseconds(1200));
+
+            pool.LastActivity = DateTime.MinValue;
+            Assert.False(pool.TryIdleTeardown(),
+                "a pinned pool with an in-flight response body must not idle-evict");
+
+            server.ReleaseResponseBodies();
+            await first.Response.Body!.CopyToAsync(Stream.Null);
+            await first.Complete;
+
+            var second = MakeExchange(new Authority("127.0.0.1", server.Port, false), server.Port);
+
+            await pool.Send(second, null!, Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32 * 1024),
+                new ExchangeScope(), CancellationToken.None);
+            await second.Response.Body!.CopyToAsync(Stream.Null);
+            await second.Complete;
+
+            Assert.Equal(1, server.AcceptedConnections);
+        }
+
+        private static Http11ConnectionPool BuildPool(
+            int port,
+            bool dedicated,
+            ProxyRuntimeSetting? setting = null,
+            Action<IHttpConnectionPool>? onFaulted = null)
         {
             var authority = new Authority("127.0.0.1", port, false);
-            var setting = ProxyRuntimeSetting.CreateDefault;
+            setting ??= ProxyRuntimeSetting.CreateDefault;
 
             var builder = new RemoteConnectionBuilder(ITimingProvider.Default, sslConnectionBuilder: null!);
 
@@ -61,7 +106,7 @@ namespace Fluxzy.Tests.UnitTests.H11Client
 
             var pool = new Http11ConnectionPool(
                 authority, builder, ITimingProvider.Default, setting,
-                setting.ArchiveWriter, dns, onConnectionFaulted: null, dedicated: dedicated);
+                setting.ArchiveWriter, dns, onConnectionFaulted: onFaulted, dedicated: dedicated);
 
             pool.Init();
 

--- a/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/Http11ConnectionPoolIdleTeardownTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 using Fluxzy.Clients;
 using Fluxzy.Clients.H11;
 using Fluxzy.Core;
@@ -116,11 +117,54 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             Assert.False(freshWrite.Disposed, "reusable connection must not be disposed");
         }
 
+        /// <summary>
+        ///     A dedicated (pinned) pool must be reclaimable on idle like any other, otherwise a
+        ///     client can hold one upstream socket per authority for the life of its downstream
+        ///     connection just by sending NTLM/Negotiate credentials. Passing a fault callback is
+        ///     what wires the idle monitor, and teardown must free the pinned socket.
+        /// </summary>
+        [Fact]
+        public void DedicatedPool_IdleTearsDown_FreesPinnedSocket_AndFiresEviction()
+        {
+            IHttpConnectionPool? evicted = null;
+            var pool = BuildPool(onFaulted: p => evicted = p, dedicated: true);
+
+            var (connection, readStream, writeStream) = MakePooledConnection();
+            Assert.True(EnqueuePooledConnection(pool, connection),
+                "precondition: pooled connection enqueued");
+
+            pool.LastActivity = DateTime.MinValue;
+
+            Assert.True(pool.TryIdleTeardown(), "an idle pinned pool must tear down");
+            Assert.True(pool.Complete);
+            Assert.Same(pool, evicted);
+            Assert.True(readStream.Disposed, "pinned connection read stream must be disposed");
+            Assert.True(writeStream.Disposed, "pinned connection write stream must be disposed");
+        }
+
+        [Fact]
+        public async Task DedicatedPool_WithFaultCallback_RunsIdleMonitor()
+        {
+            // Guards the wiring: dedicated pools used to be built with a null callback, which made
+            // Init() skip the monitor and left them immortal (haga-rak review P2).
+            var pool = BuildPool(onFaulted: _ => { }, dedicated: true);
+            pool.Init();
+
+            var monitor = typeof(Http11ConnectionPool)
+                          .GetField("_idleMonitorTask", BindingFlags.Instance | BindingFlags.NonPublic)!
+                          .GetValue(pool);
+
+            Assert.NotNull(monitor);
+
+            await pool.DisposeAsync();
+        }
+
         // ==================================================================
         // Helpers
         // ==================================================================
 
-        private static Http11ConnectionPool BuildPool(Action<IHttpConnectionPool> onFaulted)
+        private static Http11ConnectionPool BuildPool(
+            Action<IHttpConnectionPool> onFaulted, bool dedicated = false)
         {
             var authority = new Authority("test.local", 443, true);
 
@@ -133,7 +177,8 @@ namespace Fluxzy.Tests.UnitTests.H11Client
                 ProxyRuntimeSetting.CreateDefault,
                 archiveWriter: null!,
                 resolutionResult: default,
-                onConnectionFaulted: onFaulted);
+                onConnectionFaulted: onFaulted,
+                dedicated: dedicated);
         }
 
         private static (Connection connection, RecordingStream read, RecordingStream write) MakePooledConnection()

--- a/test/Fluxzy.Tests/_Fixtures/CountingHttpServer.cs
+++ b/test/Fluxzy.Tests/_Fixtures/CountingHttpServer.cs
@@ -1,0 +1,110 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Tests._Fixtures
+{
+    /// <summary>
+    ///     A loopback HTTP/1.1 server that answers every request with an empty
+    ///     <c>200 OK</c> on a keep-alive connection and counts how many TCP connections
+    ///     it accepted. Used to assert how many upstream sockets a pool actually opens.
+    /// </summary>
+    internal sealed class CountingHttpServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _acceptLoop;
+        private int _acceptedConnections;
+
+        private CountingHttpServer(TcpListener listener)
+        {
+            _listener = listener;
+            _acceptLoop = AcceptLoop();
+        }
+
+        public int Port => ((IPEndPoint) _listener.LocalEndpoint).Port;
+
+        public int AcceptedConnections => Volatile.Read(ref _acceptedConnections);
+
+        public static CountingHttpServer Start()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+
+            return new CountingHttpServer(listener);
+        }
+
+        private async Task AcceptLoop()
+        {
+            try {
+                while (!_cts.IsCancellationRequested) {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                    Interlocked.Increment(ref _acceptedConnections);
+                    _ = HandleConnection(client);
+                }
+            }
+            catch {
+                // shutting down
+            }
+        }
+
+        private async Task HandleConnection(TcpClient client)
+        {
+            try {
+                using var _ = client;
+                var stream = client.GetStream();
+                var buffer = new byte[8192];
+                var accumulated = new StringBuilder();
+
+                var response = Encoding.ASCII.GetBytes(
+                    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n");
+
+                while (!_cts.IsCancellationRequested) {
+                    var read = await stream.ReadAsync(buffer, _cts.Token).ConfigureAwait(false);
+
+                    if (read == 0)
+                        return;
+
+                    accumulated.Append(Encoding.ASCII.GetString(buffer, 0, read));
+
+                    // Answer once per complete header block (GET only, no request body).
+                    while (true) {
+                        var text = accumulated.ToString();
+                        var end = text.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+
+                        if (end < 0)
+                            break;
+
+                        accumulated.Remove(0, end + 4);
+
+                        await stream.WriteAsync(response, _cts.Token).ConfigureAwait(false);
+                        await stream.FlushAsync(_cts.Token).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch {
+                // connection torn down
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+
+            try {
+                await _acceptLoop.ConfigureAwait(false);
+            }
+            catch {
+                // ignore
+            }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/test/Fluxzy.Tests/_Fixtures/CountingHttpServer.cs
+++ b/test/Fluxzy.Tests/_Fixtures/CountingHttpServer.cs
@@ -19,11 +19,19 @@ namespace Fluxzy.Tests._Fixtures
         private readonly TcpListener _listener;
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _acceptLoop;
+        private readonly bool _gateResponseBodies;
+        private readonly TaskCompletionSource _responseBodyGate =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _acceptedConnections;
 
-        private CountingHttpServer(TcpListener listener)
+        private CountingHttpServer(TcpListener listener, bool gateResponseBodies)
         {
             _listener = listener;
+            _gateResponseBodies = gateResponseBodies;
+
+            if (!gateResponseBodies)
+                _responseBodyGate.TrySetResult();
+
             _acceptLoop = AcceptLoop();
         }
 
@@ -31,12 +39,17 @@ namespace Fluxzy.Tests._Fixtures
 
         public int AcceptedConnections => Volatile.Read(ref _acceptedConnections);
 
-        public static CountingHttpServer Start()
+        public static CountingHttpServer Start(bool gateResponseBodies = false)
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
 
-            return new CountingHttpServer(listener);
+            return new CountingHttpServer(listener, gateResponseBodies);
+        }
+
+        public void ReleaseResponseBodies()
+        {
+            _responseBodyGate.TrySetResult();
         }
 
         private async Task AcceptLoop()
@@ -61,8 +74,9 @@ namespace Fluxzy.Tests._Fixtures
                 var buffer = new byte[8192];
                 var accumulated = new StringBuilder();
 
-                var response = Encoding.ASCII.GetBytes(
-                    "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n");
+                var responseHeader = Encoding.ASCII.GetBytes(
+                    $"HTTP/1.1 200 OK\r\nContent-Length: {(_gateResponseBodies ? 1 : 0)}\r\n" +
+                    "Connection: keep-alive\r\n\r\n");
 
                 while (!_cts.IsCancellationRequested) {
                     var read = await stream.ReadAsync(buffer, _cts.Token).ConfigureAwait(false);
@@ -82,8 +96,14 @@ namespace Fluxzy.Tests._Fixtures
 
                         accumulated.Remove(0, end + 4);
 
-                        await stream.WriteAsync(response, _cts.Token).ConfigureAwait(false);
+                        await stream.WriteAsync(responseHeader, _cts.Token).ConfigureAwait(false);
                         await stream.FlushAsync(_cts.Token).ConfigureAwait(false);
+
+                        if (_gateResponseBodies) {
+                            await _responseBodyGate.Task.WaitAsync(_cts.Token).ConfigureAwait(false);
+                            await stream.WriteAsync(new byte[] { (byte) 'x' }, _cts.Token).ConfigureAwait(false);
+                            await stream.FlushAsync(_cts.Token).ConfigureAwait(false);
+                        }
                     }
                 }
             }

--- a/test/Fluxzy.Tests/_Fixtures/NtlmLikeTcpServer.cs
+++ b/test/Fluxzy.Tests/_Fixtures/NtlmLikeTcpServer.cs
@@ -1,0 +1,240 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Tests._Fixtures
+{
+    /// <summary>
+    ///     A minimal HTTP/1.1 server emulating connection-oriented authentication
+    ///     (NTLM / Negotiate-style, as used by SSPI on Windows). The crypto is faked,
+    ///     the transport semantics are the real thing:
+    ///     - the challenge issued for a TYPE1 message is scoped to the TCP connection,
+    ///     - the TYPE3 reply is only accepted on the connection that got the challenge,
+    ///       and any other request in between drops the pending security context,
+    ///     - once authenticated, the connection itself is authenticated: subsequent
+    ///       requests on it succeed without any Authorization header.
+    ///
+    ///     Protocol accepted on the Authorization header:
+    ///     - "NTLM TYPE1"                    → 401 + "WWW-Authenticate: NTLM {challenge}"
+    ///     - "NTLM TYPE3 {challenge} {user}" → 200 if {challenge} is the one pending on
+    ///       this connection, else 401 restart
+    ///     - anything else / absent          → 401 + "WWW-Authenticate: NTLM"
+    /// </summary>
+    internal sealed class NtlmLikeTcpServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _acceptLoop;
+        private readonly bool _dropOnceAfterChallenge;
+        private int _connectionCounter;
+        private int _challengeCounter;
+        private int _dropArmed;
+
+        public ConcurrentQueue<string> RequestLog { get; } = new();
+
+        private NtlmLikeTcpServer(TcpListener listener, bool dropOnceAfterChallenge)
+        {
+            _listener = listener;
+            _dropOnceAfterChallenge = dropOnceAfterChallenge;
+            _dropArmed = dropOnceAfterChallenge ? 1 : 0;
+            _acceptLoop = AcceptLoop();
+        }
+
+        public int Port => ((IPEndPoint) _listener.LocalEndpoint).Port;
+
+        public int TotalConnections => Volatile.Read(ref _connectionCounter);
+
+        /// <param name="dropOnceAfterChallenge">
+        ///     When true, the server closes the connection right after issuing its first
+        ///     challenge, emulating an upstream connection dying mid-handshake.
+        /// </param>
+        public static NtlmLikeTcpServer Start(bool dropOnceAfterChallenge = false)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+
+            return new NtlmLikeTcpServer(listener, dropOnceAfterChallenge);
+        }
+
+        private async Task AcceptLoop()
+        {
+            try {
+                while (!_cts.IsCancellationRequested) {
+                    var client = await _listener.AcceptTcpClientAsync(_cts.Token).ConfigureAwait(false);
+                    var connectionId = Interlocked.Increment(ref _connectionCounter);
+                    _ = HandleConnection(client, connectionId);
+                }
+            }
+            catch {
+                // shutting down
+            }
+        }
+
+        private async Task HandleConnection(TcpClient client, int connectionId)
+        {
+            string? pendingChallenge = null;
+            string? authenticatedUser = null;
+
+            try {
+                using var _ = client;
+                var stream = client.GetStream();
+
+                while (!_cts.IsCancellationRequested) {
+                    var headers = await ReadHeaderBlock(stream).ConfigureAwait(false);
+
+                    if (headers == null)
+                        return; // peer closed
+
+                    var authorization = GetHeader(headers, "Authorization");
+
+                    int status;
+                    string? wwwAuthenticate = null;
+                    string body;
+
+                    if (authenticatedUser != null) {
+                        // NTLM semantics: the connection carries the identity from now on
+                        status = 200;
+                        body = $"user={authenticatedUser};conn={connectionId}";
+                    }
+                    else if (authorization == "NTLM TYPE1") {
+                        pendingChallenge = $"CH-{connectionId}-{Interlocked.Increment(ref _challengeCounter)}";
+                        status = 401;
+                        wwwAuthenticate = $"NTLM {pendingChallenge}";
+                        body = "challenge issued";
+                    }
+                    else if (authorization != null && authorization.StartsWith("NTLM TYPE3 ", StringComparison.Ordinal)) {
+                        var parts = authorization.Substring("NTLM TYPE3 ".Length)
+                                                 .Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+                        var providedChallenge = parts.Length > 0 ? parts[0] : "";
+                        var user = parts.Length > 1 ? parts[1] : "anonymous";
+
+                        if (pendingChallenge != null && providedChallenge == pendingChallenge) {
+                            authenticatedUser = user;
+                            pendingChallenge = null;
+                            status = 200;
+                            body = $"user={user};conn={connectionId}";
+                        }
+                        else {
+                            // TYPE3 on a connection that holds no matching security
+                            // context: restart the handshake, as SSPI does
+                            pendingChallenge = null;
+                            status = 401;
+                            wwwAuthenticate = "NTLM";
+                            body = "handshake restarted";
+                        }
+                    }
+                    else {
+                        // an unauthenticated request drops any half-open handshake
+                        pendingChallenge = null;
+                        status = 401;
+                        wwwAuthenticate = "NTLM";
+                        body = "authentication required";
+                    }
+
+                    RequestLog.Enqueue($"conn={connectionId};auth={authorization ?? "(none)"};status={status}");
+
+                    await WriteResponse(stream, status, wwwAuthenticate, body, connectionId).ConfigureAwait(false);
+
+                    // Emulate an upstream connection dying right after a challenge (once).
+                    if (_dropOnceAfterChallenge && pendingChallenge != null
+                        && Interlocked.Exchange(ref _dropArmed, 0) == 1)
+                        return;
+                }
+            }
+            catch {
+                // connection torn down
+            }
+        }
+
+        private static async Task<List<string>?> ReadHeaderBlock(NetworkStream stream)
+        {
+            var buffer = new byte[16 * 1024];
+            var received = 0;
+
+            while (true) {
+                var read = await stream.ReadAsync(buffer, received, buffer.Length - received).ConfigureAwait(false);
+
+                if (read == 0)
+                    return null;
+
+                received += read;
+
+                var text = Encoding.ASCII.GetString(buffer, 0, received);
+                var endOfHeaders = text.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+
+                if (endOfHeaders >= 0) {
+                    // GET only: nothing to drain after the header block
+                    var lines = text.Substring(0, endOfHeaders).Split("\r\n");
+
+                    return new List<string>(lines);
+                }
+
+                if (received == buffer.Length)
+                    throw new InvalidOperationException("Header block too large");
+            }
+        }
+
+        private static string? GetHeader(List<string> headerLines, string name)
+        {
+            foreach (var line in headerLines) {
+                var separator = line.IndexOf(':');
+
+                if (separator <= 0)
+                    continue;
+
+                if (string.Equals(line.Substring(0, separator).Trim(), name, StringComparison.OrdinalIgnoreCase))
+                    return line.Substring(separator + 1).Trim();
+            }
+
+            return null;
+        }
+
+        private static async Task WriteResponse(
+            NetworkStream stream, int status, string? wwwAuthenticate, string body, int connectionId)
+        {
+            var reason = status == 200 ? "OK" : "Unauthorized";
+            var payload = Encoding.UTF8.GetBytes(body);
+
+            var builder = new StringBuilder();
+            builder.Append($"HTTP/1.1 {status} {reason}\r\n");
+            builder.Append($"Content-Length: {payload.Length}\r\n");
+            builder.Append("Content-Type: text/plain\r\n");
+            builder.Append("Connection: keep-alive\r\n");
+            builder.Append($"X-Conn-Id: {connectionId}\r\n");
+
+            if (wwwAuthenticate != null)
+                builder.Append($"WWW-Authenticate: {wwwAuthenticate}\r\n");
+
+            builder.Append("\r\n");
+
+            var header = Encoding.ASCII.GetBytes(builder.ToString());
+
+            await stream.WriteAsync(header).ConfigureAwait(false);
+            await stream.WriteAsync(payload).ConfigureAwait(false);
+            await stream.FlushAsync().ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+
+            try {
+                await _acceptLoop.ConfigureAwait(false);
+            }
+            catch {
+                // ignore
+            }
+
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Connection-oriented auth (NTLM and Negotiate/Kerberos, as done by SSPI on Windows) now works through the proxy. These schemes bind the handshake and the resulting identity to a single TCP connection; the shared pool broke that under any concurrency (endless credential reprompts) and could leak an authenticated identity to another client. Fluxzy now pins the upstream connection to the originating client for such exchanges.

No configuration is required: a built-in rule detects `Authorization: NTLM|Negotiate|Kerberos` and pins automatically. Pinned exchanges always use HTTP/1.1 upstream, the connection is dedicated to that client and never reused for another, it idle-evicts like any pooled connection, and the number of distinct pinned authorities per downstream connection is capped (default 64).

New public API:
- `ExchangeContext.RequireUpstreamPinning` (bool), to request pinning from a custom action or rule.
- `PinUpstreamConnectionAction`, usable from YAML/JSON (`typeKind: pinUpstreamConnectionAction`) and the fluent API.
- `FluxzySetting.SetDisableAutomaticConnectionAuthPinning(bool)`, to turn off the built-in auto-detection.
- `FluxzySetting.SetMaxPinnedConnectionsPerDownstream(int)`, to tune the per-connection cap.

Behavior to expect: NTLM/Negotiate against an intercepted host completes and stays authenticated across follow-up requests on the same client connection, and a different client never inherits that identity. Hosts enforcing Extended Protection / channel binding still reject the MITM certificate and need a decryption bypass. Chaining through an upstream NTLM proxy (407) is not covered here. Throughput against main is unchanged under the short benchmark (about 90 extra bytes allocated per request from the always-on detection rule).
