### PR TITLE
Coalesce HTTP/1 chunk frames and use memory-based copy paths

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11PoolProcessing.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;
@@ -24,15 +25,18 @@ namespace Fluxzy.Clients.H11
         private readonly TimeSpan _responseHeaderTimeout;
         private readonly TimeSpan _responseBodyIdleTimeout;
         private readonly ILogger _logger;
+        private readonly ArrayPool<byte> _chunkBufferPool;
 
         public Http11PoolProcessing(
             TimeSpan expectContinueTimeout, TimeSpan responseHeaderTimeout,
-            TimeSpan responseBodyIdleTimeout, ILogger? logger = null)
+            TimeSpan responseBodyIdleTimeout, ILogger? logger = null,
+            ArrayPool<byte>? chunkBufferPool = null)
         {
             _expectContinueTimeout = expectContinueTimeout;
             _responseHeaderTimeout = responseHeaderTimeout;
             _responseBodyIdleTimeout = responseBodyIdleTimeout;
             _logger = logger ?? NullLogger.Instance;
+            _chunkBufferPool = chunkBufferPool ?? ArrayPool<byte>.Shared;
         }
 
         /// <summary>
@@ -119,11 +123,11 @@ namespace Fluxzy.Clients.H11
 
             if (!hasEarlyResponseHeader && exchange.Request.Body != null) {
                 var writeStream = exchange.Connection.WriteStream;
-                ChunkedTransferWriteStream? chunkedStream = null;
+                using var chunkedStream = exchange.Request.Header.ChunkedBody
+                    ? new ChunkedTransferWriteStream(writeStream, _chunkBufferPool)
+                    : null;
 
-                if (exchange.Request.Header.ChunkedBody) {
-                    writeStream = chunkedStream = new ChunkedTransferWriteStream(writeStream);
-                }
+                writeStream = chunkedStream ?? writeStream;
 
                 var totalBodySize = await
                     exchange.Request.Body.CopyDetailed(writeStream, 1024 * 16,

--- a/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/Http11DownStreamPipe.cs
@@ -1,6 +1,7 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -19,6 +20,7 @@ namespace Fluxzy.Core
         private readonly IExchangeContextBuilder _contextBuilder;
         private readonly bool _plainAuthorityPerRequest;
         private readonly int? _plainAuthorityForcedPort;
+        private readonly ArrayPool<byte> _chunkBufferPool;
         private static int _count;
 
         private Stream? _readStream;
@@ -29,12 +31,14 @@ namespace Fluxzy.Core
             Authority requestedAuthority, Stream readStream, Stream writeStream,
             IExchangeContextBuilder contextBuilder,
             bool plainAuthorityPerRequest = false,
-            int? plainAuthorityForcedPort = null)
+            int? plainAuthorityForcedPort = null,
+            ArrayPool<byte>? chunkBufferPool = null)
         {
             _idProvider = idProvider;
             _contextBuilder = contextBuilder;
             _plainAuthorityPerRequest = plainAuthorityPerRequest;
             _plainAuthorityForcedPort = plainAuthorityForcedPort;
+            _chunkBufferPool = chunkBufferPool ?? ArrayPool<byte>.Shared;
             RequestedAuthority = requestedAuthority;
             _readStream = readStream;
             _writeStream = writeStream;
@@ -146,13 +150,10 @@ namespace Fluxzy.Core
             if (_writeStream == null)
                 throw new FluxzyException("Down stream has already been closed");
 
-            var stream = _writeStream;
-            ChunkedTransferWriteStream? chunkedWriter = null;
-
-            if (chunked) {
-                chunkedWriter = new ChunkedTransferWriteStream(stream);
-                stream = chunkedWriter;
-            }
+            using var chunkedWriter = chunked
+                ? new ChunkedTransferWriteStream(_writeStream, _chunkBufferPool)
+                : null;
+            var stream = (Stream?) chunkedWriter ?? _writeStream;
 
             if (chunked) {
                 await responseBodyStream

--- a/src/Fluxzy.Core/Misc/Streams/ChunkedTransferWriteStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/ChunkedTransferWriteStream.cs
@@ -16,20 +16,34 @@ namespace Fluxzy.Misc.Streams
     /// <summary>
     ///     A stream that write chunked transfer encoding
     /// </summary>
+    /// <remarks>
+    ///     Instances are not safe for concurrent use. Disposal returns staging buffers but leaves the inner stream open.
+    /// </remarks>
     public class ChunkedTransferWriteStream : Stream
     {
+        // A 64 KiB payload plus framing rents the 128 KiB Shared ArrayPool bucket.
+        private const int MaxStagedPayloadLength = 64 * 1024;
         private static readonly byte[] ChunkTerminator =
             { (byte) '0', (byte) '\r', (byte) '\n', (byte) '\r', (byte) '\n' };
 
         private static readonly byte[] LineTerminator = { (byte) '\r', (byte) '\n' };
         private readonly Stream _innerStream;
+        private readonly ArrayPool<byte> _arrayPool;
         private byte[]? _asyncHeaderBuffer;
+        private byte[]? _writeBuffer;
+        private int _writeBufferUsedLength;
 
         private bool _eof;
 
         public ChunkedTransferWriteStream(Stream innerStream)
+            : this(innerStream, ArrayPool<byte>.Shared)
+        {
+        }
+
+        internal ChunkedTransferWriteStream(Stream innerStream, ArrayPool<byte> arrayPool)
         {
             _innerStream = innerStream;
+            _arrayPool = arrayPool;
         }
 
         public override bool CanRead => false;
@@ -67,17 +81,31 @@ namespace Fluxzy.Misc.Streams
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            var poolBuffer = ArrayPool<byte>.Shared.Rent(64);
+            ValidateBufferArguments(buffer, offset, count);
+            Write(buffer.AsSpan(offset, count));
+        }
 
-            try {
-                var cs = Encoding.ASCII.GetBytes($"{count:X}\r\n", poolBuffer);
-                _innerStream.Write(poolBuffer, 0, cs);
-                _innerStream.Write(buffer, offset, count);
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+                return;
+
+            if (buffer.Length > MaxStagedPayloadLength) {
+                Span<byte> header = stackalloc byte[10];
+                var largeHeaderLength = FormatChunkHeader(buffer.Length, header);
+                _innerStream.Write(header.Slice(0, largeHeaderLength));
+                _innerStream.Write(buffer);
                 _innerStream.Write(LineTerminator);
+                return;
             }
-            finally {
-                ArrayPool<byte>.Shared.Return(poolBuffer);
-            }
+
+            var frame = GetWriteBuffer(buffer.Length);
+            var headerLength = FormatChunkHeader(buffer.Length, frame);
+            buffer.CopyTo(frame.AsSpan(headerLength));
+            BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(headerLength + buffer.Length), 0x0D0A);
+            var frameLength = headerLength + buffer.Length + LineTerminator.Length;
+            _writeBufferUsedLength = Math.Max(_writeBufferUsedLength, frameLength);
+            _innerStream.Write(frame, 0, frameLength);
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -89,11 +117,56 @@ namespace Fluxzy.Misc.Streams
             ReadOnlyMemory<byte> buffer,
             CancellationToken cancellationToken = new())
         {
-            var headerBuffer = _asyncHeaderBuffer ??= new byte[10];
-            var headerLength = FormatChunkHeader(buffer.Length, headerBuffer);
-            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(headerBuffer, 0, headerLength), cancellationToken).ConfigureAwait(false);
-            await _innerStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
-            await _innerStream.WriteAsync(new ReadOnlyMemory<byte>(LineTerminator), cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (buffer.IsEmpty) {
+                return;
+            }
+
+            if (buffer.Length > MaxStagedPayloadLength) {
+                var header = _asyncHeaderBuffer ??= new byte[10];
+                var largeHeaderLength = FormatChunkHeader(buffer.Length, header);
+                await _innerStream.WriteAsync(
+                        header.AsMemory(0, largeHeaderLength), cancellationToken)
+                    .ConfigureAwait(false);
+                await _innerStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                await _innerStream.WriteAsync(LineTerminator, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            var frame = GetWriteBuffer(buffer.Length);
+            var headerLength = FormatChunkHeader(buffer.Length, frame);
+            buffer.CopyTo(frame.AsMemory(headerLength));
+            BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(headerLength + buffer.Length), 0x0D0A);
+            var frameLength = headerLength + buffer.Length + LineTerminator.Length;
+            _writeBufferUsedLength = Math.Max(_writeBufferUsedLength, frameLength);
+
+            await _innerStream.WriteAsync(
+                    frame.AsMemory(0, frameLength), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        private byte[] GetWriteBuffer(int payloadLength)
+        {
+            var requiredLength = checked(payloadLength + 12);
+
+            if (_writeBuffer == null || _writeBuffer.Length < requiredLength) {
+                ReturnWriteBuffer();
+                _writeBuffer = _arrayPool.Rent(requiredLength);
+            }
+
+            return _writeBuffer;
+        }
+
+        private void ReturnWriteBuffer()
+        {
+            if (_writeBuffer != null) {
+                var writeBuffer = _writeBuffer;
+                _writeBuffer = null;
+                writeBuffer.AsSpan(0, _writeBufferUsedLength).Clear();
+                _writeBufferUsedLength = 0;
+                _arrayPool.Return(writeBuffer);
+            }
         }
 
         private static int FormatChunkHeader(int count, Span<byte> destination)
@@ -110,6 +183,7 @@ namespace Fluxzy.Misc.Streams
         {
             if (!_eof) {
                 _eof = true;
+                ReturnWriteBuffer();
 
                 return _innerStream.WriteAsync(ChunkTerminator);
             }
@@ -121,6 +195,7 @@ namespace Fluxzy.Misc.Streams
         {
             if (!_eof) {
                 _eof = true;
+                ReturnWriteBuffer();
 
                 if (trailers != null && trailers.Count > 0) {
                     return WriteEofWithTrailersAsync(trailers);
@@ -130,6 +205,12 @@ namespace Fluxzy.Misc.Streams
             }
 
             return default;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            ReturnWriteBuffer();
+            base.Dispose(disposing);
         }
 
         private async ValueTask WriteEofWithTrailersAsync(List<HeaderField> trailers)

--- a/src/Fluxzy.Core/Misc/Streams/CombinedReadonlyStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/CombinedReadonlyStream.cs
@@ -177,11 +177,17 @@ namespace Fluxzy.Misc.Streams
             return result;
         }
 
-        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), token).AsTask();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             var result = 0;
 
-            while (count > 0) {
+            while (buffer.Length > 0) {
                 var stream = Current;
 
                 if (stream == null) {
@@ -190,12 +196,11 @@ namespace Fluxzy.Misc.Streams
 
                 var currentReadCount =
                     stream is MemoryStream
-                        ? stream.Read(buffer, offset, count)
-                        : await stream.ReadAsync(buffer, offset, count, token).ConfigureAwait(false);
+                        ? stream.Read(buffer.Span)
+                        : await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 
                 result += currentReadCount;
-                count -= currentReadCount;
-                offset += currentReadCount;
+                buffer = buffer.Slice(currentReadCount);
 
                 if (currentReadCount == 0) {
                     EndOfStream();

--- a/src/Fluxzy.Core/Misc/Streams/StreamExtensions.cs
+++ b/src/Fluxzy.Core/Misc/Streams/StreamExtensions.cs
@@ -191,22 +191,48 @@ namespace Fluxzy.Misc.Streams
             return totalRead;
         }
 
-        public static async ValueTask<long> CopyDetailed(
+        public static ValueTask<long> CopyDetailed(
             this Stream source,
             Stream destination,
             byte[] buffer, Action<int> onContentCopied, CancellationToken cancellationToken)
-            => await source.CopyDetailed(
-                         destination,
-                         buffer,
-                         onContentCopied,
-                         flushAfterEachWrite: true,
-                         cancellationToken)
-                    .ConfigureAwait(false);
+            => source.CopyDetailed(
+                destination,
+                buffer.AsMemory(),
+                onContentCopied,
+                flushAfterEachWrite: true,
+                cancellationToken);
+
+        public static ValueTask<long> CopyDetailed(
+            this Stream source,
+            Stream destination,
+            byte[] buffer,
+            Action<int> onContentCopied,
+            bool flushAfterEachWrite,
+            CancellationToken cancellationToken)
+            => source.CopyDetailed(
+                destination,
+                buffer.AsMemory(),
+                onContentCopied,
+                flushAfterEachWrite,
+                cancellationToken);
+
+        public static ValueTask<long> CopyDetailed(
+            this Stream source,
+            Stream destination,
+            Memory<byte> buffer,
+            Action<int> onContentCopied,
+            CancellationToken cancellationToken)
+            => source.CopyDetailed(
+                destination,
+                buffer,
+                onContentCopied,
+                flushAfterEachWrite: true,
+                cancellationToken);
 
         public static async ValueTask<long> CopyDetailed(
             this Stream source,
             Stream destination,
-            byte[] buffer,
+            Memory<byte> buffer,
             Action<int> onContentCopied,
             bool flushAfterEachWrite,
             CancellationToken cancellationToken)
@@ -219,9 +245,8 @@ namespace Fluxzy.Misc.Streams
             long totalCopied = 0;
             int read;
 
-            while ((read = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) >
-                   0) {
-                await destination.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
+            while ((read = await source.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0) {
+                await destination.WriteAsync(buffer.Slice(0, read), cancellationToken).ConfigureAwait(false);
                 onContentCopied(read);
 
                 if (flushAfterEachWrite) {

--- a/test/Fluxzy.Tests/UnitTests/Core/Http11ChunkedWriterOwnershipTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/Http11ChunkedWriterOwnershipTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H11;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Xunit;
+using ResizableBuffer = Fluxzy.Misc.ResizableBuffers.RsBuffer;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    public class Http11ChunkedWriterOwnershipTests
+    {
+        [Fact]
+        public async Task RequestSourceFailure_ReturnsChunkBufferWithoutClosingTransport()
+        {
+            var expected = new IOException("source read failed");
+            var source = new SegmentThenTerminalStream("request"u8.ToArray(), expected);
+            var destination = new TrackingMemoryStream();
+            var pool = new TrackingArrayPool();
+            var exchange = CreateChunkedRequest(source, destination);
+            var processor = CreateProcessor(pool);
+            using var buffer = ResizableBuffer.Allocate(1024);
+            using var scope = new ExchangeScope();
+
+            var actual = await Assert.ThrowsAsync<IOException>(
+                () => processor.Process(exchange, buffer, scope, CancellationToken.None).AsTask());
+
+            Assert.Same(expected, actual);
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.Equal(0, destination.DisposeCount);
+        }
+
+        [Fact]
+        public async Task RequestCancellation_ReturnsChunkBufferWithoutClosingTransport()
+        {
+            var source = new SegmentThenTerminalStream("request"u8.ToArray());
+            var destination = new TrackingMemoryStream();
+            var pool = new TrackingArrayPool();
+            var exchange = CreateChunkedRequest(source, destination);
+            var processor = CreateProcessor(pool);
+            using var buffer = ResizableBuffer.Allocate(1024);
+            using var scope = new ExchangeScope();
+            using var cancellation = new CancellationTokenSource();
+
+            var processing = processor.Process(exchange, buffer, scope, cancellation.Token).AsTask();
+            await source.WaitingForTerminalRead.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal(0, pool.ReturnCount);
+
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await processing);
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.Equal(0, destination.DisposeCount);
+        }
+
+        [Fact]
+        public async Task DelayedResponseWriteFailure_ReturnsBufferOnlyAfterWriteCompletes()
+        {
+            var expected = new IOException("destination write failed");
+            var destination = new DelayedFailureStream();
+            var pool = new TrackingArrayPool();
+            var pipe = CreateDownStreamPipe(destination, pool);
+            using var buffer = ResizableBuffer.Allocate(1024);
+
+            var writing = pipe.WriteResponseBody(
+                new MemoryStream("response"u8.ToArray()), buffer, true, 0, new Response(),
+                CancellationToken.None).AsTask();
+            await destination.WriteStarted.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(0, pool.ReturnCount);
+            Assert.Equal(0, destination.DisposeCount);
+
+            destination.Fail(expected);
+            var actual = await Assert.ThrowsAsync<IOException>(async () => await writing);
+
+            Assert.Same(expected, actual);
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.Equal(0, destination.DisposeCount);
+
+            pipe.Dispose();
+            Assert.Equal(1, destination.DisposeCount);
+        }
+
+        [Fact]
+        public async Task SuccessfulResponseEofAndTrailers_ReturnBufferExactlyOnce()
+        {
+            var destination = new TrackingMemoryStream();
+            var pool = new TrackingArrayPool();
+            var pipe = CreateDownStreamPipe(destination, pool);
+            using var buffer = ResizableBuffer.Allocate(1024);
+            var response = new Response {
+                Trailers = new List<HeaderField> { new("x-check", "yes") }
+            };
+
+            await pipe.WriteResponseBody(
+                new MemoryStream("response"u8.ToArray()), buffer, true, 0, response,
+                CancellationToken.None);
+
+            Assert.Equal(
+                "8\r\nresponse\r\n0\r\nx-check: yes\r\n\r\n"u8.ToArray(),
+                destination.ToArray());
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.Equal(0, destination.DisposeCount);
+
+            pipe.Dispose();
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.Equal(1, destination.DisposeCount);
+        }
+
+        [Fact]
+        public async Task BufferReturn_ClearsEntireStagedHighWaterRangeExactlyOnce()
+        {
+            var destination = new MemoryStream();
+            var pool = new TrackingArrayPool(fill: 0xA5);
+            var chunked = new ChunkedTransferWriteStream(destination, pool);
+            var largePayload = new byte[4096];
+            Array.Fill(largePayload, (byte) 0x5A);
+
+            await chunked.WriteAsync(largePayload);
+            await chunked.WriteAsync("x"u8.ToArray());
+            await chunked.WriteEof();
+            chunked.Dispose();
+
+            const int largestFrameLength = 6 + 4096 + 2;
+            Assert.Equal(1, pool.ReturnCount);
+            Assert.All(pool.Buffer.AsSpan(0, largestFrameLength).ToArray(), value => Assert.Equal(0, value));
+            Assert.Equal(0xA5, pool.Buffer[largestFrameLength]);
+        }
+
+        private static Http11PoolProcessing CreateProcessor(ArrayPool<byte> pool)
+            => new(
+                TimeSpan.Zero,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan,
+                chunkBufferPool: pool);
+
+        private static Exchange CreateChunkedRequest(Stream source, Stream destination)
+        {
+            var authority = new Authority("test.local", 80, false);
+            var exchange = new Exchange(
+                IIdProvider.FromZero,
+                authority,
+                "POST / HTTP/1.1\r\nHost: test.local\r\nTransfer-Encoding: chunked\r\n\r\n".AsMemory(),
+                "HTTP/1.1",
+                DateTime.UtcNow) {
+                Connection = new Connection(authority, IIdProvider.FromZero) {
+                    ReadStream = Stream.Null,
+                    WriteStream = destination
+                }
+            };
+            exchange.Request.Body = source;
+            return exchange;
+        }
+
+        private static Http11DownStreamPipe CreateDownStreamPipe(Stream destination, ArrayPool<byte> pool)
+            => new(
+                IIdProvider.FromZero,
+                new Authority("test.local", 80, false),
+                Stream.Null,
+                destination,
+                contextBuilder: null!,
+                chunkBufferPool: pool);
+
+        private sealed class TrackingArrayPool : ArrayPool<byte>
+        {
+            public TrackingArrayPool(byte fill = 0)
+            {
+                Buffer = new byte[128 * 1024];
+                Array.Fill(Buffer, fill);
+            }
+
+            public byte[] Buffer { get; }
+
+            public int RentCount { get; private set; }
+
+            public int ReturnCount { get; private set; }
+
+            public override byte[] Rent(int minimumLength)
+            {
+                if (minimumLength > Buffer.Length)
+                    throw new InvalidOperationException("Test pool buffer is too small.");
+
+                RentCount++;
+                return Buffer;
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                if (!ReferenceEquals(Buffer, array))
+                    throw new InvalidOperationException("Unexpected buffer returned.");
+
+                ReturnCount++;
+            }
+        }
+
+        private sealed class TrackingMemoryStream : MemoryStream
+        {
+            public int DisposeCount { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                    DisposeCount++;
+
+                base.Dispose(disposing);
+            }
+        }
+
+        private sealed class DelayedFailureStream : Stream
+        {
+            private readonly TaskCompletionSource _writeStarted =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _writeCompletion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task WriteStarted => _writeStarted.Task;
+
+            public int DisposeCount { get; private set; }
+
+            public void Fail(Exception exception) => _writeCompletion.SetException(exception);
+
+            public override ValueTask WriteAsync(
+                ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                _writeStarted.TrySetResult();
+                return new ValueTask(_writeCompletion.Task);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                    DisposeCount++;
+
+                base.Dispose(disposing);
+            }
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class SegmentThenTerminalStream : Stream
+        {
+            private readonly byte[] _segment;
+            private readonly Exception? _terminalException;
+            private readonly TaskCompletionSource _waitingForTerminalRead =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private bool _segmentRead;
+
+            public SegmentThenTerminalStream(byte[] segment, Exception? terminalException = null)
+            {
+                _segment = segment;
+                _terminalException = terminalException;
+            }
+
+            public Task WaitingForTerminalRead => _waitingForTerminalRead.Task;
+
+            public override ValueTask<int> ReadAsync(
+                Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!_segmentRead) {
+                    _segmentRead = true;
+                    _segment.CopyTo(buffer);
+                    return ValueTask.FromResult(_segment.Length);
+                }
+
+                _waitingForTerminalRead.TrySetResult();
+                return _terminalException != null
+                    ? ValueTask.FromException<int>(_terminalException)
+                    : WaitForCancellation(cancellationToken);
+            }
+
+            private static async ValueTask<int> WaitForCancellation(CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return 0;
+            }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferWriteStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/ChunkedTransferWriteStreamTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class ChunkedTransferWriteStreamTests
+    {
+        [Fact]
+        public async Task SequentialWrites_EmitValidChunkFrames()
+        {
+            await using var destination = new MemoryStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+
+            chunked.Write("hello"u8.ToArray());
+            await chunked.WriteAsync(new byte[16], CancellationToken.None);
+            await chunked.WriteEof();
+
+            var expected = "5\r\nhello\r\n10\r\n" + new string('\0', 16) + "\r\n0\r\n\r\n";
+            Assert.Equal(expected, Encoding.ASCII.GetString(destination.ToArray()));
+        }
+
+        [Fact]
+        public async Task WriteAsync_StagesChunkIntoOneInnerWrite()
+        {
+            await using var destination = new CountingWriteStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+
+            await chunked.WriteAsync(new byte[16 * 1024]);
+
+            Assert.Equal(1, destination.AsyncWrites);
+            Assert.Equal(16 * 1024 + "4000\r\n\r\n"u8.Length, destination.Length);
+        }
+
+        [Theory]
+        [InlineData(64 * 1024, 1)]
+        [InlineData(64 * 1024 + 1, 3)]
+        public async Task StagingBoundary_UsesExpectedInnerWriteCount(int payloadLength, int expectedWrites)
+        {
+            await using var destination = new CountingWriteStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+
+            await chunked.WriteAsync(new byte[payloadLength]);
+
+            Assert.Equal(expectedWrites, destination.AsyncWrites);
+        }
+
+        [Fact]
+        public void Write_StagesChunkIntoOneInnerWrite()
+        {
+            using var destination = new CountingWriteStream();
+            using var chunked = new ChunkedTransferWriteStream(destination);
+
+            chunked.Write(new byte[16 * 1024], 0, 16 * 1024);
+
+            Assert.Equal(1, destination.SyncWrites);
+            Assert.Equal(16 * 1024 + "4000\r\n\r\n"u8.Length, destination.Length);
+        }
+
+        [Fact]
+        public void WriteSpan_StagesValidChunkIntoOneInnerWrite()
+        {
+            using var destination = new CountingWriteStream();
+            using var chunked = new ChunkedTransferWriteStream(destination);
+
+            chunked.Write("span"u8);
+
+            Assert.Equal(1, destination.SyncWrites);
+            Assert.Equal("4\r\nspan\r\n"u8.ToArray(), destination.ToArray());
+        }
+
+        [Fact]
+        public async Task ReusedBuffer_DoesNotLeakPreviousHeader()
+        {
+            await using var destination = new MemoryStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+
+            await chunked.WriteAsync(new byte[0x10000]);
+            await chunked.WriteAsync("x"u8.ToArray());
+            await chunked.WriteEof();
+
+            var bytes = destination.ToArray();
+            var secondHeaderOffset = "10000\r\n"u8.Length + 0x10000 + 2;
+            Assert.Equal("1\r\nx\r\n0\r\n\r\n"u8.ToArray(), bytes[secondHeaderOffset..]);
+        }
+
+        [Fact]
+        public async Task EmptyWrite_DoesNotEmitFinalChunk()
+        {
+            await using var destination = new MemoryStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+
+            chunked.Write(Array.Empty<byte>(), 0, 0);
+            chunked.Write(ReadOnlySpan<byte>.Empty);
+            await chunked.WriteAsync(Array.Empty<byte>(), 0, 0, CancellationToken.None);
+            await chunked.WriteAsync(ReadOnlyMemory<byte>.Empty);
+            await chunked.WriteEof();
+
+            Assert.Equal("0\r\n\r\n"u8.ToArray(), destination.ToArray());
+        }
+
+        [Fact]
+        public void EmptyArrayWrite_StillValidatesArguments()
+        {
+            using var destination = new CountingWriteStream();
+            using var chunked = new ChunkedTransferWriteStream(destination);
+
+            Assert.Throws<ArgumentNullException>(() => chunked.Write(null!, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => chunked.Write(Array.Empty<byte>(), -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => chunked.Write(Array.Empty<byte>(), 0, -1));
+            Assert.ThrowsAny<ArgumentException>(() => chunked.Write(Array.Empty<byte>(), 0, 1));
+            Assert.Equal(0, destination.SyncWrites);
+        }
+
+        [Fact]
+        public async Task EmptyAsyncWrites_HonorAlreadyCancelledToken()
+        {
+            await using var destination = new CountingWriteStream();
+            await using var chunked = new ChunkedTransferWriteStream(destination);
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => chunked.WriteAsync(Array.Empty<byte>(), 0, 0, cancellation.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await chunked.WriteAsync(ReadOnlyMemory<byte>.Empty, cancellation.Token));
+            Assert.Equal(0, destination.AsyncWrites);
+        }
+
+        private sealed class CountingWriteStream : MemoryStream
+        {
+            public int AsyncWrites { get; private set; }
+
+            public int SyncWrites { get; private set; }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                SyncWrites++;
+                base.Write(buffer, offset, count);
+            }
+
+            public override ValueTask WriteAsync(
+                ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                AsyncWrites++;
+                return base.WriteAsync(buffer, cancellationToken);
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/CombinedReadonlyStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/CombinedReadonlyStreamTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class CombinedReadonlyStreamTests
+    {
+        [Fact]
+        public async Task ReadAsync_MemoryOverload_PreservesPrefixAndPartialInnerReads()
+        {
+            var prefix = Encoding.ASCII.GetBytes("prefix-");
+            using var inner = new AsyncMemoryReadStream(
+                Encoding.ASCII.GetBytes("inner"), maximumReadSize: 2);
+            await using var stream = new CombinedReadonlyStream(false, prefix, inner);
+            var buffer = new byte[16];
+
+            var prefixRead = await stream.ReadAsync(buffer.AsMemory());
+            Assert.Equal(prefix.Length, prefixRead);
+            Assert.Equal("prefix-", Encoding.ASCII.GetString(buffer, 0, prefixRead));
+            Assert.Equal(prefix.Length, stream.Position);
+
+            var firstInnerRead = await stream.ReadAsync(buffer.AsMemory());
+            Assert.Equal(2, firstInnerRead);
+            Assert.Equal("in", Encoding.ASCII.GetString(buffer, 0, firstInnerRead));
+
+            var secondInnerRead = await stream.ReadAsync(buffer.AsMemory());
+            Assert.Equal(2, secondInnerRead);
+            Assert.Equal("ne", Encoding.ASCII.GetString(buffer, 0, secondInnerRead));
+
+            var finalInnerRead = await stream.ReadAsync(buffer.AsMemory());
+            Assert.Equal(1, finalInnerRead);
+            Assert.Equal("r", Encoding.ASCII.GetString(buffer, 0, finalInnerRead));
+
+            Assert.Equal(0, await stream.ReadAsync(buffer.AsMemory()));
+            Assert.Equal(prefix.Length + 5, stream.Position);
+            Assert.Equal(4, inner.MemoryReadCount);
+        }
+
+        [Fact]
+        public async Task ReadAsync_ArrayOverload_DelegatesToMemoryOverload()
+        {
+            using var inner = new AsyncMemoryReadStream(Encoding.ASCII.GetBytes("inner"));
+            await using var stream = new CombinedReadonlyStream(false, inner);
+            var buffer = new byte[8];
+
+            var read = await stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
+
+            Assert.Equal(5, read);
+            Assert.Equal("inner", Encoding.ASCII.GetString(buffer, 0, read));
+            Assert.Equal(1, inner.MemoryReadCount);
+        }
+
+        [Fact]
+        public async Task ReadAsync_ForwardsCancellationAfterPooledPrefix()
+        {
+            var prefix = Encoding.ASCII.GetBytes("prefix");
+            using var inner = new AsyncMemoryReadStream(Encoding.ASCII.GetBytes("inner"));
+            await using var stream = new CombinedReadonlyStream(false, prefix, inner);
+            var buffer = new byte[16];
+            using var cancellation = new CancellationTokenSource();
+
+            cancellation.Cancel();
+            Assert.Equal(prefix.Length, await stream.ReadAsync(buffer.AsMemory(), cancellation.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await stream.ReadAsync(buffer.AsMemory(), cancellation.Token));
+
+            Assert.Equal(prefix.Length, stream.Position);
+            Assert.Equal(0, inner.MemoryReadCount);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ReadAsync_EofHonorsInnerStreamOwnership(bool closeStreams)
+        {
+            var inner = new AsyncMemoryReadStream(Encoding.ASCII.GetBytes("inner"));
+            await using (var stream = new CombinedReadonlyStream(closeStreams, inner)) {
+                var buffer = new byte[8];
+
+                Assert.Equal(5, await stream.ReadAsync(buffer.AsMemory()));
+                Assert.Equal(0, await stream.ReadAsync(buffer.AsMemory()));
+                Assert.Equal(closeStreams, inner.IsDisposed);
+            }
+
+            Assert.Equal(closeStreams, inner.IsDisposed);
+            inner.Dispose();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DisposeAsync_HonorsInnerStreamOwnership(bool closeStreams)
+        {
+            var inner = new AsyncMemoryReadStream(Encoding.ASCII.GetBytes("inner"), maximumReadSize: 1);
+            var stream = new CombinedReadonlyStream(closeStreams, inner);
+
+            Assert.Equal(1, await stream.ReadAsync(new byte[1].AsMemory()));
+            await stream.DisposeAsync();
+
+            Assert.Equal(closeStreams, inner.IsDisposed);
+            inner.Dispose();
+        }
+
+        private sealed class AsyncMemoryReadStream : Stream
+        {
+            private readonly byte[] _content;
+            private readonly int _maximumReadSize;
+            private int _position;
+
+            public AsyncMemoryReadStream(byte[] content, int maximumReadSize = int.MaxValue)
+            {
+                _content = content;
+                _maximumReadSize = maximumReadSize;
+            }
+
+            public bool IsDisposed { get; private set; }
+
+            public int MemoryReadCount { get; private set; }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => _position;
+                set => throw new NotSupportedException();
+            }
+
+            public override async ValueTask<int> ReadAsync(
+                Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                MemoryReadCount++;
+                await Task.Yield();
+
+                var read = Math.Min(Math.Min(buffer.Length, _maximumReadSize), _content.Length - _position);
+                _content.AsMemory(_position, read).CopyTo(buffer);
+                _position += read;
+
+                return read;
+            }
+
+            public override Task<int> ReadAsync(
+                byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                throw new InvalidOperationException("The array ReadAsync overload must not be used.");
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) {
+                    IsDisposed = true;
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/StreamExtensionsCopyDetailedTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/StreamExtensionsCopyDetailedTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Misc.Streams;
@@ -44,6 +45,57 @@ namespace Fluxzy.Tests.UnitTests.Misc
                         flushAfterEachWrite: false,
                         CancellationToken.None),
                 expectedFlushCount: 0);
+        }
+
+        [Fact]
+        public async Task CopyDetailed_BufferOverload_UsesMemoryAsyncVirtuals()
+        {
+            var payload = Encoding.ASCII.GetBytes("memory-only");
+            using var source = new MemoryOnlyReadStream(payload, maximumReadSize: 3);
+            using var destination = new MemoryOnlyWriteStream();
+            var copiedBytes = 0;
+
+            var totalCopied = await source.CopyDetailed(
+                destination,
+                new byte[4],
+                copied => copiedBytes += copied,
+                flushAfterEachWrite: false,
+                CancellationToken.None);
+
+            Assert.Equal(payload.Length, totalCopied);
+            Assert.Equal(payload.Length, copiedBytes);
+            Assert.Equal(payload, destination.ToArray());
+            Assert.True(source.MemoryReadCount > 0);
+            Assert.True(destination.MemoryWriteCount > 0);
+        }
+
+        [Fact]
+        public async Task CopyDetailed_UsesMemoryAsyncVirtualsThroughHttp11StreamWrappers()
+        {
+            var prefix = Encoding.ASCII.GetBytes("pre-");
+            var payload = Encoding.ASCII.GetBytes("payload");
+            using var inner = new MemoryOnlyReadStream(payload, maximumReadSize: 2);
+            using var pushback = new PushbackReadStream(inner);
+            pushback.Push(prefix);
+            using var bounded = new ContentBoundStream(pushback, prefix.Length + payload.Length);
+            using var dispatched = new MemoryOnlyWriteStream();
+            using var dispatch = new DispatchStream(bounded, closeOnDone: false, dispatched);
+            using var source = new RecomposedStream(dispatch, Stream.Null);
+            using var destination = new MemoryOnlyWriteStream();
+
+            var totalCopied = await source.CopyDetailed(
+                destination,
+                new byte[3],
+                _ => { },
+                flushAfterEachWrite: false,
+                CancellationToken.None);
+
+            var expected = Encoding.ASCII.GetBytes("pre-payload");
+            Assert.Equal(expected.Length, totalCopied);
+            Assert.Equal(expected, destination.ToArray());
+            Assert.Equal(expected, dispatched.ToArray());
+            Assert.Equal(expected.Length, bounded.TotalRead);
+            Assert.True(inner.MemoryReadCount > 0);
         }
 
         private static async Task VerifyFlushBehavior(
@@ -116,6 +168,107 @@ namespace Fluxzy.Tests.UnitTests.Misc
             {
                 TotalWritten += buffer.Length;
                 return ValueTask.CompletedTask;
+            }
+        }
+
+        private sealed class MemoryOnlyReadStream : Stream
+        {
+            private readonly byte[] _content;
+            private readonly int _maximumReadSize;
+            private int _position;
+
+            public MemoryOnlyReadStream(byte[] content, int maximumReadSize)
+            {
+                _content = content;
+                _maximumReadSize = maximumReadSize;
+            }
+
+            public int MemoryReadCount { get; private set; }
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => _position;
+                set => throw new NotSupportedException();
+            }
+
+            public override ValueTask<int> ReadAsync(
+                Memory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                MemoryReadCount++;
+
+                var read = Math.Min(Math.Min(buffer.Length, _maximumReadSize), _content.Length - _position);
+                _content.AsMemory(_position, read).CopyTo(buffer);
+                _position += read;
+
+                return new ValueTask<int>(read);
+            }
+
+            public override Task<int> ReadAsync(
+                byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                throw new InvalidOperationException("The array ReadAsync overload must not be used.");
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        }
+
+        private sealed class MemoryOnlyWriteStream : Stream
+        {
+            private readonly MemoryStream _content = new();
+
+            public int MemoryWriteCount { get; private set; }
+
+            public byte[] ToArray() => _content.ToArray();
+
+            public override bool CanRead => false;
+            public override bool CanSeek => false;
+            public override bool CanWrite => true;
+            public override long Length => _content.Length;
+            public override long Position {
+                get => _content.Position;
+                set => throw new NotSupportedException();
+            }
+
+            public override ValueTask WriteAsync(
+                ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                MemoryWriteCount++;
+                _content.Write(buffer.Span);
+
+                return ValueTask.CompletedTask;
+            }
+
+            public override Task WriteAsync(
+                byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                throw new InvalidOperationException("The array WriteAsync overload must not be used.");
+            }
+
+            public override void Flush()
+            {
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) {
+                    _content.Dispose();
+                }
+
+                base.Dispose(disposing);
             }
         }
     }


### PR DESCRIPTION
## Problem

HTTP/1.1 body forwarding uses array-based stream APIs even when both streams support `Memory<byte>`, creating adapter tasks and temporary arrays. Chunked forwarding additionally emits a separate chunk frame for each source write, multiplying transport writes and flushes for large transfers.

## Solution

Move the shared copy paths to memory-based virtual stream APIs while preserving byte-array compatibility. Coalesce each chunked payload into a pooled frame of at most 64 KiB and write the chunk header, payload, and terminator together.

The chunk writer owns its rental only for its lifetime, clears staged bytes through the high-water mark, returns the buffer exactly once on success/failure/cancellation, and leaves the underlying transport open.

## Benefits

- 16 MiB chunked upload throughput improved 26.1%; CPU fell 37.2% and allocation fell 53.5%.
- 16 MiB chunked download throughput improved 38.9%; CPU fell 31.7% and allocation fell 54.8%.
- Fixed-length 16 MiB upload/download allocation fell 55.5% and 53.4%; throughput remained within run-to-run variation.
- All exact-body and hash checks passed.

## Changes

- Use memory-based `ReadAsync` and `WriteAsync` paths in H1 copying wrappers.
- Preserve array overload behavior for existing callers.
- Coalesce chunk frames in a bounded pooled buffer.
- Add deterministic ownership, cancellation, failure, framing, and exact-content tests.

## Verification

- Release test-project build completed with zero errors.
- 27 focused stream, chunking, and ownership tests passed.
- 64 initial alternating samples covered fixed/chunked upload/download at 1 MiB and 16 MiB.
- 16 additional 16 MiB chunked samples tightened the primary throughput result.
- Every one of the 80 samples validated HTTP/1.1, framing mode, exact length, and SHA-256.

## Line Count

| Category | Additions | Removals | Net |
|---|---:|---:|---:|
| Documentation | 0 | 0 | 0 |
| Configuration | 0 | 0 | 0 |
| Runtime | 170 | 54 | +116 |
| Tests | 794 | 0 | +794 |
| **Total** | **964** | **54** | **+910** |

Generated or vendored content: none.
