### PR TITLE
Use the native macOS authorization dialog for graphical elevation

### DIFF
--- a/src/Fluxzy.Core/Misc/IOsxElevationLauncher.cs
+++ b/src/Fluxzy.Core/Misc/IOsxElevationLauncher.cs
@@ -1,0 +1,24 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Fluxzy.Misc
+{
+    /// <summary>
+    /// Alternative macOS elevation mechanism. When assigned to
+    /// <see cref="ProcessUtils.OsxElevationLauncher"/>, it replaces the built-in flow
+    /// (system authorization dialog, sudo) entirely.
+    /// </summary>
+    public interface IOsxElevationLauncher
+    {
+        /// <summary>
+        /// Starts <paramref name="commandName"/> as root. When <paramref name="redirectStdOut"/>
+        /// is true, the returned process must expose live stdin/stdout. Returns null when
+        /// elevation is declined or unavailable.
+        /// </summary>
+        Task<Process?> StartElevatedAsync(
+            string commandName, string[] args, bool redirectStdOut,
+            string askPasswordPrompt, bool redirectStandardError);
+    }
+}

--- a/src/Fluxzy.Core/Misc/ProcessUtils.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtils.cs
@@ -230,15 +230,14 @@ namespace Fluxzy.Misc
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
-                if (Environment.GetEnvironmentVariable("FluxzyDesktopVersion") != null
-                    || string.Equals(Environment.GetEnvironmentVariable("FluxzyGraphicalPrivilegePrompt"), "TRUE",
-                        StringComparison.OrdinalIgnoreCase)) {
-                    var acquired = await ProcessUtilsOsx.OsxTryAcquireElevation(askPasswordPrompt)
-                                                        .ConfigureAwait(false);
+                var graphical = Environment.GetEnvironmentVariable("FluxzyDesktopVersion") != null
+                                || string.Equals(Environment.GetEnvironmentVariable("FluxzyGraphicalPrivilegePrompt"),
+                                    "TRUE", StringComparison.OrdinalIgnoreCase);
 
-                    if (!acquired) {
-                        return null;
-                    }
+                if (graphical && !await ProcessUtilX.CanElevated().ConfigureAwait(false)) {
+                    return redirectStdOut
+                        ? ProcessUtilsOsx.StartElevatedStreamed(commandName, args, redirectStandardError)
+                        : ProcessUtilsOsx.StartElevatedOneShot(commandName, args, askPasswordPrompt);
                 }
 
                 var osXProcess = Process.Start(new ProcessStartInfo("sudo", $"-n \"{commandName}\" {fullArgs}") {

--- a/src/Fluxzy.Core/Misc/ProcessUtils.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtils.cs
@@ -210,6 +210,11 @@ namespace Fluxzy.Misc
             return true;
         }
 
+        /// <summary>
+        /// Replaces the built-in macOS elevation flow when set. Ignored on other platforms.
+        /// </summary>
+        public static IOsxElevationLauncher? OsxElevationLauncher { get; set; }
+
         public static async Task<Process?> RunElevatedAsync(
             string commandName, string[] args, bool redirectStdOut,
             string askPasswordPrompt, bool redirectStandardError = false)
@@ -230,6 +235,13 @@ namespace Fluxzy.Misc
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                var customLauncher = OsxElevationLauncher;
+
+                if (customLauncher != null) {
+                    return await customLauncher.StartElevatedAsync(commandName, args, redirectStdOut,
+                        askPasswordPrompt, redirectStandardError).ConfigureAwait(false);
+                }
+
                 var graphical = Environment.GetEnvironmentVariable("FluxzyDesktopVersion") != null
                                 || string.Equals(Environment.GetEnvironmentVariable("FluxzyGraphicalPrivilegePrompt"),
                                     "TRUE", StringComparison.OrdinalIgnoreCase);

--- a/src/Fluxzy.Core/Misc/ProcessUtilsOsx.cs
+++ b/src/Fluxzy.Core/Misc/ProcessUtilsOsx.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Fluxzy.Misc.Streams;
 
@@ -9,6 +10,73 @@ namespace Fluxzy.Misc
 {
     internal static class ProcessUtilsOsx
     {
+        /// <summary>
+        /// Launches commandName as root through the system authorization dialog, keeping live
+        /// stdin/stdout on the returned process. The password is collected by macOS, never by
+        /// this process.
+        /// </summary>
+        internal static Process? StartElevatedStreamed(
+            string commandName, string[] args, bool redirectStandardError)
+        {
+            // security(1) forwards this process's stdin to the elevated child, but never reads
+            // back the AuthorizationExecuteWithPrivileges pipe that carries the child's stdout;
+            // only the child's stderr flows back. Swap stdout/stderr inside the elevated shell
+            // and swap them back outside, so the child's stdout lands on StandardOutput.
+            var elevated = new[] {
+                "/usr/bin/security", "-q", "execute-with-privileges",
+                "/bin/sh", "-c", "exec \"$0\" \"$@\" 1>&2", commandName
+            }.Concat(args);
+
+            var startInfo = new ProcessStartInfo("/bin/sh") {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                RedirectStandardError = redirectStandardError
+            };
+
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add($"exec {string.Join(" ", elevated.Select(QuoteForShell))} 2>&1");
+
+            return Process.Start(startInfo);
+        }
+
+        /// <summary>
+        /// Runs a one-shot command as root through the system authorization dialog. The returned
+        /// process exits when the command completes and reflects its failure in the exit code.
+        /// </summary>
+        internal static Process? StartElevatedOneShot(string commandName, string[] args, string prompt)
+        {
+            var command = string.Join(" ",
+                new[] { commandName }.Concat(args).Select(QuoteForShell));
+
+            var script = $"do shell script {QuoteForAppleScript(command)}";
+
+            if (!string.IsNullOrWhiteSpace(prompt)) {
+                script += $" with prompt {QuoteForAppleScript(prompt)}";
+            }
+
+            script += " with administrator privileges";
+
+            var startInfo = new ProcessStartInfo("/usr/bin/osascript") {
+                UseShellExecute = false
+            };
+
+            startInfo.ArgumentList.Add("-e");
+            startInfo.ArgumentList.Add(script);
+
+            return Process.Start(startInfo);
+        }
+
+        private static string QuoteForShell(string value)
+        {
+            return "'" + value.Replace("'", "'\\''") + "'";
+        }
+
+        private static string QuoteForAppleScript(string value)
+        {
+            return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
+        }
+
         /// <summary>
         /// Try to register current process in a sudo session
         /// </summary>


### PR DESCRIPTION
Replaces the osascript password box (display dialog with hidden answer piped to sudo -S) with the system authorization dialog. The password is now collected by macOS and never enters the fluxzy process.

Streamed launches (raw capture sidecar) go through /usr/bin/security execute-with-privileges, which keeps live stdin/stdout on the returned Process. Since security(1) only relays stdin and inherited stderr, the elevated shell swaps the child's stdout onto stderr and the outer shell swaps it back.

One-shot launches (system keychain cert install) go through osascript do shell script with administrator privileges, which waits for completion and reflects failure in the exit code, with the fluxzy prompt text shown in the dialog.

Callers can substitute the whole macOS flow by assigning ProcessUtils.OsxElevationLauncher (IOsxElevationLauncher); when set it takes precedence over the built-in paths. This is the seam the desktop privileged helper will plug into.

The silent sudo -n path when a sudo ticket is already valid is unchanged, as are Windows and Linux. OsxTryAcquireElevation is kept for now because the desktop repo still references it via InternalsVisibleTo; it can be removed once the desktop side switches.
