### PR TITLE
Update NuGet package tags

### DIFF
--- a/src/Fluxzy.Core.Pcap/Fluxzy.Core.Pcap.csproj
+++ b/src/Fluxzy.Core.Pcap/Fluxzy.Core.Pcap.csproj
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://www.fluxzy.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/haga-rak/fluxzy.core</RepositoryUrl>
-    <PackageTags>mitm;http;pcap;proxy</PackageTags>
+    <PackageTags>pcap;pcapng;packet-capture;wireshark;mitm;proxy;http;tls;sslkeylog;network;sniffer;libpcap;sharppcap;tcpdump</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Fluxzy.Core/Fluxzy.Core.csproj
+++ b/src/Fluxzy.Core/Fluxzy.Core.csproj
@@ -13,7 +13,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/haga-rak/fluxzy.core</RepositoryUrl>
-    <PackageTags>mitm;http;https;proxy;sock5;grpc</PackageTags>
+    <PackageTags>mitm;proxy;http;https;http-proxy;mitm-proxy;mitmproxy;interceptor;http2;websocket;tls;ssl;socks5;har;traffic;sniffer;network;debugging;testing;certificate</PackageTags>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Improves discoverability on nuget.org for `Fluxzy.Core` and `Fluxzy.Core.Pcap`. Tags only, no code or behavior change.
