### PR TITLE
Fix/track downstream http stream halves

### DIFF
--- a/src/Fluxzy.Core/Core/DataFrameEntry.cs
+++ b/src/Fluxzy.Core/Core/DataFrameEntry.cs
@@ -11,15 +11,19 @@ namespace Fluxzy.Core
         public readonly int Length;
         public readonly int FlowControlledBytes;
         public readonly IList<HeaderField>? TrailerHeaders;
-        public readonly int TrailerStreamIdentifier;
+        public readonly int StreamIdentifier;
+        public readonly bool CompletesResponse;
 
-        public DataFrameEntry(byte[] rentedBuffer, int length, int flowControlledBytes)
+        public DataFrameEntry(
+            byte[] rentedBuffer, int length, int flowControlledBytes,
+            int streamIdentifier, bool completesResponse = false)
         {
             RentedBuffer = rentedBuffer;
             Length = length;
             FlowControlledBytes = flowControlledBytes;
             TrailerHeaders = null;
-            TrailerStreamIdentifier = 0;
+            StreamIdentifier = streamIdentifier;
+            CompletesResponse = completesResponse;
         }
 
         public DataFrameEntry(IList<HeaderField> trailerHeaders, int trailerStreamIdentifier)
@@ -28,7 +32,8 @@ namespace Fluxzy.Core
             Length = 0;
             FlowControlledBytes = 0;
             TrailerHeaders = trailerHeaders;
-            TrailerStreamIdentifier = trailerStreamIdentifier;
+            StreamIdentifier = trailerStreamIdentifier;
+            CompletesResponse = true;
         }
     }
 }

--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Channels;
@@ -51,6 +52,15 @@ namespace Fluxzy.Core
         private readonly SemaphoreSlim _writeSignal = new(0);
         private int _writeSignalState;
         private int _writeLoopIterations;
+        private int _closedStreamCount;
+        private int _droppedResponseBufferCount;
+        private int _responseDataEnqueuedCount;
+        private int _responseDataEnqueuedWaitTarget;
+        private TaskCompletionSource<object?>? _responseDataEnqueuedWaiter;
+        private int _activeStreamWaitIdentifier;
+        private TaskCompletionSource<object?>? _activeStreamWaiter;
+        private TaskCompletionSource<object?>? _writeLoopGateForTests;
+        private TaskCompletionSource<object?>? _writeLoopIdleForTests;
 
         private readonly CancellationToken _mainLoopToken;
         private readonly CancellationTokenSource _mainLoopTokenSource;
@@ -64,6 +74,7 @@ namespace Fluxzy.Core
         private H2ErrorCode _goAwayErrorCode;
         private int _highestAcceptedStreamId;
         private bool _goAwaySent;
+        private int _expectedContinuationStreamId;
 
         public H2DownStreamPipe(
             IIdProvider idProvider,
@@ -230,16 +241,24 @@ namespace Fluxzy.Core
 
             foreach (var (streamId, worker) in _currentStreams) {
                 if (streamId > lastStreamId) {
-                    if (_currentStreams.TryRemove(streamId, out _))
-                        worker.Dispose();
+                    worker.Abort(errorCode);
+                    CheckoutServerStreamWorker(worker);
                 }
             }
         }
 
         private void CheckoutServerStreamWorker(ServerStreamWorker streamWorker)
         {
-            _currentStreams.TryRemove(streamWorker.StreamIdentifier, out _);
-            streamWorker.Dispose();
+            if (_currentStreams.TryRemove(streamWorker.StreamIdentifier, out var removedWorker)) {
+                removedWorker.Dispose();
+                Interlocked.Increment(ref _closedStreamCount);
+            }
+        }
+
+        private void AbortServerStreamWorker(ServerStreamWorker streamWorker, H2ErrorCode errorCode)
+        {
+            streamWorker.Abort(errorCode);
+            CheckoutServerStreamWorker(streamWorker);
         }
 
         private async Task ReadLoop(CancellationToken token)
@@ -261,6 +280,23 @@ namespace Fluxzy.Core
 
                     if (frame.IsEmpty) {
                         // EOF — peer closed the connection
+                        break;
+                    }
+
+                    if (_expectedContinuationStreamId != 0 &&
+                        (frame.BodyType != H2FrameType.Continuation ||
+                         frame.StreamIdentifier != _expectedContinuationStreamId)) {
+                        if (_currentStreams.TryGetValue(
+                                _expectedContinuationStreamId, out var fragmentedWorker))
+                            AbortServerStreamWorker(fragmentedWorker, H2ErrorCode.ProtocolError);
+
+                        WriteGoAway(H2ErrorCode.ProtocolError);
+                        break;
+                    }
+
+                    if (_expectedContinuationStreamId == 0 &&
+                        frame.BodyType == H2FrameType.Continuation) {
+                        WriteGoAway(H2ErrorCode.ProtocolError);
                         break;
                     }
 
@@ -298,7 +334,8 @@ namespace Fluxzy.Core
 
                     if (frame.BodyType == H2FrameType.RstStream) {
                         if (_currentStreams.TryGetValue(frame.StreamIdentifier, out var rstWorker)) {
-                            CheckoutServerStreamWorker(rstWorker);
+                            AbortServerStreamWorker(
+                                rstWorker, frame.GetRstStreamFrame().ErrorCode);
                         }
                         continue;
                     }
@@ -308,22 +345,36 @@ namespace Fluxzy.Core
                         continue;
                     }
 
-                    //
-
                     if (!_currentStreams.TryGetValue(frame.StreamIdentifier, out var worker)) {
+                        if (frame.BodyType != H2FrameType.Headers) {
+                            if (frame.StreamIdentifier <= _highestAcceptedStreamId)
+                                continue;
+
+                            WriteGoAway(H2ErrorCode.ProtocolError);
+                            break;
+                        }
+
+                        if (frame.StreamIdentifier <= 0 || (frame.StreamIdentifier & 1) == 0 ||
+                            frame.StreamIdentifier <= _highestAcceptedStreamId) {
+                            WriteGoAway(H2ErrorCode.ProtocolError);
+                            break;
+                        }
+
                         worker = new ServerStreamWorker(frame.StreamIdentifier, _headerEncoder,
                             _h2StreamSetting);
 
                         _currentStreams.TryAdd(frame.StreamIdentifier, worker);
+                        _highestAcceptedStreamId = frame.StreamIdentifier;
 
-                        if (frame.StreamIdentifier > _highestAcceptedStreamId)
-                            _highestAcceptedStreamId = frame.StreamIdentifier;
+                        if (frame.StreamIdentifier == Volatile.Read(ref _activeStreamWaitIdentifier))
+                            Interlocked.Exchange(ref _activeStreamWaiter, null)?.TrySetResult(null);
                     }
 
                     if (frame.BodyType == H2FrameType.PushPromise) {
                         var pushErrorCode = H2ErrorCode.ProtocolError;
                         WriteRstStream(frame.StreamIdentifier, pushErrorCode);
-                        CheckoutServerStreamWorker(worker);
+                        AbortServerStreamWorker(worker, pushErrorCode);
+                        continue;
                     }
 
                     if (frame.BodyType == H2FrameType.Headers) {
@@ -332,8 +383,12 @@ namespace Fluxzy.Core
                         if (headerErrorCode != H2ErrorCode.NoError)
                         {
                             WriteRstStream(frame.StreamIdentifier, headerErrorCode);
-                            CheckoutServerStreamWorker(worker);
+                            AbortServerStreamWorker(worker, headerErrorCode);
+                            continue;
                         }
+
+                        if (!frame.GetHeadersFrame().EndHeaders)
+                            _expectedContinuationStreamId = frame.StreamIdentifier;
                     }
 
                     if (frame.BodyType == H2FrameType.Continuation) {
@@ -341,9 +396,16 @@ namespace Fluxzy.Core
 
                         if (contErrorCode != H2ErrorCode.NoError)
                         {
+                            if (frame.GetContinuationFrame().EndHeaders)
+                                _expectedContinuationStreamId = 0;
+
                             WriteRstStream(frame.StreamIdentifier, contErrorCode);
-                            CheckoutServerStreamWorker(worker);
+                            AbortServerStreamWorker(worker, contErrorCode);
+                            continue;
                         }
+
+                        if (frame.GetContinuationFrame().EndHeaders)
+                            _expectedContinuationStreamId = 0;
                     }
 
                     if (frame.BodyType == H2FrameType.Data) {
@@ -353,7 +415,8 @@ namespace Fluxzy.Core
                         if (dataErrorCode != H2ErrorCode.NoError)
                         {
                             WriteRstStream(frame.StreamIdentifier, dataErrorCode);
-                            CheckoutServerStreamWorker(worker);
+                            AbortServerStreamWorker(worker, dataErrorCode);
+                            continue;
                         }
                         else {
                             // send window size increment stream level
@@ -366,6 +429,11 @@ namespace Fluxzy.Core
                                 NotifyConnectionWindowSizeDecrement(bodyLength, token);
                             }
                         }
+                    }
+
+                    if (worker.IsClosed) {
+                        CheckoutServerStreamWorker(worker);
+                        continue;
                     }
 
                     if (worker.ReadyToCreateExchange) {
@@ -411,6 +479,81 @@ namespace Fluxzy.Core
         ///     than WINDOW_UPDATEs can arrive (see WriteLoop_DoesNotSpinWhenConnectionWindowExhausted).
         /// </summary>
         internal int WriteLoopIterationsForTests => Volatile.Read(ref _writeLoopIterations);
+        internal int ActiveStreamCountForTests => _currentStreams.Count;
+        internal int ClosedStreamCountForTests => Volatile.Read(ref _closedStreamCount);
+        internal int DroppedResponseBufferCountForTests
+            => Volatile.Read(ref _droppedResponseBufferCount);
+
+        internal void PauseWriteLoopForTests()
+        {
+            var gate = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (Interlocked.CompareExchange(ref _writeLoopGateForTests, gate, null) != null)
+                throw new InvalidOperationException("The HTTP/2 write loop is already paused");
+
+            SignalWriteLoop();
+        }
+
+        internal void ResumeWriteLoopForTests()
+            => Interlocked.Exchange(ref _writeLoopGateForTests, null)?.TrySetResult(null);
+
+        internal Task WaitForWriteLoopIdleForTests()
+        {
+            var waiter = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            if (Interlocked.CompareExchange(ref _writeLoopIdleForTests, waiter, null) != null)
+                throw new InvalidOperationException("A write-loop idle waiter is already registered");
+
+            SignalWriteLoop();
+            return waiter.Task;
+        }
+
+        internal Task WaitForResponseDataEntriesForTests(int count)
+        {
+            if (Volatile.Read(ref _responseDataEnqueuedCount) >= count)
+                return Task.CompletedTask;
+
+            var waiter = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Volatile.Write(ref _responseDataEnqueuedWaitTarget, count);
+
+            if (Interlocked.CompareExchange(
+                    ref _responseDataEnqueuedWaiter, waiter, null) != null)
+                throw new InvalidOperationException("A response-data waiter is already registered");
+
+            if (Volatile.Read(ref _responseDataEnqueuedCount) >= count)
+                Interlocked.Exchange(ref _responseDataEnqueuedWaiter, null)?.TrySetResult(null);
+
+            return waiter.Task;
+        }
+
+        internal Task WaitForStreamActiveForTests(int streamIdentifier)
+        {
+            if (_currentStreams.ContainsKey(streamIdentifier))
+                return Task.CompletedTask;
+
+            var waiter = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Volatile.Write(ref _activeStreamWaitIdentifier, streamIdentifier);
+
+            if (Interlocked.CompareExchange(ref _activeStreamWaiter, waiter, null) != null)
+                throw new InvalidOperationException("An active-stream waiter is already registered");
+
+            if (_currentStreams.ContainsKey(streamIdentifier))
+                Interlocked.Exchange(ref _activeStreamWaiter, null)?.TrySetResult(null);
+
+            return waiter.Task;
+        }
+
+        private void NotifyResponseDataEnqueuedForTests()
+        {
+            var count = Interlocked.Increment(ref _responseDataEnqueuedCount);
+
+            if (count >= Volatile.Read(ref _responseDataEnqueuedWaitTarget))
+                Interlocked.Exchange(ref _responseDataEnqueuedWaiter, null)?.TrySetResult(null);
+        }
 
         /// <summary>
         ///     Test seam: injects a synthetic <see cref="DataFrameEntry"/> with the given
@@ -421,25 +564,33 @@ namespace Fluxzy.Core
         internal void EnqueueFlowControlledDataForTest(int flowControlledBytes)
         {
             var buffer = ArrayPool<byte>.Shared.Rent(9);
-            _dataChannel.Writer.TryWrite(new DataFrameEntry(buffer, 9, flowControlledBytes));
+            _dataChannel.Writer.TryWrite(new DataFrameEntry(buffer, 9, flowControlledBytes, 0));
             SignalWriteLoop();
         }
 
         private async Task WriteLoop(CancellationToken token)
         {
             var gatherBuffer = ArrayPool<byte>.Shared.Rent(GatherBufferSize);
+            var completedResponses = new List<int>();
 
             try {
                 while (!token.IsCancellationRequested) {
                     Interlocked.Increment(ref _writeLoopIterations);
                     var didWork = false;
 
+                    if (Volatile.Read(ref _writeLoopGateForTests) is { } writeLoopGate)
+                        await writeLoopGate.Task.WaitAsync(token).ConfigureAwait(false);
+
                     // Phase 1: Drain pending header encodes into the ring buffer, then drain
                     //          the ring buffer (control frames + HEADERS — priority, no flow control).
                     //          Encoding runs only here, so the shared HPACK dynamic table needs
                     //          no synchronization.
                     while (_pendingHeaders.Reader.TryRead(out var pending)) {
-                        EncodePendingHeader(pending);
+                        var bodylessWorker = EncodePendingHeader(pending);
+
+                        if (bodylessWorker != null)
+                            await CompleteBodylessHeaderAsync(bodylessWorker, token).ConfigureAwait(false);
+
                         didWork = true;
                     }
 
@@ -457,14 +608,27 @@ namespace Fluxzy.Core
                         // HEADERS frame for stream X always precedes its DATA on the wire.
                         // Headers go into the ring buffer, which the interleave block below flushes.
                         while (_pendingHeaders.Reader.TryRead(out var pending)) {
-                            EncodePendingHeader(pending);
+                            if (gatherOffset > 0) {
+                                await FlushGatheredDataAsync(
+                                    gatherBuffer, gatherOffset, completedResponses, token)
+                                    .ConfigureAwait(false);
+                                gatherOffset = 0;
+                            }
+
+                            var bodylessWorker = EncodePendingHeader(pending);
+
+                            if (bodylessWorker != null)
+                                await CompleteBodylessHeaderAsync(bodylessWorker, token).ConfigureAwait(false);
+
                             didWork = true;
                         }
 
                         // Interleave: flush gathered data and drain ring buffer if priority data exists
                         if (_ringBuffer.ReadableCount > 0) {
                             if (gatherOffset > 0) {
-                                await _writeStream.WriteAsync(gatherBuffer.AsMemory(0, gatherOffset), token).ConfigureAwait(false);
+                                await FlushGatheredDataAsync(
+                                    gatherBuffer, gatherOffset, completedResponses, token)
+                                    .ConfigureAwait(false);
                                 gatherOffset = 0;
                                 didWork = true;
                             }
@@ -477,16 +641,33 @@ namespace Fluxzy.Core
                         // per-stream ordering relative to the DATA frames queued ahead of it).
                         if (entry.TrailerHeaders != null) {
                             if (gatherOffset > 0) {
-                                await _writeStream.WriteAsync(gatherBuffer.AsMemory(0, gatherOffset), token).ConfigureAwait(false);
+                                await FlushGatheredDataAsync(
+                                    gatherBuffer, gatherOffset, completedResponses, token)
+                                    .ConfigureAwait(false);
                                 gatherOffset = 0;
                             }
 
+                            if (!_currentStreams.TryGetValue(entry.StreamIdentifier, out var trailerWorker) ||
+                                trailerWorker.IsAborted) {
+                                _dataChannel.Reader.TryRead(out _);
+                                continue;
+                            }
+
                             var trailerBytes = _headerEncoder.EncodeTrailers(
-                                entry.TrailerHeaders, _headerEncodeBuffer, entry.TrailerStreamIdentifier);
+                                entry.TrailerHeaders, _headerEncodeBuffer, entry.StreamIdentifier);
 
                             await _writeStream.WriteAsync(trailerBytes, token).ConfigureAwait(false);
                             _dataChannel.Reader.TryRead(out _); // consume the peeked entry
+                            CompleteWrittenResponse(entry.StreamIdentifier);
                             didWork = true;
+                            continue;
+                        }
+
+                        if (entry.StreamIdentifier != 0 &&
+                            (!_currentStreams.TryGetValue(entry.StreamIdentifier, out var entryWorker) ||
+                             entryWorker.IsAborted)) {
+                            _dataChannel.Reader.TryRead(out _);
+                            DropDataEntry(entry);
                             continue;
                         }
 
@@ -503,9 +684,18 @@ namespace Fluxzy.Core
 
                         // Single frame with nothing else queued — write directly, skip gather
                         if (gatherOffset == 0 && !_dataChannel.Reader.TryPeek(out _)) {
-                            await _writeStream.WriteAsync(
-                                entry.RentedBuffer!.AsMemory(0, entry.Length), token).ConfigureAwait(false);
-                            ArrayPool<byte>.Shared.Return(entry.RentedBuffer!);
+                            try {
+                                await _writeStream.WriteAsync(
+                                    entry.RentedBuffer!.AsMemory(0, entry.Length), token)
+                                    .ConfigureAwait(false);
+                            }
+                            finally {
+                                ArrayPool<byte>.Shared.Return(entry.RentedBuffer!);
+                            }
+
+                            if (entry.CompletesResponse)
+                                CompleteWrittenResponse(entry.StreamIdentifier);
+
                             didWork = true;
                             break;
                         }
@@ -514,7 +704,9 @@ namespace Fluxzy.Core
                         if (gatherOffset + entry.Length > gatherBuffer.Length) {
                             // Flush current batch before it overflows
                             if (gatherOffset > 0) {
-                                await _writeStream.WriteAsync(gatherBuffer.AsMemory(0, gatherOffset), token).ConfigureAwait(false);
+                                await FlushGatheredDataAsync(
+                                    gatherBuffer, gatherOffset, completedResponses, token)
+                                    .ConfigureAwait(false);
                                 gatherOffset = 0;
                                 didWork = true;
                             }
@@ -523,12 +715,18 @@ namespace Fluxzy.Core
                         entry.RentedBuffer!.AsSpan(0, entry.Length).CopyTo(gatherBuffer.AsSpan(gatherOffset));
                         gatherOffset += entry.Length;
                         ArrayPool<byte>.Shared.Return(entry.RentedBuffer!);
+
+                        if (entry.CompletesResponse)
+                            completedResponses.Add(entry.StreamIdentifier);
+
                         didWork = true;
                     }
 
                     // Flush remaining gathered data
                     if (gatherOffset > 0) {
-                        await _writeStream.WriteAsync(gatherBuffer.AsMemory(0, gatherOffset), token).ConfigureAwait(false);
+                        await FlushGatheredDataAsync(
+                            gatherBuffer, gatherOffset, completedResponses, token)
+                            .ConfigureAwait(false);
                         didWork = true;
                     }
 
@@ -572,7 +770,8 @@ namespace Fluxzy.Core
 
                     if (didWork)
                         await _writeStream.FlushAsync(token).ConfigureAwait(false);
-                    
+
+                    Interlocked.Exchange(ref _writeLoopIdleForTests, null)?.TrySetResult(null);
                     await _writeSignal.WaitAsync(token).ConfigureAwait(false);
                 }
             }
@@ -595,6 +794,7 @@ namespace Fluxzy.Core
                 while (_pendingHeaders.Reader.TryRead(out _)) { }
 
                 _writeHalted = true;
+                Interlocked.Exchange(ref _writeLoopIdleForTests, null)?.TrySetCanceled(token);
             }
         }
 
@@ -624,20 +824,57 @@ namespace Fluxzy.Core
         ///     Called only from the single-threaded WriteLoop, so no synchronization around the
         ///     shared HPACK dynamic table is required.
         /// </summary>
-        private void EncodePendingHeader(in PendingHeaderWrite pending)
+        private ServerStreamWorker? EncodePendingHeader(in PendingHeaderWrite pending)
         {
+            if (!_currentStreams.TryGetValue(pending.StreamIdentifier, out var worker) ||
+                worker.IsAborted)
+                return null;
+
             var encoded = _headerEncoder.Encode(
                 new HeaderEncodingJob(pending.Http11Header, pending.StreamIdentifier, 0),
                 _headerEncodeBuffer, !pending.HasBody);
 
             _ringBuffer.Write(encoded.Span);
 
-            if (!pending.HasBody) {
-                // No body will follow — clean up the stream worker now.
-                if (_currentStreams.TryRemove(pending.StreamIdentifier, out var worker)) {
-                    worker.Dispose();
-                }
-            }
+            return pending.HasBody ? null : worker;
+        }
+
+        private async ValueTask CompleteBodylessHeaderAsync(
+            ServerStreamWorker worker, CancellationToken token)
+        {
+            await FlushRingBufferAsync(token).ConfigureAwait(false);
+
+            if (worker.CompleteResponse())
+                CheckoutServerStreamWorker(worker);
+        }
+
+        private void CompleteWrittenResponse(int streamIdentifier)
+        {
+            if (_currentStreams.TryGetValue(streamIdentifier, out var worker) &&
+                worker.CompleteResponse())
+                CheckoutServerStreamWorker(worker);
+        }
+
+        private async ValueTask FlushGatheredDataAsync(
+            byte[] gatherBuffer, int length, List<int> completedResponses,
+            CancellationToken token)
+        {
+            await _writeStream.WriteAsync(
+                gatherBuffer.AsMemory(0, length), token).ConfigureAwait(false);
+
+            foreach (var streamIdentifier in completedResponses)
+                CompleteWrittenResponse(streamIdentifier);
+
+            completedResponses.Clear();
+        }
+
+        private void DropDataEntry(in DataFrameEntry entry)
+        {
+            if (entry.RentedBuffer == null)
+                return;
+
+            ArrayPool<byte>.Shared.Return(entry.RentedBuffer);
+            Interlocked.Increment(ref _droppedResponseBufferCount);
         }
 
         public ValueTask WriteInterimResponse(int statusCode, ReadOnlyMemory<char> reasonPhrase, int streamIdentifier, CancellationToken token)
@@ -653,14 +890,18 @@ namespace Fluxzy.Core
         public ValueTask WriteResponseHeader(
             ResponseHeader responseHeader, RsBuffer buffer, bool shouldClose, int streamIdentifier, ReadOnlyMemory<char> requestMethod, CancellationToken token)
         {
+            if (!_currentStreams.TryGetValue(streamIdentifier, out var worker) || worker.IsAborted)
+                throw new FluxzyException($"Invalid Local H2 stream : identifier {streamIdentifier}");
+
             // Compute hasBody on the caller thread (needs requestMethod.Span) and materialize the
             // HTTP/1.1 header representation here — GetHttp11Header() is a pure, fresh allocation
             // so it's safe to hand off. Actual HPACK encoding happens on the WriteLoop, which is
             // the sole owner of the shared HPACK dynamic table: no lock required on the hot path.
             var hasBody = responseHeader.HasResponseBody(requestMethod.Span, out _);
 
-            _pendingHeaders.Writer.TryWrite(new PendingHeaderWrite(
-                responseHeader.GetHttp11Header(), streamIdentifier, hasBody));
+            if (!_pendingHeaders.Writer.TryWrite(new PendingHeaderWrite(
+                    responseHeader.GetHttp11Header(), streamIdentifier, hasBody)))
+                throw new IOException("HTTP/2 downstream writer is closed");
 
             SignalWriteLoop();
 
@@ -670,58 +911,82 @@ namespace Fluxzy.Core
         public async ValueTask WriteResponseBody(Stream responseBodyStream,
             RsBuffer rsBuffer, bool chunked, int streamIdentifier, Response? responseForTrailers, CancellationToken token)
         {
-            // take care of window size
             if (!_currentStreams.TryGetValue(streamIdentifier, out var worker)) {
-
-                // stream already closed
                 throw new FluxzyException($"Invalid Local H2 stream : identifier {streamIdentifier}");
             }
 
             var remoteMaxFrameSize = _h2StreamSetting.Remote.MaxFrameSize;
+            using var responseTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                token, worker.ResponseAbortToken);
+            var responseToken = responseTokenSource.Token;
 
-            while (true)
-            {
-                var booked = await worker.BookWindowSize(remoteMaxFrameSize, token).ConfigureAwait(false);
-
-                if (booked == 0)
+            try {
+                while (true)
                 {
-                    // stream closed
-                    return;
+                    var booked = await worker.BookWindowSize(remoteMaxFrameSize, responseToken)
+                        .ConfigureAwait(false);
+
+                    if (booked == 0 || worker.IsAborted)
+                        return;
+
+                    var bodySize = Math.Min(booked, remoteMaxFrameSize);
+                    var ownedWindow = booked;
+                    byte[]? rentedBuffer = ArrayPool<byte>.Shared.Rent(bodySize + 9);
+
+                    try {
+                        var read = await responseBodyStream
+                            .ReadAsync(rentedBuffer.AsMemory(9, bodySize), responseToken)
+                            .ConfigureAwait(false);
+
+                        if (read == 0)
+                        {
+                            worker.RefundWindowSize(ownedWindow);
+                            ownedWindow = 0;
+                            break;
+                        }
+
+                        var refund = booked - read;
+
+                        if (refund > 0) {
+                            worker.RefundWindowSize(refund);
+                            ownedWindow -= refund;
+                        }
+
+                        if (worker.IsAborted)
+                            return;
+
+                        new DataFrame(HeaderFlags.None, read, streamIdentifier)
+                            .WriteHeaderOnly(rentedBuffer, read);
+
+                        var frameLength = read + 9;
+
+                        if (!_dataChannel.Writer.TryWrite(new DataFrameEntry(
+                                rentedBuffer, frameLength, read, streamIdentifier)))
+                            throw new IOException("HTTP/2 downstream writer is closed");
+
+                        rentedBuffer = null;
+                        ownedWindow = 0;
+                        NotifyResponseDataEnqueuedForTests();
+                        SignalWriteLoop();
+                    }
+                    finally {
+                        if (rentedBuffer != null)
+                            ArrayPool<byte>.Shared.Return(rentedBuffer);
+
+                        if (ownedWindow > 0)
+                            worker.RefundWindowSize(ownedWindow);
+                    }
                 }
-
-                var bodySize = Math.Min(booked, remoteMaxFrameSize);
-
-                // Rent buffer upfront; read body directly at offset 9 (after frame header)
-                var rentedBuffer = ArrayPool<byte>.Shared.Rent(bodySize + 9);
-
-                var read = await responseBodyStream
-                    .ReadAsync(rentedBuffer.AsMemory(9, bodySize), token).ConfigureAwait(false);
-
-                if (read == 0)
-                {
-                    // EOF — return buffer, refund booked window, break to send end-stream
-                    ArrayPool<byte>.Shared.Return(rentedBuffer);
-                    worker.RefundWindowSize(booked);
-                    break;
-                }
-
-                // Refund unused window if we read less than booked
-                var refund = booked - read;
-
-                if (refund > 0) {
-                    worker.RefundWindowSize(refund);
-                }
-
-                // Build DATA frame header directly in rented buffer
-                new DataFrame(HeaderFlags.None, read, streamIdentifier)
-                    .WriteHeaderOnly(rentedBuffer, read);
-
-                var frameLength = read + 9;
-
-                 _dataChannel.Writer.TryWrite(new DataFrameEntry(rentedBuffer, frameLength, read));
-
-                SignalWriteLoop();
             }
+            catch (OperationCanceledException) when (worker.IsAborted) {
+                return;
+            }
+            catch (ObjectDisposedException) when (worker.IsAborted) {
+                return;
+            }
+
+            if (worker.IsAborted)
+                return;
 
             // Read trailers lazily — they are set by StreamWorker after the body pipe completes
             var trailers = responseForTrailers?.Trailers;
@@ -730,7 +995,8 @@ namespace Fluxzy.Core
                 // Enqueue a trailer-encoding job; WriteLoop encodes it on its own thread (no lock).
                 // Wire ordering is preserved because all DATA frames for this stream are already
                 // queued ahead of this entry in the same FIFO channel.
-                _dataChannel.Writer.TryWrite(new DataFrameEntry(trailers, streamIdentifier));
+                if (!_dataChannel.Writer.TryWrite(new DataFrameEntry(trailers, streamIdentifier)))
+                    throw new IOException("HTTP/2 downstream writer is closed");
 
                 SignalWriteLoop();
             }
@@ -741,14 +1007,13 @@ namespace Fluxzy.Core
                 new DataFrame(HeaderFlags.EndStream, 0, streamIdentifier)
                     .WriteHeaderOnly(endFrameBuffer, 0);
 
-                _dataChannel.Writer.TryWrite(new DataFrameEntry(endFrameBuffer, 9, 0));
+                if (!_dataChannel.Writer.TryWrite(new DataFrameEntry(
+                        endFrameBuffer, 9, 0, streamIdentifier, completesResponse: true))) {
+                    ArrayPool<byte>.Shared.Return(endFrameBuffer);
+                    throw new IOException("HTTP/2 downstream writer is closed");
+                }
 
                 SignalWriteLoop();
-            }
-
-            // Stream is fully complete — clean up the worker.
-            if (_currentStreams.TryRemove(streamIdentifier, out var completedWorker)) {
-                completedWorker.Dispose();
             }
         }
 

--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -564,7 +564,12 @@ namespace Fluxzy.Core
         internal void EnqueueFlowControlledDataForTest(int flowControlledBytes)
         {
             var buffer = ArrayPool<byte>.Shared.Rent(9);
-            _dataChannel.Writer.TryWrite(new DataFrameEntry(buffer, 9, flowControlledBytes, 0));
+            if (!_dataChannel.Writer.TryWrite(
+                    new DataFrameEntry(buffer, 9, flowControlledBytes, 0))) {
+                ArrayPool<byte>.Shared.Return(buffer);
+                return;
+            }
+
             SignalWriteLoop();
         }
 

--- a/src/Fluxzy.Core/Core/ServerStreamWorker.cs
+++ b/src/Fluxzy.Core/Core/ServerStreamWorker.cs
@@ -229,7 +229,7 @@ namespace Fluxzy.Core
             Stream bodyStream;
 
             if (IsRequestComplete) {
-                bodyStream = Stream.Null; // no response body
+                bodyStream = Stream.Null; // no request body
             }
             else {
                 _requestBodyPipe = new Pipe(new PipeOptions(

--- a/src/Fluxzy.Core/Core/ServerStreamWorker.cs
+++ b/src/Fluxzy.Core/Core/ServerStreamWorker.cs
@@ -23,10 +23,11 @@ namespace Fluxzy.Core
         private readonly byte[] _headerBuffer;
         private int _receivedHeaderLength;
         private bool _endHeader;
-        private bool _endStream;
         private bool _exchangeCreated;
         private bool _initialHeadersComplete;
         private int _receivedTrailerLength;
+        private bool _trailersComplete;
+        private bool _pendingHeaderEndStream;
         private Exchange? _createdExchange;
 
         private Pipe? _requestBodyPipe;
@@ -34,7 +35,10 @@ namespace Fluxzy.Core
         private readonly WindowSizeHolder _streamWindowSizeHolder;
         private readonly H2StreamSetting _h2StreamSetting;
 
-        private bool _disposed;
+        private readonly CancellationTokenSource _responseAbortTokenSource = new();
+        private readonly CancellationToken _responseAbortToken;
+        private int _disposed;
+        private int _lifecycleState;
         private int _unNotifiedWindowSize;
 
         /// <summary>
@@ -48,6 +52,9 @@ namespace Fluxzy.Core
         ///     Reduces async calls when the stream window is large.
         /// </summary>
         private const int BatchFrames = 4;
+        private const int RequestCompleteState = 1;
+        private const int ResponseCompleteState = 2;
+        private const int AbortedState = 4;
 
         public ServerStreamWorker(
             int streamIdentifier,
@@ -59,6 +66,7 @@ namespace Fluxzy.Core
             _h2StreamSetting = h2StreamSetting;
             _headerBuffer = ArrayPool<byte>.Shared.Rent(h2StreamSetting.MaxHeaderSize);
             _streamWindowSizeHolder = new WindowSizeHolder(h2StreamSetting.Remote.WindowSize, streamIdentifier);
+            _responseAbortToken = _responseAbortTokenSource.Token;
         }
 
         private H2ErrorCode ReceiveHeaderFragment(ReadOnlySpan<byte> data, bool endHeaders)
@@ -111,22 +119,26 @@ namespace Fluxzy.Core
         {
             var headerFrame = frame.GetHeadersFrame();
 
-            if (headerFrame.EndStream) {
-                _endStream = true;
-            }
+            _pendingHeaderEndStream = headerFrame.EndStream;
 
             if (_initialHeadersComplete) {
+                if (_trailersComplete || IsRequestComplete || !headerFrame.EndStream)
+                    return H2ErrorCode.ProtocolError;
+
                 // This is a trailing HEADERS frame (after body)
                 var result = ReceiveTrailerFragment(headerFrame.Data.Span, headerFrame.EndHeaders);
 
-                if (_endStream && _requestBodyPipe != null) {
-                    _requestBodyPipe.Writer.Complete();
+                if (result == H2ErrorCode.NoError && headerFrame.EndHeaders) {
+                    _trailersComplete = true;
+                    _requestBodyPipe?.Writer.Complete();
+                    CompleteRequest();
                 }
 
                 return result;
             }
 
-            return ReceiveHeaderFragment(headerFrame.Data.Span, headerFrame.EndHeaders);
+            var initialResult = ReceiveHeaderFragment(headerFrame.Data.Span, headerFrame.EndHeaders);
+            return initialResult;
         }
 
         public H2ErrorCode ProcessContinuation(ref H2FrameReadResult frame)
@@ -134,10 +146,24 @@ namespace Fluxzy.Core
             var continuationFrame = frame.GetContinuationFrame();
 
             if (_initialHeadersComplete) {
-                return ReceiveTrailerFragment(continuationFrame.Data.Span, continuationFrame.EndHeaders);
+                if (_trailersComplete || IsRequestComplete || !_pendingHeaderEndStream)
+                    return H2ErrorCode.ProtocolError;
+
+                var trailerResult = ReceiveTrailerFragment(
+                    continuationFrame.Data.Span, continuationFrame.EndHeaders);
+
+                if (trailerResult == H2ErrorCode.NoError && continuationFrame.EndHeaders) {
+                    _trailersComplete = true;
+                    _requestBodyPipe?.Writer.Complete();
+                    CompleteRequest();
+                }
+
+                return trailerResult;
             }
 
-            return ReceiveHeaderFragment(continuationFrame.Data.Span, continuationFrame.EndHeaders);
+            var initialResult = ReceiveHeaderFragment(
+                continuationFrame.Data.Span, continuationFrame.EndHeaders);
+            return initialResult;
         }
 
         public async Task<ReceiveBodyResult> ReceiveBodyFragment(H2FrameReadResult frame, RsBuffer buffer, CancellationToken token)
@@ -146,6 +172,9 @@ namespace Fluxzy.Core
             buffer.Ensure(length);
             frame.GetDataFrame().Buffer.CopyTo(buffer.Memory);
             var endStream = frame.GetDataFrame().EndStream;
+
+            if (IsRequestComplete)
+                return new (H2ErrorCode.StreamClosed, 0, null);
 
             if (_requestBodyPipe == null)
             {
@@ -158,8 +187,8 @@ namespace Fluxzy.Core
 
             if (endStream)
             {
-                _endStream = true;
                 await _requestBodyPipe.Writer.CompleteAsync().ConfigureAwait(false);
+                CompleteRequest();
             }
 
             _unNotifiedWindowSize += length;
@@ -190,13 +219,16 @@ namespace Fluxzy.Core
 
             _receivedHeaderLength = 0; // Reset for possible trailer accumulation
 
+            if (_pendingHeaderEndStream)
+                CompleteRequest();
+
             var receivedFromProxy = ITimingProvider.Default.Instant();
 
             var requestHeader = new RequestHeader(plainRequest, true);
 
             Stream bodyStream;
 
-            if (_endStream) {
+            if (IsRequestComplete) {
                 bodyStream = Stream.Null; // no response body
             }
             else {
@@ -226,9 +258,51 @@ namespace Fluxzy.Core
             _streamWindowSizeHolder.UpdateWindowSize(windowSizeIncrement);
         }
 
+        public bool CompleteRequest()
+        {
+            var state = Interlocked.Or(ref _lifecycleState, RequestCompleteState) |
+                        RequestCompleteState;
+            return IsClosedState(state);
+        }
+
+        public bool CompleteResponse()
+        {
+            var state = Interlocked.Or(ref _lifecycleState, ResponseCompleteState) |
+                        ResponseCompleteState;
+            return IsClosedState(state);
+        }
+
+        public void Abort(H2ErrorCode errorCode)
+        {
+            var previous = Interlocked.Or(ref _lifecycleState, AbortedState);
+
+            if ((previous & AbortedState) != 0)
+                return;
+
+            try { _responseAbortTokenSource.Cancel(); }
+            catch (ObjectDisposedException) { }
+            var error = new ExchangeException(
+                $"Downstream reset HTTP/2 stream {StreamIdentifier}: {errorCode}");
+
+            try { _requestBodyPipe?.Writer.Complete(error); }
+            catch (InvalidOperationException) { }
+        }
+
+        public bool IsClosed => IsClosedState(Volatile.Read(ref _lifecycleState));
+        public bool IsAborted => (Volatile.Read(ref _lifecycleState) & AbortedState) != 0;
+        public CancellationToken ResponseAbortToken => _responseAbortToken;
+
+        private bool IsRequestComplete
+            => (Volatile.Read(ref _lifecycleState) & RequestCompleteState) != 0;
+
+        private static bool IsClosedState(int state)
+            => (state & AbortedState) != 0 ||
+               (state & (RequestCompleteState | ResponseCompleteState)) ==
+               (RequestCompleteState | ResponseCompleteState);
+
         public async ValueTask<int> BookWindowSize(int requestedBodyLength, CancellationToken cancellationToken)
         {
-            if (requestedBodyLength == 0)
+            if (requestedBodyLength == 0 || IsAborted)
                 return 0;
 
             // Fast path: serve from pre-booked local budget (zero holder calls).
@@ -268,13 +342,15 @@ namespace Fluxzy.Core
 
         public void Dispose()
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
                 return;
 
-            _disposed = true;
-
-            _requestBodyPipe?.Writer.Complete();
+            try { _requestBodyPipe?.Writer.Complete(); }
+            catch (InvalidOperationException) { }
+            try { _responseAbortTokenSource.Cancel(); }
+            catch (ObjectDisposedException) { }
             _streamWindowSizeHolder.Dispose();
+            _responseAbortTokenSource.Dispose();
 
             ArrayPool<byte>.Shared.Return(_headerBuffer);
         }

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
@@ -570,5 +570,94 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
 
             Assert.Equal("aaabbbccc", body);
         }
+
+        [Fact]
+        public async Task MultiplexedUploadsContinueAfterEarlyResponse()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.CompleteHandshake();
+
+            await ctx.SendHeadersFrame(1,
+                "POST /early HTTP/2\r\nHost: localhost\r\nContent-Length: 6\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+            await ctx.SendHeadersFrame(3,
+                "POST /normal HTTP/2\r\nHost: localhost\r\nContent-Length: 6\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope1 = new ExchangeScope();
+            using var scope3 = new ExchangeScope();
+            var exchange1 = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope1, ctx.Token);
+            var exchange3 = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope3, ctx.Token);
+
+            Assert.NotNull(exchange1);
+            Assert.NotNull(exchange3);
+
+            await WriteBodylessResponse(ctx, buffer, 1, "POST");
+            await ReadFrameWithoutReset(ctx, H2FrameType.Headers, 1);
+            Assert.Equal(2, ctx.DownStreamPipe.ActiveStreamCountForTests);
+
+            var body1 = ReadBody(ctx, exchange1!.Request.Body!);
+            var body3 = ReadBody(ctx, exchange3!.Request.Body!);
+            await ctx.SendDataFrame(1, System.Text.Encoding.ASCII.GetBytes("a1"), false);
+            await ctx.SendDataFrame(3, System.Text.Encoding.ASCII.GetBytes("b1"), false);
+            await ctx.SendDataFrame(1, System.Text.Encoding.ASCII.GetBytes("a2"), false);
+            await ctx.SendDataFrame(3, System.Text.Encoding.ASCII.GetBytes("b2"), false);
+            await ctx.SendDataFrame(1, System.Text.Encoding.ASCII.GetBytes("a3"), true);
+            await ctx.SendDataFrame(3, System.Text.Encoding.ASCII.GetBytes("b3"), true);
+
+            Assert.Equal("a1a2a3", await body1);
+            Assert.Equal("b1b2b3", await body3);
+            await PingBarrier(ctx, 101);
+            Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+
+            await WriteBodylessResponse(ctx, buffer, 3, "POST");
+            await ReadFrameWithoutReset(ctx, H2FrameType.Headers, 3);
+            await PingBarrier(ctx, 103);
+            Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            Assert.Equal(2, ctx.DownStreamPipe.ClosedStreamCountForTests);
+
+            await ctx.SendHeadersFrame(5,
+                "GET /next HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true, endHeaders: true);
+            using var scope5 = new ExchangeScope();
+            var next = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope5, ctx.Token);
+            Assert.NotNull(next);
+            Assert.Equal(5, next!.StreamIdentifier);
+        }
+
+        private static ValueTask WriteBodylessResponse(
+            H2TestContext ctx, Fluxzy.Misc.ResizableBuffers.RsBuffer buffer,
+            int streamIdentifier, string method)
+            => ctx.DownStreamPipe.WriteResponseHeader(
+                new ResponseHeader(
+                    "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".AsMemory(),
+                    true, false),
+                buffer, false, streamIdentifier, method.AsMemory(), ctx.Token);
+
+        private static async Task<H2FrameReadResult> ReadFrameWithoutReset(
+            H2TestContext ctx, H2FrameType frameType, int streamIdentifier)
+        {
+            while (true) {
+                var frame = await ctx.ReadNextFrame();
+                Assert.NotEqual(H2FrameType.RstStream, frame.BodyType);
+
+                if (frame.BodyType == frameType && frame.StreamIdentifier == streamIdentifier)
+                    return frame;
+            }
+        }
+
+        private static async Task PingBarrier(H2TestContext ctx, long opaqueData)
+        {
+            await ctx.SendPing(opaqueData);
+            await ReadFrameWithoutReset(ctx, H2FrameType.Ping, 0);
+        }
+
+        private static async Task<string> ReadBody(H2TestContext ctx, Stream body)
+        {
+            using var destination = new MemoryStream();
+            await body.CopyToAsync(destination, ctx.Token);
+            return System.Text.Encoding.ASCII.GetString(destination.ToArray());
+        }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2StreamLifecycleTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2StreamLifecycleTests.cs
@@ -1,0 +1,316 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Frames;
+using Fluxzy.Core;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Serve
+{
+    public class H2StreamLifecycleTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RequestAndResponseHalvesCloseInEitherOrder(bool responseFirst)
+        {
+            await using var ctx = await H2TestContext.Create();
+            await CompleteHandshake(ctx);
+            await ctx.SendHeadersFrame(1,
+                "POST /order HTTP/2\r\nHost: localhost\r\nContent-Length: 3\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+            Assert.NotNull(exchange);
+            var body = ReadBody(exchange!.Request.Body!, ctx);
+
+            if (responseFirst) {
+                await WriteBodylessResponse(ctx, buffer, 1, "POST");
+                await ReadStreamFrames(ctx, 1, 1);
+                await PingBarrier(ctx, 11);
+                Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+                await ctx.SendDataFrame(1, Encoding.ASCII.GetBytes("req"), endStream: true);
+            }
+            else {
+                await ctx.SendDataFrame(1, Encoding.ASCII.GetBytes("req"), endStream: true);
+                Assert.Equal("req", await body);
+                await PingBarrier(ctx, 12);
+                Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+                await WriteBodylessResponse(ctx, buffer, 1, "POST");
+                await ReadStreamFrames(ctx, 1, 1);
+            }
+
+            Assert.Equal("req", await body);
+            await PingBarrier(ctx, 13);
+            Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            Assert.Equal(1, ctx.DownStreamPipe.ClosedStreamCountForTests);
+        }
+
+        [Theory]
+        [InlineData(ResponseTerminal.BodylessHeaders)]
+        [InlineData(ResponseTerminal.FinalData)]
+        [InlineData(ResponseTerminal.Trailers)]
+        public async Task TerminalResponsePathsCloseAfterTheirWrites(ResponseTerminal terminal)
+        {
+            await using var ctx = await H2TestContext.Create();
+            await CompleteHandshake(ctx);
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+
+            for (var iteration = 0; iteration < 5; iteration++) {
+                var streamIdentifier = iteration * 2 + 1;
+                await ctx.SendHeadersFrame(streamIdentifier,
+                    $"GET /terminal/{iteration} HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                    endStream: true, endHeaders: true);
+                using var scope = new ExchangeScope();
+                var exchange = await ctx.DownStreamPipe.ReadNextExchange(
+                    buffer, scope, ctx.Token);
+                Assert.NotNull(exchange);
+
+                await WriteResponse(ctx, buffer, streamIdentifier, terminal);
+                var frames = await ReadStreamFrames(
+                    ctx, streamIdentifier, terminal == ResponseTerminal.BodylessHeaders ? 1 : 3);
+
+                Assert.True(frames[^1].Flags.HasFlag(HeaderFlags.EndStream));
+                Assert.Equal(terminal == ResponseTerminal.Trailers
+                        ? H2FrameType.Headers
+                        : terminal == ResponseTerminal.FinalData
+                            ? H2FrameType.Data
+                            : H2FrameType.Headers,
+                    frames[^1].BodyType);
+                await PingBarrier(ctx, 100 + iteration);
+                Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+                Assert.Equal(iteration + 1, ctx.DownStreamPipe.ClosedStreamCountForTests);
+            }
+        }
+
+        [Fact]
+        public async Task TerminalWriteGateRetainsWorkerUntilWriteSucceeds()
+        {
+            GatedWriteStream? transport = null;
+            await using var ctx = await H2TestContext.Create(stream =>
+                transport = new GatedWriteStream(stream));
+            await CompleteHandshake(ctx);
+            await ctx.SendHeadersFrame(1,
+                "GET /gated HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            Assert.NotNull(await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token));
+            transport!.GateNextWrite();
+
+            await WriteBodylessResponse(ctx, buffer, 1, "GET");
+            await transport.WriteStarted.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            Assert.Equal(0, ctx.DownStreamPipe.ClosedStreamCountForTests);
+
+            transport.ReleaseWrite();
+            await ReadStreamFrames(ctx, 1, 1);
+            await PingBarrier(ctx, 201);
+            Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            Assert.Equal(1, ctx.DownStreamPipe.ClosedStreamCountForTests);
+        }
+
+        [Fact]
+        public async Task FragmentedInitialEndStreamCompletesOnlyAfterContinuation()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await CompleteHandshake(ctx);
+            var fragments = ctx.CreateFragmentedHeadersFrames(1,
+                "GET /fragmented HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: true);
+
+            var streamActive = ctx.DownStreamPipe.WaitForStreamActiveForTests(1);
+            await ctx.SendRawFrame(fragments.Headers);
+            await streamActive.WaitAsync(TimeSpan.FromSeconds(2));
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchangeTask = ctx.DownStreamPipe.ReadNextExchange(
+                buffer, scope, ctx.Token).AsTask();
+            Assert.False(exchangeTask.IsCompleted);
+            Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+
+            await ctx.SendRawFrame(fragments.Continuation);
+            var exchange = await exchangeTask.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.NotNull(exchange);
+            Assert.Same(Stream.Null, exchange!.Request.Body);
+
+            await WriteBodylessResponse(ctx, buffer, 1, "GET");
+            await ReadStreamFrames(ctx, 1, 1);
+            await PingBarrier(ctx, 301);
+            Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+        }
+
+        [Fact]
+        public async Task ResetFaultsRequestCancelsResponseAndDropsQueuedBuffers()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await CompleteHandshake(ctx);
+            await ctx.SendHeadersFrame(1,
+                "POST /reset HTTP/2\r\nHost: localhost\r\nContent-Length: 1\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+            Assert.NotNull(exchange);
+            var requestBody = ReadBody(exchange!.Request.Body!, ctx);
+            ctx.DownStreamPipe.PauseWriteLoopForTests();
+
+            try {
+                await ctx.DownStreamPipe.WriteResponseHeader(
+                    new ResponseHeader(
+                        "HTTP/1.1 200 OK\r\nContent-Length: 70000\r\n\r\n".AsMemory(),
+                        true, false),
+                    buffer, false, 1, "POST".AsMemory(), ctx.Token);
+                var queued = ctx.DownStreamPipe.WaitForResponseDataEntriesForTests(3);
+                var response = ctx.DownStreamPipe.WriteResponseBody(
+                    new MemoryStream(new byte[70000]), buffer, false, 1,
+                    new Response(), ctx.Token).AsTask();
+                await queued.WaitAsync(TimeSpan.FromSeconds(2));
+                Assert.False(response.IsCompleted);
+
+                await ctx.SendRstStream(1, H2ErrorCode.Cancel);
+                await Assert.ThrowsAnyAsync<Exception>(async () => await requestBody);
+                await response.WaitAsync(TimeSpan.FromSeconds(2));
+                Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+                Assert.Equal(1, ctx.DownStreamPipe.ClosedStreamCountForTests);
+
+                var idle = ctx.DownStreamPipe.WaitForWriteLoopIdleForTests();
+                ctx.DownStreamPipe.ResumeWriteLoopForTests();
+                await idle.WaitAsync(TimeSpan.FromSeconds(2));
+                Assert.Equal(3, ctx.DownStreamPipe.DroppedResponseBufferCountForTests);
+
+                await ctx.SendDataFrame(1, Encoding.ASCII.GetBytes("late"), endStream: true);
+                await PingBarrier(ctx, 401);
+                Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            }
+            finally {
+                ctx.DownStreamPipe.ResumeWriteLoopForTests();
+            }
+        }
+
+        [Fact]
+        public async Task StreamProtocolErrorAbortsOwnedRequestBody()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await CompleteHandshake(ctx);
+            await ctx.SendHeadersFrame(1,
+                "POST /protocol HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+            Assert.NotNull(exchange);
+            var requestBody = ReadBody(exchange!.Request.Body!, ctx);
+
+            await ctx.SendHeadersFrame(1,
+                "x-invalid: trailer without end stream\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+            await Assert.ThrowsAnyAsync<Exception>(async () => await requestBody);
+            var reset = await ReadUntilFrame(ctx, H2FrameType.RstStream);
+            Assert.Equal(1, reset.StreamIdentifier);
+            Assert.Equal(0, ctx.DownStreamPipe.ActiveStreamCountForTests);
+            Assert.Equal(1, ctx.DownStreamPipe.ClosedStreamCountForTests);
+        }
+
+        private static async Task CompleteHandshake(H2TestContext ctx)
+        {
+            await ctx.CompleteHandshake();
+            var settingsAck = await ReadUntilFrame(ctx, H2FrameType.Settings);
+            Assert.True(settingsAck.Flags.HasFlag(HeaderFlags.Ack));
+        }
+
+        private static async Task WriteResponse(
+            H2TestContext ctx, Fluxzy.Misc.ResizableBuffers.RsBuffer buffer, int streamIdentifier,
+            ResponseTerminal terminal)
+        {
+            if (terminal == ResponseTerminal.BodylessHeaders) {
+                await WriteBodylessResponse(ctx, buffer, streamIdentifier, "GET");
+                return;
+            }
+
+            await ctx.DownStreamPipe.WriteResponseHeader(
+                new ResponseHeader(
+                    "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n".AsMemory(),
+                    true, false),
+                buffer, false, streamIdentifier, "GET".AsMemory(), ctx.Token);
+            var response = new Response();
+
+            if (terminal == ResponseTerminal.Trailers) {
+                response.Trailers = new List<HeaderField> { new("x-terminal", "trailer") };
+            }
+
+            await ctx.DownStreamPipe.WriteResponseBody(
+                new MemoryStream(new byte[] { 1 }), buffer, false,
+                streamIdentifier, response, ctx.Token);
+        }
+
+        private static ValueTask WriteBodylessResponse(
+            H2TestContext ctx, Fluxzy.Misc.ResizableBuffers.RsBuffer buffer,
+            int streamIdentifier, string method)
+            => ctx.DownStreamPipe.WriteResponseHeader(
+                new ResponseHeader(
+                    "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".AsMemory(),
+                    true, false),
+                buffer, false, streamIdentifier, method.AsMemory(), ctx.Token);
+
+        private static async Task<List<H2FrameReadResult>> ReadStreamFrames(
+            H2TestContext ctx, int streamIdentifier, int count)
+        {
+            var frames = new List<H2FrameReadResult>();
+
+            while (frames.Count < count) {
+                var frame = await ctx.ReadNextFrame();
+                Assert.NotEqual(H2FrameType.RstStream, frame.BodyType);
+
+                if (frame.StreamIdentifier == streamIdentifier)
+                    frames.Add(frame);
+            }
+
+            return frames;
+        }
+
+        private static async Task<H2FrameReadResult> ReadUntilFrame(
+            H2TestContext ctx, H2FrameType frameType)
+        {
+            while (true) {
+                var frame = await ctx.ReadNextFrame();
+
+                if (frame.BodyType == frameType)
+                    return frame;
+            }
+        }
+
+        private static async Task PingBarrier(H2TestContext ctx, long opaqueData)
+        {
+            await ctx.SendPing(opaqueData);
+            var ping = await ReadUntilFrame(ctx, H2FrameType.Ping);
+            Assert.True(ping.Flags.HasFlag(HeaderFlags.Ack));
+        }
+
+        private static async Task<string> ReadBody(Stream body, H2TestContext ctx)
+        {
+            using var destination = new MemoryStream();
+            await body.CopyToAsync(destination, ctx.Token);
+            return Encoding.ASCII.GetString(destination.ToArray());
+        }
+
+        public enum ResponseTerminal
+        {
+            BodylessHeaders,
+            FinalData,
+            Trailers
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2TrailerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2TrailerTests.cs
@@ -333,6 +333,46 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
             Assert.Equal("x-checksum", ex2.Request.Trailers[0].Name.ToString());
             Assert.Equal("deadbeef", ex2.Request.Trailers[0].Value.ToString());
         }
+
+        [Fact]
+        public async Task FragmentedRequestTrailersCompleteAfterFinalContinuation()
+        {
+            await using var ctx = await H2TestContext.Create();
+            await ctx.CompleteHandshake();
+            await ctx.SendHeadersFrame(1,
+                "POST /fragmented-trailers HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory(),
+                endStream: false, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+            Assert.NotNull(exchange);
+            await ctx.SendDataFrame(1, Encoding.ASCII.GetBytes("body"), endStream: false);
+            var body = ReadBody(exchange!.Request.Body!, ctx.Token);
+            var fragments = ctx.CreateFragmentedTrailerFrames(1, new List<HeaderField>
+            {
+                new("x-fragmented", "complete")
+            });
+
+            await ctx.SendRawFrame(fragments.Headers);
+            Assert.False(body.IsCompleted);
+            Assert.Null(exchange.Request.Trailers);
+
+            await ctx.SendRawFrame(fragments.Continuation);
+            Assert.Equal("body", await body.WaitAsync(TimeSpan.FromSeconds(2)));
+            Assert.NotNull(exchange.Request.Trailers);
+            Assert.Single(exchange.Request.Trailers!);
+            Assert.Equal("x-fragmented", exchange.Request.Trailers[0].Name.ToString());
+            Assert.Equal("complete", exchange.Request.Trailers[0].Value.ToString());
+            Assert.Equal(1, ctx.DownStreamPipe.ActiveStreamCountForTests);
+        }
+
+        private static async Task<string> ReadBody(Stream body, CancellationToken token)
+        {
+            using var destination = new MemoryStream();
+            await body.CopyToAsync(destination, token);
+            return Encoding.ASCII.GetString(destination.ToArray());
+        }
     }
 
     public class H2TrailerEncodingTests

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2TrailerTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2TrailerTests.cs
@@ -413,6 +413,29 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
             }
         }
 
+        [Fact]
+        public void BuildFragmentedTrailerFrames_LargeValueEncodesWithoutFixedBufferLimit()
+        {
+            var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
+            var encoder = new HPackEncoder(new EncodingContext(memoryProvider));
+            var decoder = new HPackDecoder(
+                new DecodingContext(new Authority("localhost", 443, true), memoryProvider));
+            var value = new string('x', 6000);
+            var trailers = new List<HeaderField> { new("x-large-trailer", value) };
+
+            var frames = H2FrameHelper.BuildFragmentedTrailerFrames(
+                encoder, streamId: 1, trailers);
+            var firstLength = frames.Headers.Length - 9;
+            var encoded = new byte[firstLength + frames.Continuation.Length - 9];
+            frames.Headers.AsSpan(9).CopyTo(encoded);
+            frames.Continuation.AsSpan(9).CopyTo(encoded.AsSpan(firstLength));
+
+            var decoded = decoder.DecodeTrailerFields(encoded);
+            var trailer = Assert.Single(decoded);
+            Assert.Equal("x-large-trailer", trailer.Name.ToString());
+            Assert.Equal(value, trailer.Value.ToString());
+        }
+
         /// <summary>
         /// Verify DecodeTrailerFields returns empty list for empty input.
         /// </summary>

--- a/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
+++ b/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
@@ -52,6 +52,66 @@ namespace Fluxzy.Tests._Fixtures
         }
     }
 
+    internal sealed class GatedWriteStream : Stream
+    {
+        private readonly Stream _inner;
+        private TaskCompletionSource<object?>? _release;
+        private TaskCompletionSource<object?>? _writeStarted;
+
+        public GatedWriteStream(Stream inner)
+        {
+            _inner = inner;
+        }
+
+        public Task WriteStarted
+            => Volatile.Read(ref _writeStarted)?.Task ?? Task.CompletedTask;
+
+        public void GateNextWrite()
+        {
+            _writeStarted = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _release = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public void ReleaseWrite()
+            => Interlocked.Exchange(ref _release, null)?.TrySetResult(null);
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var release = Volatile.Read(ref _release);
+
+            if (release != null) {
+                Volatile.Read(ref _writeStarted)?.TrySetResult(null);
+                await release.Task.WaitAsync(cancellationToken);
+            }
+
+            await _inner.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => _inner.FlushAsync(cancellationToken);
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count)
+            => _inner.Write(buffer, offset, count);
+    }
+
     /// <summary>
     /// A simple IIdProvider for testing that returns incrementing IDs.
     /// </summary>
@@ -205,6 +265,40 @@ namespace Fluxzy.Tests._Fixtures
             return frameBuffer;
         }
 
+        public static (byte[] Headers, byte[] Continuation) BuildFragmentedHeadersFrames(
+            HPackEncoder encoder, int streamId, ReadOnlyMemory<char> plainHeaders,
+            bool endStream)
+        {
+            var encodedBuffer = new byte[plainHeaders.Length * 4 + 256];
+            var encoded = encoder.Encode(plainHeaders, encodedBuffer);
+            return BuildFragmentedHeaderBlock(encoded, streamId, endStream);
+        }
+
+        public static (byte[] Headers, byte[] Continuation) BuildFragmentedTrailerFrames(
+            HPackEncoder encoder, int streamId, IList<HeaderField> trailerFields)
+        {
+            var encodedBuffer = new byte[4096];
+            var encoded = encoder.EncodeFields(trailerFields, encodedBuffer);
+            return BuildFragmentedHeaderBlock(encoded, streamId, endStream: true);
+        }
+
+        private static (byte[] Headers, byte[] Continuation) BuildFragmentedHeaderBlock(
+            ReadOnlySpan<byte> encoded, int streamId, bool endStream)
+        {
+            var firstLength = Math.Max(1, encoded.Length / 2);
+            var secondLength = encoded.Length - firstLength;
+            var headers = new byte[9 + firstLength];
+            var continuation = new byte[9 + secondLength];
+            var flags = endStream ? HeaderFlags.EndStream : HeaderFlags.None;
+
+            H2Frame.Write(headers, firstLength, H2FrameType.Headers, flags, streamId);
+            encoded.Slice(0, firstLength).CopyTo(headers.AsSpan(9));
+            H2Frame.Write(continuation, secondLength, H2FrameType.Continuation,
+                HeaderFlags.EndHeaders, streamId);
+            encoded.Slice(firstLength).CopyTo(continuation.AsSpan(9));
+            return (headers, continuation);
+        }
+
         public static H2FrameReadResult ParseFrame(byte[] headerBuffer, byte[] bodyBuffer)
         {
             var frame = new H2Frame(headerBuffer.AsSpan());
@@ -248,7 +342,8 @@ namespace Fluxzy.Tests._Fixtures
         /// creates the pipe, creates H2DownStreamPipe, sends the client preface,
         /// and calls Init on the pipe.
         /// </summary>
-        public static async Task<H2TestContext> Create()
+        public static async Task<H2TestContext> Create(
+            Func<Stream, Stream>? serverWriteStreamFactory = null)
         {
             var pipe = new DuplexPipe();
             var authority = new Authority("localhost", 443, true);
@@ -257,7 +352,7 @@ namespace Fluxzy.Tests._Fixtures
                 new TestIdProvider(),
                 authority,
                 pipe.ServerReadStream,
-                pipe.ServerWriteStream,
+                serverWriteStreamFactory?.Invoke(pipe.ServerWriteStream) ?? pipe.ServerWriteStream,
                 new TestExchangeContextBuilder());
 
             var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
@@ -303,6 +398,22 @@ namespace Fluxzy.Tests._Fixtures
             var frameBuffer = H2FrameHelper.BuildHeadersFrame(
                 _clientEncoder, streamId, plainHeaders, endStream, endHeaders);
             await Pipe.ClientWriteStream.WriteAsync(frameBuffer, Token);
+            await Pipe.ClientWriteStream.FlushAsync(Token);
+        }
+
+        public (byte[] Headers, byte[] Continuation) CreateFragmentedHeadersFrames(
+            int streamId, ReadOnlyMemory<char> plainHeaders, bool endStream)
+            => H2FrameHelper.BuildFragmentedHeadersFrames(
+                _clientEncoder, streamId, plainHeaders, endStream);
+
+        public (byte[] Headers, byte[] Continuation) CreateFragmentedTrailerFrames(
+            int streamId, IList<HeaderField> trailerFields)
+            => H2FrameHelper.BuildFragmentedTrailerFrames(
+                _clientEncoder, streamId, trailerFields);
+
+        public async Task SendRawFrame(byte[] frame)
+        {
+            await Pipe.ClientWriteStream.WriteAsync(frame, Token);
             await Pipe.ClientWriteStream.FlushAsync(Token);
         }
 

--- a/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
+++ b/test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs
@@ -189,7 +189,7 @@ namespace Fluxzy.Tests._Fixtures
             ReadOnlyMemory<char> plainHeaders,
             bool endStream, bool endHeaders)
         {
-            var encodedBuffer = new byte[plainHeaders.Length * 4 + 256];
+            var encodedBuffer = new byte[GetHeaderEncodingBufferSize(plainHeaders)];
             var encoded = encoder.Encode(plainHeaders, encodedBuffer);
 
             HeaderFlags flags = HeaderFlags.None;
@@ -253,7 +253,7 @@ namespace Fluxzy.Tests._Fixtures
         public static byte[] BuildTrailerHeadersFrame(
             HPackEncoder encoder, int streamId, IList<HeaderField> trailerFields)
         {
-            var encodedBuffer = new byte[4096];
+            var encodedBuffer = new byte[GetHeaderEncodingBufferSize(trailerFields)];
             var encoded = encoder.EncodeFields(trailerFields, encodedBuffer);
 
             var flags = HeaderFlags.EndStream | HeaderFlags.EndHeaders;
@@ -269,7 +269,7 @@ namespace Fluxzy.Tests._Fixtures
             HPackEncoder encoder, int streamId, ReadOnlyMemory<char> plainHeaders,
             bool endStream)
         {
-            var encodedBuffer = new byte[plainHeaders.Length * 4 + 256];
+            var encodedBuffer = new byte[GetHeaderEncodingBufferSize(plainHeaders)];
             var encoded = encoder.Encode(plainHeaders, encodedBuffer);
             return BuildFragmentedHeaderBlock(encoded, streamId, endStream);
         }
@@ -277,9 +277,24 @@ namespace Fluxzy.Tests._Fixtures
         public static (byte[] Headers, byte[] Continuation) BuildFragmentedTrailerFrames(
             HPackEncoder encoder, int streamId, IList<HeaderField> trailerFields)
         {
-            var encodedBuffer = new byte[4096];
+            var encodedBuffer = new byte[GetHeaderEncodingBufferSize(trailerFields)];
             var encoded = encoder.EncodeFields(trailerFields, encodedBuffer);
             return BuildFragmentedHeaderBlock(encoded, streamId, endStream: true);
+        }
+
+        private static int GetHeaderEncodingBufferSize(ReadOnlyMemory<char> plainHeaders)
+            => GetHeaderEncodingBufferSize(Http11Parser.Read(plainHeaders));
+
+        private static int GetHeaderEncodingBufferSize(IList<HeaderField> fields)
+        {
+            var encodedMaxLength = 0;
+
+            foreach (var field in fields) {
+                encodedMaxLength = checked(encodedMaxLength +
+                    checked((field.Name.Length + field.Value.Length + 64) * 2));
+            }
+
+            return Math.Max(encodedMaxLength, 64);
         }
 
         private static (byte[] Headers, byte[] Continuation) BuildFragmentedHeaderBlock(


### PR DESCRIPTION
## Problem

At baseline `c3d82961eb2a3c62e53822692720aba18fc347f6`, completing a downstream HTTP/2 response removes and disposes its `ServerStreamWorker`, even when the request half of the stream remains open.

For an early-response POST, a valid late `DATA[END_STREAM]` frame can therefore create an empty replacement worker, fail request-body processing, and trigger a protocol reset.

Response completion is also recorded when terminal work is queued rather than after the terminal frame has been written successfully.

## Solution

Track request completion, response completion, and abort as a single atomic worker state. Keep each worker registered until both halves of the stream complete, while resets and stream protocol errors abort it immediately.

Worker creation is now limited to valid initial `HEADERS`. Fragmented request completion is deferred until the final `CONTINUATION` frame has been decoded.

Queued `DATA` work carries only the stream identity and terminal-response metadata. The single response writer marks the response complete only after the terminal transport write succeeds.

Reset handling now:

- Faults the request body.
- Cancels response flow-control waits.
- Discards queued response work for the affected stream.
- Returns any associated rented buffers.

This is a focused extraction of the downstream stream-lifecycle invariant rather than a wholesale import of predecessor commit `6b391a6`. It intentionally excludes client connection-pool changes, receive-window redesign, broad asynchronous connection disposal, benchmark changes, and unrelated writer optimizations.

## Benefits

- Preserves multiplexed POST request bodies when a stream receives an early response.
- Removes workers and disposes pooled resources exactly once, after both stream halves close.
- Prevents `DATA` and `CONTINUATION` frames from recreating completed or reset streams.
- Completes bodyless, final-`DATA`, and trailer responses only after successful terminal writes.
- Preserves HPACK FIFO ownership, response-frame ordering, existing trailer ordering, and flow-control accounting.

## Changes

- Added atomic request-completion, response-completion, and abort transitions to `ServerStreamWorker`.
- Added reset cancellation and immediate abort behavior.
- Restricted downstream worker creation to valid initial request headers.
- Corrected completion ordering for fragmented initial headers and trailers.
- Made the response writer responsible for terminal response completion.
- Added reset-time queue cleanup and pooled-buffer return handling.
- Added deterministic gate-based coverage for multiplexed streams, both request/response completion orderings, repeated terminal events, terminal-write completion gating, fragmented headers and trailers, reset cancellation, stream protocol errors, and pooled-buffer returns.
- Hardened test seams so failed channel writes return pooled buffers and HPACK fixtures size buffers from their encoded fields.

## Verification

Built the test project in Release mode for .NET 10:

```bash
dotnet build test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  -p:TargetFrameworks=net10.0
```

Result: succeeded with 59 existing warnings and no errors.

Ran `H2StreamLifecycleTests` ten times against the final change:

```bash
dotnet test test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  --no-build \
  --no-restore \
  -p:TargetFrameworks=net10.0 \
  --filter "FullyQualifiedName~H2StreamLifecycleTests"
```

Result: 90 passed, 0 failed across ten runs.

Ran the adjacent HTTP/2 server tests, excluding the environment-dependent certificate case:

```bash
dotnet test test/Fluxzy.Tests/Fluxzy.Tests.csproj \
  -c Release \
  --no-build \
  --no-restore \
  -p:TargetFrameworks=net10.0 \
  --filter "FullyQualifiedName~Fluxzy.Tests.UnitTests.H2Serve&FullyQualifiedName!~Fluxzy.Tests.UnitTests.H2Serve.H2ServeTests.SimpleH2Request"
```

Result: 54 passed, 0 failed.

The excluded certificate test was run separately and reproduced its baseline failure because the non-root test environment could not install and trust the generated root certificate. No assertion was weakened and no test was globally skipped.

The diff also passed whitespace validation:

```bash
git diff --check origin/main...HEAD
```

The full solution build was not used as a gate because of an existing, unrelated target-framework mismatch between a `net8.0` project and a project reference that supports only `net10.0`. The affected test project was therefore built and tested explicitly for `net10.0`. This change does not modify that mismatch.

| Category | Files | Additions | Removals | Net |
| --- | --- | ---: | ---: | ---: |
| Documentation | None | 0 | 0 | 0 |
| Configuration | None | 0 | 0 | 0 |
| Runtime | `src/Fluxzy.Core/Core/DataFrameEntry.cs`<br>`src/Fluxzy.Core/Core/H2DownStreamPipe.cs`<br>`src/Fluxzy.Core/Core/ServerStreamWorker.cs` | 448 | 97 | +351 |
| Tests | `test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs`<br>`test/Fluxzy.Tests/UnitTests/H2Serve/H2StreamLifecycleTests.cs`<br>`test/Fluxzy.Tests/UnitTests/H2Serve/H2TrailerTests.cs`<br>`test/Fluxzy.Tests/_Fixtures/H2TestHelper.cs` | 598 | 4 | +594 |
| **Total** | **7 files** | **1046** | **101** | **+945** |
