### PR TITLE
Ignore ownerless sockets when resolving a process from a local port

### DIFF
--- a/src/Fluxzy.Core/Utils/ProcessTracking/LinuxProcessHelper.cs
+++ b/src/Fluxzy.Core/Utils/ProcessTracking/LinuxProcessHelper.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
@@ -13,14 +14,14 @@ namespace Fluxzy.Utils.ProcessTracking
     {
         public static ProcessInfo? GetProcessInfo(int localPort)
         {
-            // Find the socket inode for the given port
-            var inode = FindSocketInodeForPort(localPort);
+            // Find the socket inodes for the given port
+            var inodes = FindSocketInodesForPort(localPort);
 
-            if (inode == null)
+            if (inodes.Count == 0)
                 return null;
 
-            // Find the process that owns this socket
-            var pid = FindProcessBySocketInode(inode.Value);
+            // Find the process that owns one of those sockets
+            var pid = FindProcessBySocketInodes(inodes);
 
             if (pid == null)
                 return null;
@@ -30,49 +31,59 @@ namespace Fluxzy.Utils.ProcessTracking
             return new ProcessInfo(pid.Value, processPath, processArguments);
         }
 
-        private static long? FindSocketInodeForPort(int localPort)
+        private static HashSet<long> FindSocketInodesForPort(int localPort)
         {
             // Try IPv4 first, then IPv6
-            var inode = FindSocketInodeInFile("/proc/net/tcp", localPort);
+            var inodes = FindSocketInodesInFile("/proc/net/tcp", localPort);
 
-            if (inode == null)
-                inode = FindSocketInodeInFile("/proc/net/tcp6", localPort);
+            if (inodes.Count == 0)
+                inodes = FindSocketInodesInFile("/proc/net/tcp6", localPort);
 
-            return inode;
+            return inodes;
         }
 
-        private static long? FindSocketInodeInFile(string path, int localPort)
+        private static HashSet<long> FindSocketInodesInFile(string path, int localPort)
         {
-            if (!File.Exists(path))
-                return null;
+            var inodes = new HashSet<long>();
 
-            var portHex = localPort.ToString("X4", CultureInfo.InvariantCulture);
+            if (!File.Exists(path))
+                return inodes;
 
             try
             {
                 using var reader = new StreamReader(path);
-
-                // Skip header line
-                reader.ReadLine();
-
-                string? line;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    var inode = ParseTcpLineForPort(line, portHex);
-                    if (inode != null)
-                        return inode;
-                }
+                CollectSocketInodes(reader, localPort, inodes);
             }
             catch (IOException)
             {
-                return null;
+                // partial results are still usable
             }
             catch (UnauthorizedAccessException)
             {
-                return null;
+                // partial results are still usable
             }
 
-            return null;
+            return inodes;
+        }
+
+        internal static void CollectSocketInodes(TextReader reader, int localPort, HashSet<long> inodes)
+        {
+            var portHex = localPort.ToString("X4", CultureInfo.InvariantCulture);
+
+            // Skip header line
+            reader.ReadLine();
+
+            string? line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                var inode = ParseTcpLineForPort(line, portHex);
+
+                // Several entries may share the same local port. Sockets with no owning file
+                // descriptor (TIME_WAIT, connections still in the accept queue) report inode 0
+                // and must not shadow the live socket we are looking for.
+                if (inode is > 0)
+                    inodes.Add(inode.Value);
+            }
         }
 
         private static long? ParseTcpLineForPort(ReadOnlySpan<char> line, ReadOnlySpan<char> portHex)
@@ -156,9 +167,12 @@ namespace Fluxzy.Utils.ProcessTracking
             return null;
         }
 
-        private static int? FindProcessBySocketInode(long inode)
+        private static int? FindProcessBySocketInodes(HashSet<long> inodes)
         {
-            var socketLink = $"socket:[{inode}]";
+            var socketLinks = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var inode in inodes)
+                socketLinks.Add($"socket:[{inode}]");
 
             try
             {
@@ -182,8 +196,7 @@ namespace Fluxzy.Utils.ProcessTracking
                             try
                             {
                                 var linkTarget = File.ResolveLinkTarget(fdPath, false);
-                                if (linkTarget != null &&
-                                    linkTarget.Name.Equals(socketLink, StringComparison.Ordinal))
+                                if (linkTarget != null && socketLinks.Contains(linkTarget.Name))
                                 {
                                     return pid;
                                 }

--- a/src/Fluxzy.Core/Utils/ProcessTracking/WindowsProcessHelper.cs
+++ b/src/Fluxzy.Core/Utils/ProcessTracking/WindowsProcessHelper.cs
@@ -102,7 +102,12 @@ namespace Fluxzy.Utils.ProcessTracking
 
                 if (port == localPort)
                 {
-                    return MemoryMarshal.Read<int>(rowSpan.Slice(20, 4));
+                    var owningPid = MemoryMarshal.Read<int>(rowSpan.Slice(20, 4));
+
+                    // Several rows may share the same local port. TIME_WAIT rows carry no real
+                    // owner and must not shadow the live socket we are looking for.
+                    if (owningPid > 0)
+                        return owningPid;
                 }
             }
 

--- a/test/Fluxzy.Tests/UnitTests/Util/LinuxProcessHelperTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Util/LinuxProcessHelperTests.cs
@@ -1,0 +1,76 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Fluxzy.Utils.ProcessTracking;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Util
+{
+    public class LinuxProcessHelperTests
+    {
+        private const string Header =
+            "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+
+        private static HashSet<long> Collect(int localPort, params string[] lines)
+        {
+            var content = string.Join("\n", new[] { Header }.Concat(lines));
+            var result = new HashSet<long>();
+
+            LinuxProcessHelper.CollectSocketInodes(new StringReader(content), localPort, result);
+
+            return result;
+        }
+
+        [Fact]
+        public void CollectSocketInodes_EstablishedSocket()
+        {
+            // 0xA1B2 == 41394
+            var inodes = Collect(41394,
+                "   0: 0100007F:A1B2 0100007F:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 987654 1 0000000000000000 20 0 0 10 -1");
+
+            Assert.Equal(new HashSet<long> { 987654 }, inodes);
+        }
+
+        [Fact]
+        public void CollectSocketInodes_SkipsTimeWaitShadowingLivePort()
+        {
+            // A TIME_WAIT entry (st 06, inode 0) may hold the same local port as a live socket:
+            // the ephemeral port gets reused for a different remote tuple. The live inode must win.
+            var inodes = Collect(41394,
+                "   0: 0100007F:A1B2 0100007F:2710 06 00000000:00000000 00:00000000 00000000     0        0 0 0 0000000000000000",
+                "   1: 0100007F:A1B2 0100007F:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 987654 1 0000000000000000 20 0 0 10 -1");
+
+            Assert.Equal(new HashSet<long> { 987654 }, inodes);
+        }
+
+        [Fact]
+        public void CollectSocketInodes_IgnoresRemotePortMatches()
+        {
+            var inodes = Collect(41394,
+                "   0: 0100007F:1F90 0100007F:A1B2 01 00000000:00000000 00:00000000 00000000  1000        0 987654 1 0000000000000000 20 0 0 10 -1");
+
+            Assert.Empty(inodes);
+        }
+
+        [Fact]
+        public void CollectSocketInodes_CollectsEveryCandidate()
+        {
+            var inodes = Collect(41394,
+                "   0: 0100007F:A1B2 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 111 1 0000000000000000 100 0 0 10 0",
+                "   1: 0100007F:A1B2 0100007F:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 222 1 0000000000000000 20 0 0 10 -1");
+
+            Assert.Equal(new HashSet<long> { 111, 222 }, inodes);
+        }
+
+        [Fact]
+        public void CollectSocketInodes_ParsesIpV6Table()
+        {
+            var inodes = Collect(41394,
+                "   0: 00000000000000000000000001000000:A1B2 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 333 1 0000000000000000 100 0 0 10 0");
+
+            Assert.Equal(new HashSet<long> { 333 }, inodes);
+        }
+    }
+}


### PR DESCRIPTION
`ProcessTrackerTests.GetProcessInfo_WithConnectedSocket_ReturnsProcessInfo` fails intermittently on Linux CI. The test is fine, the resolution is not.

`/proc/net/tcp` can list several entries sharing the same local port: an ephemeral port gets reused for a new remote tuple while a stale TIME_WAIT entry still holds it. Ownerless entries (TIME_WAIT, connections still in the accept queue) report inode 0, and the lookup returned the first port match whatever its inode, so `socket:[0]` resolved to no pid and the caller got null. Which entry comes first is hash bucket order, hence the flakiness.

```
local port 43589 (hex AA45), /proc/net/tcp entries:
  local=0100007F:AA45 rem=0100007F:9E33 st=06 inode=0        <- TIME_WAIT, listed first
  local=0100007F:AA45 rem=0100007F:B01B st=01 inode=1202706  <- the live socket
old logic picked inode 0 -> resolvable: False
```

Not test-only: `LocalTcpTableProcessResolver` uses this path, so the proxy intermittently failed to identify the process behind a loopback connection.

`LinuxProcessHelper` now collects every candidate inode for the port, discards inode 0, and resolves them in a single `/proc` walk. Windows has the same shadowing (TIME_WAIT rows carry no owning pid) and now skips those rows. macOS enumerates file descriptors first and cannot observe ownerless sockets, so it is unchanged.

`LinuxProcessHelperTests` covers the parser against a synthetic table: TIME_WAIT shadowing, remote port not mistaken for a local one, multiple candidates, IPv6 layout.