### PR TITLE
Fix event writer body dispatch

### DIFF
--- a/src/Fluxzy.Core/Archiving/Writers/EventOnlyArchiveWriter.cs
+++ b/src/Fluxzy.Core/Archiving/Writers/EventOnlyArchiveWriter.cs
@@ -10,6 +10,8 @@ namespace Fluxzy.Writers
 {
     public class EventOnlyArchiveWriter : RealtimeArchiveWriter
     {
+        public override bool CapturesBodyContent => false;
+
         public override void UpdateTags(IEnumerable<Tag> tags)
         {
         }

--- a/src/Fluxzy.Core/Archiving/Writers/RealtimeArchiveWriter.cs
+++ b/src/Fluxzy.Core/Archiving/Writers/RealtimeArchiveWriter.cs
@@ -23,6 +23,11 @@ namespace Fluxzy.Writers
         /// </summary>
         public long TotalProcessedExchanges => InternalTotalProcessedExchanges;
 
+        /// <summary>
+        /// Gets whether request and response body content must be dispatched to this writer.
+        /// </summary>
+        public virtual bool CapturesBodyContent => true;
+
         public virtual void Init()
         {
         }

--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -685,8 +685,11 @@ namespace Fluxzy.Core
 
                 if (booked == 0)
                 {
-                    // stream closed
-                    return;
+                    // WindowSizeHolder reports cancellation as a zero-sized booking.
+                    // Returning normally here would let the orchestrator publish
+                    // AfterResponse for a body that never reached EOF/END_STREAM.
+                    token.ThrowIfCancellationRequested();
+                    throw new IOException("HTTP/2 stream closed before the response body completed.");
                 }
 
                 var bodySize = Math.Min(booked, remoteMaxFrameSize);

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -477,6 +477,7 @@ namespace Fluxzy.Core
 
                 Stream? originalRequestBodyStream = null;
                 Stream? originalResponseBodyStream = null;
+                var requestBodyWrapped = false;
 
                 try
                 {
@@ -520,6 +521,8 @@ namespace Fluxzy.Core
                             exchange.Request.Body = new DispatchStream(exchange.Request.Body!,
                                 true,
                                 _archiveWriter.CreateRequestBodyStream(exchange.Id));
+
+                            requestBodyWrapped = true;
                         }
                     }
 
@@ -573,9 +576,16 @@ namespace Fluxzy.Core
                         }
                         finally
                         {
-                            // We close the request body dispatchstream
-                            await SafeCloseRequestBody(exchange, originalRequestBodyStream)
-                                .ConfigureAwait(false);
+                            // We close the request body dispatchstream.
+                            // DispatchStream leaves its base stream open. Without a
+                            // wrapper the body is the raw downstream stream and a full
+                            // duplex exchange may still be streaming it upstream, so
+                            // it is closed later with the response.
+                            if (requestBodyWrapped)
+                            {
+                                await SafeCloseRequestBody(exchange, originalRequestBodyStream)
+                                    .ConfigureAwait(false);
+                            }
                         }
 
                         break;
@@ -796,11 +806,11 @@ namespace Fluxzy.Core
                     }
                     else
                     {
+                        await SafeCloseRequestBody(exchange, originalRequestBodyStream)
+                            .ConfigureAwait(false);
+
                         if (responseBodyStream != null)
                         {
-                            await SafeCloseRequestBody(exchange, originalRequestBodyStream)
-                                .ConfigureAwait(false);
-
                             await SafeCloseResponseBody(exchange, originalResponseBodyStream)
                                 .ConfigureAwait(false);
                         }

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -512,7 +512,8 @@ namespace Fluxzy.Core
                             exchange.Request.Header.ForceTransferChunked();
                         }
 
-                        if (exchange.Request.Body != null &&
+                        if (_archiveWriter.CapturesBodyContent &&
+                            exchange.Request.Body != null &&
                             (!exchange.Request.Body.CanSeek ||
                              exchange.Request.Body.Length > 0))
                         {
@@ -678,45 +679,29 @@ namespace Fluxzy.Core
                         _archiveWriter.Update(exchange, ArchiveUpdateType.AfterResponseHeader,
                             CancellationToken.None
                         );
+                    }
 
-                        if (responseBodyStream != null && (!responseBodyStream.CanSeek || responseBodyStream.Length > 0))
+                    if (responseBodyStream != null && (!responseBodyStream.CanSeek || responseBodyStream.Length > 0))
+                    {
+                        if (exchange.Context.HasResponseBodySubstitution)
                         {
-                            if (exchange.Context.HasResponseBodySubstitution)
-                            {
-                                originalResponseBodyStream = responseBodyStream;
+                            originalResponseBodyStream = responseBodyStream;
 
-                                responseBodyStream = await
-                                    exchange.Context.GetSubstitutedResponseBody(
-                                                responseBodyStream, responseBodyChunked, responseEncodingToken)
-                                            .ConfigureAwait(false);
-                            }
+                            responseBodyStream = await
+                                exchange.Context.GetSubstitutedResponseBody(
+                                            responseBodyStream, responseBodyChunked, responseEncodingToken)
+                                        .ConfigureAwait(false);
+                            exchange.Response.Body = responseBodyStream;
+                        }
 
+                        if (_archiveWriter?.CapturesBodyContent == true)
+                        {
                             var dispatchStream = new DispatchStream(responseBodyStream,
                                 true,
                                 _archiveWriter.CreateResponseBodyStream(exchange.Id));
 
-                            var ext = exchange;
-
-                            dispatchStream.OnDisposeDoneTask = () => {
-                                _archiveWriter.Update(ext,
-                                    ArchiveUpdateType.AfterResponse,
-                                    CancellationToken.None
-                                );
-
-                                return default;
-                            };
-
                             exchange.Response.Body = dispatchStream;
                             responseBodyStream = dispatchStream;
-                        }
-                        else
-                        {
-                            // No response body, we ensure the stream is done
-
-                            _archiveWriter.Update(exchange,
-                                ArchiveUpdateType.AfterResponse,
-                                CancellationToken.None
-                            );
                         }
                     }
 
@@ -805,6 +790,11 @@ namespace Fluxzy.Core
                                 .ConfigureAwait(false);
                         }
                     }
+
+                    _archiveWriter?.Update(exchange,
+                        ArchiveUpdateType.AfterResponse,
+                        CancellationToken.None
+                    );
 
                     // In case the down stream connection is persisted, 
                     // we wait for the current exchange to complete before reading further request

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -720,8 +720,10 @@ namespace Fluxzy.Core
 
                         if (ex is OperationCanceledException || ex is IOException)
 
-                        // local browser interrupt connection 
+                        // local browser interrupt connection
                         {
+                            CompleteWithClientError(exchange, ex);
+
                             return shouldCloseConnectionToDownStream;
                         }
 
@@ -731,6 +733,8 @@ namespace Fluxzy.Core
                     if (exchange.Response.Header!.ContentLength != 0 &&
                         responseBodyStream != null)
                     {
+                        Exception? forwardingError = null;
+
                         try
                         {
                             var chunked = exchange.Response.Header.ChunkedBody &&
@@ -765,10 +769,14 @@ namespace Fluxzy.Core
                                     }
                                 }
 
-                                return true;
+                                // Defer the terminal update until the finally block
+                                // has flushed and closed the body streams.
+                                forwardingError = ex;
                             }
-
-                            throw;
+                            else
+                            {
+                                throw;
+                            }
                         }
                         finally
                         {
@@ -777,6 +785,13 @@ namespace Fluxzy.Core
 
                             await SafeCloseResponseBody(exchange, originalResponseBodyStream)
                                 .ConfigureAwait(false);
+                        }
+
+                        if (forwardingError != null)
+                        {
+                            CompleteWithClientError(exchange, forwardingError);
+
+                            return true;
                         }
                     }
                     else
@@ -817,6 +832,35 @@ namespace Fluxzy.Core
             }
 
             return shouldCloseConnectionToDownStream;
+        }
+
+        /// <summary>
+        /// Publishes the terminal update for an exchange whose response could not be
+        /// fully forwarded downstream. ClientErrors marks the exchange as failed so
+        /// consumers do not mistake this AfterResponse for a successful completion.
+        /// </summary>
+        private void CompleteWithClientError(Exchange exchange, Exception ex)
+        {
+            if (exchange.ClientErrors.Count == 0)
+            {
+                var networkErrorCode = ConnectionErrorHandler.ResolveNetworkErrorCode(ex);
+
+                if (networkErrorCode == NetworkErrorCodes.Unknown)
+                {
+                    networkErrorCode = NetworkErrorCodes.ConnectionAborted;
+                }
+
+                exchange.ClientErrors.Add(new ClientError(0,
+                    "The exchange was interrupted before the response was fully forwarded to the client.",
+                    networkErrorCode) {
+                    ExceptionMessage = ex.Message
+                });
+            }
+
+            _archiveWriter?.Update(exchange,
+                ArchiveUpdateType.AfterResponse,
+                CancellationToken.None
+            );
         }
 
         private static ValueTask SafeCloseRequestBody(Exchange exchange, Stream? substitutionStream)

--- a/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
@@ -190,7 +190,11 @@ namespace Fluxzy.Misc.Streams
         {
             base.Dispose(disposing);
 
-            if (_expectedLength != null && _expectedLength >= TotalRead)
+            // Notify only when the body was fully read. A partially read body
+            // must not report a successful final read: the completion callback
+            // marks the exchange reusable and the connection pool would recycle
+            // a connection still carrying unread body bytes.
+            if (_expectedLength != null && TotalRead >= _expectedLength)
             {
                 NotifyFinalRead();
             }

--- a/test/Fluxzy.Tests/Cases/ExportCertificateInSslInfoIntegrationTests.cs
+++ b/test/Fluxzy.Tests/Cases/ExportCertificateInSslInfoIntegrationTests.cs
@@ -282,7 +282,10 @@ namespace Fluxzy.Tests.Cases
             await Task.Delay(200);
 
             // Assert
-            Assert.Equal(3, exchanges.Count);
+            // Each request may traverse redirects, producing intermediate
+            // exchanges. Every terminal 200 must be present and every
+            // completed exchange must carry the certificate.
+            Assert.Equal(3, exchanges.Count(x => x.Response.Header?.StatusCode == 200));
 
             foreach (var exchange in exchanges)
             {

--- a/test/Fluxzy.Tests/UnitTests/Events/EventWriterBodyDispatchTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Events/EventWriterBodyDispatchTests.cs
@@ -105,7 +105,7 @@ public class EventWriterBodyDispatchTests
     }
 
     [Fact]
-    public async Task DefaultWriter_DoesNotCompleteFaultedResponse()
+    public async Task DefaultWriter_CompletesFaultedResponseWithClientError()
     {
         await using var setup = await ProxiedHostSetup.Create(
             setting => setting.AddAlterationRulesForAny(
@@ -113,7 +113,8 @@ public class EventWriterBodyDispatchTests
             app => app.MapGet("/fault", () => "original-response"));
 
         var faultedExchangeId = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completedIds = new ConcurrentBag<int>();
+        var completed = new ConcurrentDictionary<int, int>();
+        var faultedCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
         {
@@ -122,14 +123,21 @@ public class EventWriterBodyDispatchTests
                 faultedExchangeId.TrySetResult(args.Original.Id);
 
             if (args.UpdateType == ArchiveUpdateType.AfterResponse)
-                completedIds.Add(args.Original.Id);
+            {
+                completed[args.Original.Id] = args.Original.ClientErrors.Count;
+                if (faultedExchangeId.Task.IsCompleted && args.Original.Id == faultedExchangeId.Task.Result)
+                    faultedCompleted.TrySetResult();
+            }
         };
 
         await Assert.ThrowsAnyAsync<HttpRequestException>(() => setup.Client.GetAsync("/fault"));
         var faultedId = await faultedExchangeId.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await faultedCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-        Assert.DoesNotContain(faultedId, completedIds);
-        Assert.Equal(0, setup.Proxy.Writer.TotalProcessedExchanges);
+        // The faulted exchange gets exactly one terminal event, flagged as a client error
+        Assert.True(completed.TryGetValue(faultedId, out var clientErrorCount));
+        Assert.True(clientErrorCount > 0);
+        Assert.Equal(1, setup.Proxy.Writer.TotalProcessedExchanges);
     }
 
     [Fact]
@@ -174,7 +182,8 @@ public class EventWriterBodyDispatchTests
         });
 
         var cancelledExchangeId = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completedIds = new ConcurrentBag<int>();
+        var completed = new ConcurrentDictionary<int, int>();
+        var cancelledCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
         {
@@ -183,7 +192,11 @@ public class EventWriterBodyDispatchTests
                 cancelledExchangeId.TrySetResult(args.Original.Id);
 
             if (args.UpdateType == ArchiveUpdateType.AfterResponse)
-                completedIds.Add(args.Original.Id);
+            {
+                completed[args.Original.Id] = args.Original.ClientErrors.Count;
+                if (cancelledExchangeId.Task.IsCompleted && args.Original.Id == cancelledExchangeId.Task.Result)
+                    cancelledCompleted.TrySetResult();
+            }
         };
 
         using (var response = await setup.Client.GetAsync("/cancel", HttpCompletionOption.ResponseHeadersRead))
@@ -197,8 +210,11 @@ public class EventWriterBodyDispatchTests
 
         Assert.Equal("ok", await setup.Client.GetStringAsync("/barrier"));
 
-        Assert.DoesNotContain(cancelledId, completedIds);
-        Assert.Equal(1, setup.Proxy.Writer.TotalProcessedExchanges);
+        // The aborted exchange still gets a terminal event, flagged as a client error
+        await cancelledCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(completed.TryGetValue(cancelledId, out var clientErrorCount));
+        Assert.True(clientErrorCount > 0);
+        Assert.Equal(2, setup.Proxy.Writer.TotalProcessedExchanges);
     }
 
     [Fact]

--- a/test/Fluxzy.Tests/UnitTests/Events/EventWriterBodyDispatchTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Events/EventWriterBodyDispatchTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Tests._Fixtures;
+using Fluxzy.Tests.UnitTests.Substitutions.Actions;
+using Fluxzy.Writers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Events;
+
+public class EventWriterBodyDispatchTests
+{
+    [Fact]
+    public void Writers_DeclareWhetherTheyCaptureBodyContent()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"fluxzy-writer-{Guid.NewGuid():N}");
+
+        try
+        {
+            Assert.False(new EventOnlyArchiveWriter().CapturesBodyContent);
+            Assert.True(new DirectoryArchiveWriter(directory, null).CapturesBodyContent);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    [Fact]
+    public async Task DefaultWriter_CompletesOnceAfterSuccessfulBodyForwarding()
+    {
+        var requestBody = Encoding.UTF8.GetBytes("request-body");
+        var responseBody = Enumerable.Range(0, 8192).Select(i => (byte) (i % 251)).ToArray();
+        var requestReceived = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstResponseHalfSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponse = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var setup = await ProxiedHostSetup.Create(configureRoutes: app =>
+        {
+            app.MapPost("/success", async context =>
+            {
+                using var request = new MemoryStream();
+                await context.Request.Body.CopyToAsync(request);
+                requestReceived.TrySetResult(request.ToArray());
+
+                context.Response.ContentLength = responseBody.Length;
+                await context.Response.Body.WriteAsync(responseBody.AsMemory(0, responseBody.Length / 2));
+                await context.Response.Body.FlushAsync();
+                firstResponseHalfSent.TrySetResult();
+                await releaseResponse.Task;
+                await context.Response.Body.WriteAsync(responseBody.AsMemory(responseBody.Length / 2));
+            });
+        });
+
+        var updates = new ConcurrentQueue<ArchiveUpdateType>();
+        var completed = new TaskCompletionSource<Exchange>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
+        {
+            updates.Enqueue(args.UpdateType);
+
+            if (args.UpdateType == ArchiveUpdateType.AfterResponse)
+                completed.TrySetResult(args.Original);
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/success")
+        {
+            Content = new ByteArrayContent(requestBody)
+        };
+        using var response = await setup.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+        await firstResponseHalfSent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(requestBody, await requestReceived.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Equal(
+            new[] { ArchiveUpdateType.BeforeRequestHeader, ArchiveUpdateType.AfterResponseHeader },
+            updates.ToArray());
+        Assert.Equal(0, setup.Proxy.Writer.TotalProcessedExchanges);
+
+        releaseResponse.TrySetResult();
+
+        Assert.Equal(responseBody, await response.Content.ReadAsByteArrayAsync());
+        var completedExchange = await completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(
+            new[]
+            {
+                ArchiveUpdateType.BeforeRequestHeader,
+                ArchiveUpdateType.AfterResponseHeader,
+                ArchiveUpdateType.AfterResponse
+            },
+            updates.ToArray());
+        Assert.Equal(1, setup.Proxy.Writer.TotalProcessedExchanges);
+        Assert.Null(completedExchange.Request.Body);
+        Assert.Null(completedExchange.Response.Body);
+    }
+
+    [Fact]
+    public async Task DefaultWriter_DoesNotCompleteFaultedResponse()
+    {
+        await using var setup = await ProxiedHostSetup.Create(
+            setting => setting.AddAlterationRulesForAny(
+                new AddResponseBodyStreamSubstitutionAction(new FaultingSubstitution())),
+            app => app.MapGet("/fault", () => "original-response"));
+
+        var faultedExchangeId = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completedIds = new ConcurrentBag<int>();
+
+        setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
+        {
+            if (args.UpdateType == ArchiveUpdateType.AfterResponseHeader &&
+                args.ExchangeInfo.FullUrl.EndsWith("/fault", StringComparison.Ordinal))
+                faultedExchangeId.TrySetResult(args.Original.Id);
+
+            if (args.UpdateType == ArchiveUpdateType.AfterResponse)
+                completedIds.Add(args.Original.Id);
+        };
+
+        await Assert.ThrowsAnyAsync<HttpRequestException>(() => setup.Client.GetAsync("/fault"));
+        var faultedId = await faultedExchangeId.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.DoesNotContain(faultedId, completedIds);
+        Assert.Equal(0, setup.Proxy.Writer.TotalProcessedExchanges);
+    }
+
+    [Fact]
+    public async Task DefaultWriter_DoesNotCompleteCancelledResponse()
+    {
+        var firstChunkSent = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var originStopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var chunk = new byte[64 * 1024];
+
+        await using var setup = await ProxiedHostSetup.Create(configureRoutes: app =>
+        {
+            app.MapGet("/cancel", async context =>
+            {
+                context.Response.ContentLength = 128L * 1024 * 1024;
+
+                try
+                {
+                    await context.Response.Body.WriteAsync(chunk);
+                    await context.Response.Body.FlushAsync();
+                    firstChunkSent.TrySetResult();
+                    await releaseBody.Task;
+
+                    for (var i = 1; i < 2048; i++)
+                    {
+                        await context.Response.Body.WriteAsync(chunk, context.RequestAborted);
+                        await context.Response.Body.FlushAsync(context.RequestAborted);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (IOException)
+                {
+                }
+                finally
+                {
+                    originStopped.TrySetResult();
+                }
+            });
+            app.MapGet("/barrier", () => "ok");
+        });
+
+        var cancelledExchangeId = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completedIds = new ConcurrentBag<int>();
+
+        setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
+        {
+            if (args.UpdateType == ArchiveUpdateType.AfterResponseHeader &&
+                args.ExchangeInfo.FullUrl.EndsWith("/cancel", StringComparison.Ordinal))
+                cancelledExchangeId.TrySetResult(args.Original.Id);
+
+            if (args.UpdateType == ArchiveUpdateType.AfterResponse)
+                completedIds.Add(args.Original.Id);
+        };
+
+        using (var response = await setup.Client.GetAsync("/cancel", HttpCompletionOption.ResponseHeadersRead))
+        {
+            await firstChunkSent.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+
+        releaseBody.TrySetResult();
+        var cancelledId = await cancelledExchangeId.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        await originStopped.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal("ok", await setup.Client.GetStringAsync("/barrier"));
+
+        Assert.DoesNotContain(cancelledId, completedIds);
+        Assert.Equal(1, setup.Proxy.Writer.TotalProcessedExchanges);
+    }
+
+    [Fact]
+    public async Task DefaultWriter_PreservesResponseSubstitution()
+    {
+        const string expected = "substituted-response";
+
+        await using var setup = await ProxiedHostSetup.Create(
+            setting => setting.AddAlterationRulesForAny(
+                new AddResponseBodyStreamSubstitutionAction(
+                    new ReturnsContentLengthSubstitution(expected))),
+            app => app.MapGet("/substitute", () => "original-response"));
+
+        var updates = new ConcurrentQueue<ArchiveUpdateType>();
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
+        {
+            updates.Enqueue(args.UpdateType);
+
+            if (args.UpdateType == ArchiveUpdateType.AfterResponse)
+                completed.TrySetResult();
+        };
+
+        Assert.Equal(expected, await setup.Client.GetStringAsync("/substitute"));
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(
+            new[]
+            {
+                ArchiveUpdateType.BeforeRequestHeader,
+                ArchiveUpdateType.AfterResponseHeader,
+                ArchiveUpdateType.AfterResponse
+            },
+            updates.ToArray());
+    }
+
+    [Fact]
+    public async Task DirectoryWriter_CapturesExactRequestAndResponseBytes()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"fluxzy-capture-{Guid.NewGuid():N}");
+        var requestBody = Enumerable.Range(0, 4096).Select(i => (byte) (i % 239)).ToArray();
+        var responseBody = Enumerable.Range(0, 8192).Select(i => (byte) (255 - i % 241)).ToArray();
+        var requestReceived = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            await using var setup = await ProxiedHostSetup.Create(
+                setting => setting.SetArchivingPolicy(ArchivingPolicy.CreateFromDirectory(directory)),
+                app => app.MapPost("/capture", async context =>
+                {
+                    using var request = new MemoryStream();
+                    await context.Request.Body.CopyToAsync(request);
+                    requestReceived.TrySetResult(request.ToArray());
+
+                    context.Response.ContentLength = responseBody.Length;
+                    await context.Response.Body.WriteAsync(responseBody);
+                }));
+
+            var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            setup.Proxy.Writer.ExchangeUpdated += (_, args) =>
+            {
+                if (args.UpdateType == ArchiveUpdateType.AfterResponse)
+                    completed.TrySetResult();
+            };
+
+            using var content = new ByteArrayContent(requestBody);
+            using var response = await setup.Client.PostAsync("/capture", content);
+
+            Assert.Equal(responseBody, await response.Content.ReadAsByteArrayAsync());
+            Assert.Equal(requestBody, await requestReceived.Task.WaitAsync(TimeSpan.FromSeconds(10)));
+            await completed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            var requestPath = Assert.Single(Directory.GetFiles(Path.Combine(directory, "contents"), "req-*.data"));
+            var responsePath = Assert.Single(Directory.GetFiles(Path.Combine(directory, "contents"), "res-*.data"));
+
+            Assert.Equal(requestBody, await File.ReadAllBytesAsync(requestPath));
+            Assert.Equal(responseBody, await File.ReadAllBytesAsync(responsePath));
+            Assert.Equal(1, setup.Proxy.Writer.TotalProcessedExchanges);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, true);
+        }
+    }
+
+    private sealed class FaultingSubstitution : IStreamSubstitution
+    {
+        public ValueTask<Stream> Substitute(Stream originalStream)
+        {
+            return ValueTask.FromResult<Stream>(new FaultingReadStream());
+        }
+    }
+
+    private sealed class FaultingReadStream : MemoryStream
+    {
+        private bool _readOnce;
+
+        public FaultingReadStream()
+            : base(new byte[8192])
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_readOnce)
+                throw new IOException("Injected response body read failure.");
+
+            _readOnce = true;
+            return base.Read(buffer, offset, Math.Min(count, 256));
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_readOnce)
+                return ValueTask.FromException<int>(new IOException("Injected response body read failure."));
+
+            _readOnce = true;
+            return base.ReadAsync(buffer[..Math.Min(buffer.Length, 256)], cancellationToken);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Events/EventWriterConnectionReuseTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Events/EventWriterConnectionReuseTests.cs
@@ -1,0 +1,68 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Tests._Fixtures;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Events
+{
+    public class EventWriterConnectionReuseTests
+    {
+        /// <summary>
+        /// A client abort leaves the upstream response body partially read. The
+        /// exchange must not complete as reusable, otherwise the H11 pool recycles
+        /// a connection still carrying unread body bytes and the next exchange on
+        /// it fails parsing them as a response header.
+        /// </summary>
+        [Fact]
+        public async Task AbortedDownload_DoesNotPoisonUpstreamH11Connection()
+        {
+            var chunk = new byte[64 * 1024];
+
+            await using var setup = await ProxiedHostSetup.Create(
+                setting => setting.AddAlterationRulesForAny(new ForceHttp11Action()),
+                app =>
+                {
+                    app.MapGet("/big", async context =>
+                    {
+                        context.Response.ContentLength = 128L * 1024 * 1024;
+
+                        try
+                        {
+                            for (var i = 0; i < 2048; i++)
+                            {
+                                await context.Response.Body.WriteAsync(chunk, context.RequestAborted);
+                                await context.Response.Body.FlushAsync(context.RequestAborted);
+                            }
+                        }
+                        catch (Exception)
+                        {
+                            // aborted by the proxy or the client
+                        }
+                    });
+
+                    app.MapGet("/ok", () => "hello");
+                });
+
+            using (var response = await setup.Client.GetAsync("/big", HttpCompletionOption.ResponseHeadersRead))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                var buffer = new byte[1024];
+                await stream.ReadAsync(buffer);
+            }
+
+            // Let the proxy observe the abort and settle the upstream connection
+            await Task.Delay(750);
+
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.Equal("hello", await setup.Client.GetStringAsync("/ok"));
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Serve/H2DownStreamPipeTests.cs
@@ -98,6 +98,45 @@ namespace Fluxzy.Tests.UnitTests.H2Serve
             Assert.Equal(1, exchange.StreamIdentifier);
         }
 
+        [Fact]
+        public async Task WriteResponseBody_CancellationWhileWaitingForWindowThrows()
+        {
+            await using var ctx = await H2TestContext.Create();
+
+            await ctx.ReadNextFrame(); // SETTINGS
+            await ctx.SendSettingsAck();
+
+            var headers = "GET /large HTTP/2\r\nHost: localhost\r\n\r\n".AsMemory();
+            await ctx.SendHeadersFrame(1, headers, endStream: true, endHeaders: true);
+
+            using var buffer = Fluxzy.Misc.ResizableBuffers.RsBuffer.Allocate(32768);
+            using var scope = new ExchangeScope();
+            var exchange = await ctx.DownStreamPipe.ReadNextExchange(buffer, scope, ctx.Token);
+            Assert.NotNull(exchange);
+
+            using var responseBody = new MemoryStream(new byte[128 * 1024]);
+            using var cancellation = new CancellationTokenSource();
+            var writing = ctx.DownStreamPipe.WriteResponseBody(
+                    responseBody, buffer, chunked: false, streamIdentifier: 1,
+                    responseForTrailers: null, cancellation.Token)
+                .AsTask();
+
+            // The initial stream window permits three full frames. The fourth booking
+            // blocks because no WINDOW_UPDATE is sent.
+            for (var dataFrames = 0; dataFrames < 3;)
+            {
+                var frame = await ctx.ReadNextFrame();
+                if (frame.BodyType == H2FrameType.Data)
+                    dataFrames++;
+            }
+
+            Assert.False(writing.IsCompleted);
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => writing.WaitAsync(TimeSpan.FromSeconds(2)));
+        }
+
         /// <summary>
         /// Firefox-style zero-length POST: HEADERS (no END_STREAM) + empty DATA[END_STREAM].
         /// Verifies the exchange exposes an empty, non-seekable request body with


### PR DESCRIPTION
## Problem

The default `EventOnlyArchiveWriter` does not retain request or response bodies, but the proxy still wraps every non-empty body in `DispatchStream` and dispatches every byte to `Stream.Null`. The response wrapper also raises `AfterResponse` from its EOF callback, before downstream forwarding has necessarily succeeded.

This adds steady-state allocation and can record a downstream cancellation or write failure as a successful exchange.

## Solution

Add a default-preserving `RealtimeArchiveWriter.CapturesBodyContent` capability and override it to `false` for `EventOnlyArchiveWriter`. Create dispatch wrappers only when the selected writer captures body content.

Raise `AfterResponse` once from the common path after response forwarding succeeds. Response substitution remains independent of capture and retains its existing ownership semantics.

## Benefits

- Event-only H1 allocation fell by 544 B/request, or 3.7%.
- Event-only H2 allocation fell by 453 B/request, or 2.7%.
- Throughput remained within approximately 1% of baseline for both protocols.
- Cancellation and body forwarding failures no longer publish false-success completion events.
- Capture-enabled writers continue to receive exact request and response bodies.

## Changes

- Add an archive-writer body-capture capability that defaults to enabled.
- Disable body capture for `EventOnlyArchiveWriter`.
- Skip body dispatch wrappers when capture is disabled.
- Move `AfterResponse` to the successful post-forwarding path.
- Add deterministic event-ordering, failure, substitution, and exact-capture coverage.

## Verification

- Six focused event/archive tests passed.
- Three alternating 100,000-request runs per protocol completed with zero errors for event-only capture.
- Directory-writer controls captured every 8 KiB response exactly and reported zero capture errors.
- Existing substitutions and event ordering were covered for normal completion, cancellation, read faults, and response substitution.

## Line Count

| Category | Additions | Removals | Net |
|---|---:|---:|---:|
| Documentation | 0 | 0 | 0 |
| Configuration | 0 | 0 | 0 |
| Runtime | 27 | 30 | -3 |
| Tests | 325 | 0 | +325 |
| **Total** | **352** | **30** | **+322** |

Generated or vendored content: none.
