### PR TITLE
Fix downstream exchange channel completion

### DIFF
--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -56,11 +56,9 @@ namespace Fluxzy.Core
         private readonly CancellationTokenSource _mainLoopTokenSource;
 
         private int _unNotifiedWindowSize;
-        private bool _readHalted;
         private bool _writeHalted;
         private int _lastStreamId = int.MaxValue;
         private bool _disposed;
-        private bool _goAwayReceived;
         private H2ErrorCode _goAwayErrorCode;
         private int _highestAcceptedStreamId;
         private bool _goAwaySent;
@@ -222,7 +220,6 @@ namespace Fluxzy.Core
 
         private void OnGoAwayReceived(int lastStreamId, H2ErrorCode errorCode)
         {
-            _goAwayReceived = true;
             _goAwayErrorCode = errorCode;
 
             if (errorCode != H2ErrorCode.NoError && DebugContext.EnableDumpStackTraceOn502)
@@ -386,7 +383,7 @@ namespace Fluxzy.Core
                 throw;
             }
             finally  {
-                _readHalted = true;
+                _exchangeChannel.Writer.TryComplete();
             }
         }
 
@@ -601,9 +598,6 @@ namespace Fluxzy.Core
 
         public async ValueTask<Exchange?> ReadNextExchange(RsBuffer buffer, ExchangeScope exchangeScope, CancellationToken token)
         {
-            if (_disposed || _goAwayReceived || _goAwaySent || _readHalted || _writeHalted)
-                return null;
-
             try {
                 if (_exchangeChannel.Reader.TryRead(out var exchange))
                     return exchange;
@@ -612,9 +606,6 @@ namespace Fluxzy.Core
                 return exchange;
             }
             catch (ChannelClosedException) {
-                return null;
-            }
-            catch (OperationCanceledException) when (_mainLoopToken.IsCancellationRequested) {
                 return null;
             }
         }

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
@@ -236,34 +236,112 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
             return pingFrame.OpaqueData;
         }
 
-        /// <summary>
-        /// Send a GOAWAY frame and verify that ReadNextExchange returns null.
-        /// </summary>
         [Fact]
-        public async Task GoAway_ReadNextExchangeReturnsNull()
+        public async Task InputCompletion_WakesPendingReadWithNull()
         {
             await using var ctx = await H2TestContext.Create();
-
-            // Drain initial server SETTINGS
             await ctx.ReadNextFrame(); // SETTINGS
-
-            // Send SETTINGS ACK
             await ctx.SendSettingsAck();
 
-            // Send GOAWAY
-            await ctx.SendGoAway(0, H2ErrorCode.NoError);
-
-            // Give the read loop a moment to process the GOAWAY
-            await Task.Delay(100);
-
-            // ReadNextExchange should return null because GOAWAY was received
             using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
             using var scope = new ExchangeScope();
-            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
 
-            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, timeoutCts.Token);
+            var pendingRead = ctx.DownStreamPipe
+                .ReadNextExchange(buffer, scope, ctx.Token).AsTask();
+            Assert.False(pendingRead.IsCompleted);
+
+            await ctx.CompleteClientInput();
+
+            var exchange = await pendingRead.WaitAsync(TimeSpan.FromSeconds(3));
+            Assert.Null(exchange);
+        }
+
+        [Fact]
+        public async Task InputCompletion_DrainsQueuedExchangesInOrderBeforeNull()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.ReadNextFrame(); // SETTINGS
+            await ctx.SendSettingsAck();
+
+            await ctx.SendHeadersFrame(1,
+                "GET /first HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true, endHeaders: true);
+            await ctx.SendHeadersFrame(3,
+                "GET /second HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true, endHeaders: true);
+            await ctx.CompleteClientInput();
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var firstScope = new ExchangeScope();
+            using var secondScope = new ExchangeScope();
+            using var terminalScope = new ExchangeScope();
+
+            var first = await ctx.DownStreamPipe
+                .ReadNextExchange(buffer, firstScope, ctx.Token).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(3));
+            var second = await ctx.DownStreamPipe
+                .ReadNextExchange(buffer, secondScope, ctx.Token).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(3));
+            var terminal = await ctx.DownStreamPipe
+                .ReadNextExchange(buffer, terminalScope, ctx.Token).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(1, first!.StreamIdentifier);
+            Assert.Equal(3, second!.StreamIdentifier);
+            Assert.Null(terminal);
+        }
+
+        [Fact]
+        public async Task GoAway_WakesPendingReadWithNull()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.ReadNextFrame(); // SETTINGS
+            await ctx.SendSettingsAck();
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+
+            var pendingRead = ctx.DownStreamPipe
+                .ReadNextExchange(buffer, scope, ctx.Token).AsTask();
+            Assert.False(pendingRead.IsCompleted);
+
+            await ctx.SendGoAway(0, H2ErrorCode.NoError);
+
+            var exchange = await pendingRead.WaitAsync(TimeSpan.FromSeconds(3));
 
             Assert.Null(exchange);
+        }
+
+        [Fact]
+        public async Task CallerCancellation_DoesNotCompleteExchangeChannel()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.ReadNextFrame(); // SETTINGS
+            await ctx.SendSettingsAck();
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var canceledScope = new ExchangeScope();
+            using var cancellation = new CancellationTokenSource();
+
+            var canceledRead = ctx.DownStreamPipe
+                .ReadNextExchange(buffer, canceledScope, cancellation.Token).AsTask();
+            Assert.False(canceledRead.IsCompleted);
+
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await canceledRead.WaitAsync(TimeSpan.FromSeconds(3)));
+
+            await ctx.SendHeadersFrame(1,
+                "GET /after-cancellation HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true, endHeaders: true);
+
+            using var nextScope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe
+                .ReadNextExchange(buffer, nextScope, ctx.Token).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(1, exchange!.StreamIdentifier);
         }
 
         /// <summary>

--- a/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
+++ b/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
@@ -43,6 +43,11 @@ namespace Fluxzy.Tests._Fixtures
         public Stream ServerReadStream { get; }
         public Stream ServerWriteStream { get; }
 
+        public ValueTask CompleteClientInput()
+        {
+            return _clientToServer.Writer.CompleteAsync();
+        }
+
         public void Dispose()
         {
             _clientToServer.Writer.Complete();
@@ -280,6 +285,11 @@ namespace Fluxzy.Tests._Fixtures
         {
             await Pipe.ClientWriteStream.WriteAsync(H2Constants.Preface, Token);
             await Pipe.ClientWriteStream.FlushAsync(Token);
+        }
+
+        public ValueTask CompleteClientInput()
+        {
+            return Pipe.CompleteClientInput();
         }
 
         public async Task SendSettingsFrame(params (SettingIdentifier id, int value)[] settings)


### PR DESCRIPTION
## Problem
`H2DownStreamPipe.ReadLoop` produces downstream HTTP/2 exchanges but does not complete `_exchangeChannel` when input processing ends. As a result, a pending `ReadNextExchange` call can remain blocked after clean EOF, GOAWAY, cancellation, or a read-loop fault.
In addition, the terminal-state precheck in `ReadNextExchange` can return `null` before consuming exchanges that were queued before termination.
## Solution
Complete the single-producer exchange channel in `ReadLoop`'s `finally` block so every read-loop exit path signals completion.
Have `ReadNextExchange` consume the channel directly. This ensures:
- Queued exchanges drain in FIFO order.
- Channel completion returns `null`.
- Disposal wakes pending readers through the existing channel-completion mechanism.
- Caller-token cancellation continues to throw `OperationCanceledException`.
Graceful GOAWAY does not complete response-output channels, so response draining behavior remains unchanged.
## Benefits
- Pending exchange reads terminate when downstream HTTP/2 input ends.
- Exchanges decoded before EOF or GOAWAY are not discarded.
- Caller cancellation remains distinguishable from producer completion.
- Response draining, flow control, worker state, upstream clients, performance behavior, and public APIs remain unchanged.
## Changes
- Complete `_exchangeChannel` when `ReadLoop` exits.
- Remove terminal-state short-circuiting and internal cancellation handling from `ReadNextExchange`.
- Add deterministic regression coverage for:
- Pending reads when input completes.
- Pending reads after GOAWAY.
- FIFO draining of queued exchanges before terminal `null`.
- Caller cancellation without channel closure.
- Add an in-memory client-input completion barrier to the HTTP/2 test fixture.
Category	Files	Additions	Removals
Documentation	None	0	0
Configuration	None	0	0
Runtime	`src/Fluxzy.Core/Core/H2DownStreamPipe.cs`	1	10
Tests	`test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs`<br>`test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs`	102	14
## Verification
Built the test project in Release mode for .NET 10:
dotnet build test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  -p:TargetFrameworks=net10.0
Result: succeeded with 60 existing warnings and no errors.
Ran the focused downstream-pipe tests:
dotnet test test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  --no-build \
  --no-restore \
  -p:TargetFrameworks=net10.0 \
  --filter "FullyQualifiedName~Fluxzy.Tests.UnitTests.H2Serve.H2DownStreamPipeTests"
Result: 20 passed, 0 failed.
Ran the existing deterministic HTTP/2 tests, excluding the environment-dependent certificate case:
dotnet test test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  --no-build \
  --no-restore \
  -p:TargetFrameworks=net10.0 \
  --filter "FullyQualifiedName~Fluxzy.Tests.UnitTests.H2&FullyQualifiedName!~Fluxzy.Tests.UnitTests.H2Serve.H2ServeTests.SimpleH2Request"
Result: 61 passed, 0 failed.
The excluded certificate test was run separately and reproduced its baseline failure because the non-root environment could not install the test certificate. No assertion was weakened and no test was globally skipped.
The full solution build was not used as a gate because of an existing, unrelated target-framework mismatch between a `net8.0` project and a project reference that supports only `net10.0`. The affected test project was therefore built and tested explicitly for `net10.0`. This change does not modify that mismatch.