### PR TITLE
Fix HTTP/2 stream buffer ownership

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -92,7 +92,9 @@ namespace Fluxzy.Clients.H2
 
             _writerChannel =
                 Channel.CreateUnbounded<WriteTask>(new UnboundedChannelOptions {
-                    SingleReader = true,
+                    // The writer loop is the normal consumer, while teardown may
+                    // concurrently drain rejected work to settle borrowed buffers.
+                    SingleReader = false,
                     SingleWriter = false
                 });
 

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -270,6 +270,12 @@ namespace Fluxzy.Clients.H2
         // Invoked immediately before the dedicated request-body buffer and task are created.
         internal Action? RequestBodyWorkStartedForTests { get; set; }
 
+        /// <summary>Test seam: enqueue a write task through the writer channel.</summary>
+        internal void EnqueueWriteTaskForTests(ref WriteTask writeTask) => UpStreamChannel(ref writeTask);
+
+        /// <summary>Test seam: run the writer loop directly without Init.</summary>
+        internal Task RunWriterLoopForTests(CancellationToken token) => InternalWriteLoop(token);
+
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe _, RsBuffer buffer, ExchangeScope __,
             CancellationToken cancellationToken = default)

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -23,8 +23,6 @@ namespace Fluxzy.Clients.H2
 {
     public class H2ConnectionPool : IHttpConnectionPool
     {
-        internal const int MaxUploadPayloadSize = 64 * 1024;
-
         private static int _connectionIdCounter;
 
         private readonly Connection _connection;
@@ -894,7 +892,8 @@ namespace Fluxzy.Clients.H2
                 // Allocate a dedicated buffer for request body forwarding so we can
                 // return the shared buffer to the caller once the response is available.
                 RequestBodyWorkStartedForTests?.Invoke();
-                var uploadPayloadSize = Math.Min(Setting.Remote.MaxFrameSize, MaxUploadPayloadSize);
+                var uploadPayloadSize = Math.Min(
+                    Setting.Remote.MaxFrameSize, FluxzySharedSetting.H2MaxUploadPayloadSize);
                 var bodyBuffer = RsBuffer.Allocate(uploadPayloadSize + 9);
 
                 var requestBodyTask = activeStream.ProcessRequestBody(

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -23,6 +23,7 @@ namespace Fluxzy.Clients.H2
 {
     public class H2ConnectionPool : IHttpConnectionPool
     {
+        internal const int MaxUploadPayloadSize = 64 * 1024;
 
         private static int _connectionIdCounter;
 
@@ -263,6 +264,9 @@ namespace Fluxzy.Clients.H2
 
         /// <summary>Test seam: direct access to the stream pool for unit-level assertions.</summary>
         internal StreamPool StreamPoolForTests => _streamPool;
+
+        // Invoked immediately before the dedicated request-body buffer and task are created.
+        internal Action? RequestBodyWorkStartedForTests { get; set; }
 
         public async ValueTask Send(
             Exchange exchange, IDownStreamPipe _, RsBuffer buffer, ExchangeScope __,
@@ -811,6 +815,7 @@ namespace Fluxzy.Clients.H2
 
             try {
                 Task waitForHeaderSentTask;
+                bool requestHeaderEndedStream;
 
                 try {
                     if (Complete || _connectionToken.IsCancellationRequested)
@@ -824,7 +829,7 @@ namespace Fluxzy.Clients.H2
 
                     // activeStream.OR
 
-                    waitForHeaderSentTask =
+                    (waitForHeaderSentTask, requestHeaderEndedStream) =
                         activeStream.EnqueueRequestHeader(exchange, buffer, streamCancellationToken);
                 }
                 finally {
@@ -836,13 +841,14 @@ namespace Fluxzy.Clients.H2
 
                 exchange.Metrics.RequestHeaderSent = ITimingProvider.Default.Instant();
 
-                var hasRequestBody = exchange.Request.Body != null
-                    && (!exchange.Request.Body.CanSeek || exchange.Request.Body.Length > 0);
-
-                if (!hasRequestBody) {
+                if (requestHeaderEndedStream) {
                     exchange.Metrics.RequestBodySent = exchange.Metrics.RequestHeaderSent;
                     FluxzyLogEvents.LogRequestSent(
                         _streamPool.Context.Logger, exchange, earlyResponse: false);
+
+                    await activeStream.ProcessResponse(streamCancellationToken, this)
+                                      .ConfigureAwait(false);
+                    return;
                 }
 
                 // Run request body upload and response processing concurrently.
@@ -851,8 +857,9 @@ namespace Fluxzy.Clients.H2
 
                 // Allocate a dedicated buffer for request body forwarding so we can
                 // return the shared buffer to the caller once the response is available.
-                var bodyBuffer = RsBuffer.Allocate(
-                    Math.Min(Setting.Local.MaxFrameSize, buffer.Buffer.Length));
+                RequestBodyWorkStartedForTests?.Invoke();
+                var uploadPayloadSize = Math.Min(Setting.Remote.MaxFrameSize, MaxUploadPayloadSize);
+                var bodyBuffer = RsBuffer.Allocate(uploadPayloadSize + 9);
 
                 var requestBodyTask = activeStream.ProcessRequestBody(
                     exchange, bodyBuffer, streamCancellationToken);

--- a/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H2/H2ConnectionPool.cs
@@ -360,7 +360,9 @@ namespace Fluxzy.Clients.H2
 
         private void UpStreamChannel(ref WriteTask data)
         {
-            _writerChannel?.Writer.TryWrite(data);
+            if (_writerChannel == null || !_writerChannel.Writer.TryWrite(data))
+                data.OnComplete(new ConnectionCloseException(
+                    "HTTP/2 writer channel is already closed"));
         }
 
         private void EmitPing(long opaqueData)
@@ -457,18 +459,8 @@ namespace Fluxzy.Clients.H2
             if (!_connectionCancellationTokenSource.IsCancellationRequested)
                 _connectionCancellationTokenSource.Cancel();
 
-            if (releaseChannelItems && _writerChannel != null) {
-                _writerChannel.Writer.TryComplete();
-
-                var list = new List<WriteTask>();
-
-                if (_writerChannel.Reader.TryReadAll(list)) {
-                    foreach (var item in list) {
-                        if (!item.DoneTask.IsCompleted)
-                            item.CompletionSource.SetCanceled();
-                    }
-                }
-            }
+            if (releaseChannelItems)
+                CompleteWriterChannel(ex ?? new OperationCanceledException(_connectionToken));
 
             // Notify last so the callback observes a fully-quiesced pool. Use a
             // CAS-guarded fire so concurrent teardown paths (read-loop exit racing
@@ -479,13 +471,34 @@ namespace Fluxzy.Clients.H2
                 _onConnectionFaulted?.Invoke(this);
         }
 
+        private void CompleteWriterChannel(Exception exception)
+        {
+            if (_writerChannel == null)
+                return;
+
+            _writerChannel.Writer.TryComplete();
+            var pending = new List<WriteTask>();
+
+            if (!_writerChannel.Reader.TryReadAll(pending))
+                return;
+
+            CompleteWriteTasks(pending, exception);
+        }
+
+        private static void CompleteWriteTasks(
+            IEnumerable<WriteTask> writeTasks, Exception exception)
+        {
+            foreach (var writeTask in writeTasks)
+                writeTask.OnComplete(exception);
+        }
+
         private async Task InternalWriteLoop(CancellationToken token)
         {
             Exception? outException = null;
+            var tasks = new List<WriteTask>();
+            var otherTasks = new List<WriteTask>();
 
             try {
-                var tasks = new List<WriteTask>();
-                var otherTasks = new List<WriteTask>();
 
                 while (!token.IsCancellationRequested) {
                     tasks.Clear();
@@ -514,22 +527,32 @@ namespace Fluxzy.Clients.H2
                         if (windowUpdateCount > 0) {
                             var bufferLength = windowUpdateCount * 13;
                             var heapBuffer = ArrayPool<byte>.Shared.Rent(bufferLength);
-                            var memoryBuffer = new Memory<byte>(heapBuffer).Slice(0, bufferLength);
 
-                            for (var i = 0; i < tasks.Count; i++) {
-                                var writeTask = tasks[i];
-                                if (writeTask.FrameType != H2FrameType.WindowUpdate)
-                                    continue;
+                            try {
+                                var memoryBuffer = new Memory<byte>(heapBuffer).Slice(0, bufferLength);
 
-                                new WindowUpdateFrame(writeTask.WindowUpdateSize, writeTask.StreamIdentifier)
-                                    .Write(memoryBuffer.Span);
+                                for (var i = 0; i < tasks.Count; i++) {
+                                    var writeTask = tasks[i];
+                                    if (writeTask.FrameType != H2FrameType.WindowUpdate)
+                                        continue;
 
-                                memoryBuffer = memoryBuffer.Slice(13);
+                                    new WindowUpdateFrame(writeTask.WindowUpdateSize, writeTask.StreamIdentifier)
+                                        .Write(memoryBuffer.Span);
+
+                                    memoryBuffer = memoryBuffer.Slice(13);
+                                }
+
+                                await _baseStream.WriteAsync(heapBuffer, 0, bufferLength, token)
+                                                 .ConfigureAwait(false);
+
+                                for (var i = 0; i < tasks.Count; i++) {
+                                    if (tasks[i].FrameType == H2FrameType.WindowUpdate)
+                                        tasks[i].OnComplete(null);
+                                }
                             }
-
-                            await _baseStream.WriteAsync(heapBuffer, 0, bufferLength, token).ConfigureAwait(false);
-
-                            ArrayPool<byte>.Shared.Return(heapBuffer);
+                            finally {
+                                ArrayPool<byte>.Shared.Return(heapBuffer);
+                            }
                         }
 
                         // Sort non-window-update tasks in-place by priority
@@ -576,7 +599,7 @@ namespace Fluxzy.Clients.H2
                                     otherTasks[i].OnComplete(null);
                                 }
                             }
-                            catch (Exception ex) when (ex is SocketException || ex is IOException) {
+                            catch (Exception ex) {
                                 for (var i = 0; i < otherTasks.Count; i++) {
                                     otherTasks[i].OnComplete(ex);
                                 }
@@ -602,16 +625,21 @@ namespace Fluxzy.Clients.H2
 
                 await _baseStream.FlushAsync(token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException) {
+            catch (OperationCanceledException ex) {
+                CompleteWriteTasks(tasks, ex);
             }
             catch (Exception ex) {
                 // We catch this exception here to throw it to the
                 // caller in SendAsync() instead of Dispose() ;
-
+                CompleteWriteTasks(tasks, ex);
                 outException = ex;
             }
             finally {
-                OnLoopEnd(outException, true);
+                // Always close and drain here. The read loop may have won OnLoopEnd's
+                // idempotence guard, but only the writer loop can guarantee that its
+                // dequeued and still-queued tasks have reached a terminal state.
+                CompleteWriterChannel(outException ?? new OperationCanceledException(token));
+                OnLoopEnd(outException, false);
             }
         }
 
@@ -622,7 +650,7 @@ namespace Fluxzy.Clients.H2
                 await baseStream.WriteAsync(writeTask.BufferBytes, token).ConfigureAwait(false);
                 writeTask.OnComplete(null);
             }
-            catch (Exception ex) when (ex is SocketException || ex is IOException) {
+            catch (Exception ex) {
                 writeTask.OnComplete(ex);
                 throw;
             }

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -214,6 +214,8 @@ namespace Fluxzy.Clients.H2
         public (Task Sent, bool EndStream) EnqueueRequestHeader(
             Exchange exchange, RsBuffer buffer, CancellationToken token)
         {
+            token.ThrowIfCancellationRequested();
+
             var endStream = exchange.Request.Header.ContentLength == 0 ||
                             exchange.Request.Body == null ||
                             (exchange.Request.Body.CanSeek && exchange.Request.Body.Length == 0);
@@ -224,22 +226,32 @@ namespace Fluxzy.Clients.H2
                 new HeaderEncodingJob(exchange.Request.Header.GetHttp11Header(), StreamIdentifier, StreamDependency),
                 buffer, endStream);
 
+            // The encoder writes into the caller-owned pooled RsBuffer. Materialize the
+            // packetized header before enqueue so caller cancellation may return that
+            // buffer without racing an in-flight transport write.
+            var ownedHeader = readyToBeSent.ToArray();
+
             exchange.Metrics.RequestHeaderSending = ITimingProvider.Default.Instant();
-            exchange.Metrics.RequestHeaderLength = readyToBeSent.Length;
+            exchange.Metrics.RequestHeaderLength = ownedHeader.Length;
 
             FluxzyLogEvents.LogRequestSending(Parent.Context.Logger, exchange);
 
             var writeHeaderTask = new WriteTask(H2FrameType.Headers, StreamIdentifier, StreamPriority,
-                StreamDependency, readyToBeSent);
+                StreamDependency, ownedHeader);
 
             Parent.Context.UpStreamChannel(ref writeHeaderTask);
 
             return (
-                writeHeaderTask.DoneTask
-                               .ContinueWith(t => {
-                                   return _exchange.Metrics.TotalSent += readyToBeSent.Length;
-                               }, token),
+                CompleteRequestHeaderWrite(
+                    writeHeaderTask.DoneTask, ownedHeader.Length, token),
                 endStream);
+        }
+
+        private async Task CompleteRequestHeaderWrite(
+            Task writeTask, int headerLength, CancellationToken token)
+        {
+            await writeTask.WaitAsync(token).ConfigureAwait(false);
+            _exchange.Metrics.TotalSent += headerLength;
         }
 
         public async ValueTask ProcessRequestBody(Exchange exchange, RsBuffer buffer, CancellationToken token)

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -280,7 +280,7 @@ namespace Fluxzy.Clients.H2
                 while (true) {
                     var bookedSize = Math.Min(
                         Parent.Context.Setting.Remote.MaxFrameSize,
-                        Math.Min(H2ConnectionPool.MaxUploadPayloadSize, buffer.Buffer.Length - 9));
+                        Math.Min(FluxzySharedSetting.H2MaxUploadPayloadSize, buffer.Buffer.Length - 9));
 
                     if (Volatile.Read(ref _disposed) != 0)
                         throw new TaskCanceledException("Stream cancellation request");

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,10 +21,13 @@ namespace Fluxzy.Clients.H2
 
         private readonly SemaphoreSlim _headerReceivedSemaphore = new(0, 1);
         
-        private readonly Pipe _pipeResponseBody;
+        private Pipe? _pipeResponseBody;
         private readonly CancellationTokenSource _resetTokenSource;
 
-        private bool _disposed;
+        private bool _responseBodyCompleted;
+        private Exception? _responseBodyCompletionError;
+
+        private int _disposed;
         private bool _firstBodyFragment = true;
 
         private byte[]? _headerBuffer;
@@ -57,16 +61,9 @@ namespace Fluxzy.Clients.H2
             RemoteWindowSize = new WindowSizeHolder(parent.Context.Setting.Remote.WindowSize,
                 streamIdentifier);
             
-            _pipeResponseBody = new Pipe(new PipeOptions(
-                pool: MemoryPool<byte>.Shared,
-                readerScheduler: PipeScheduler.ThreadPool,
-                writerScheduler: PipeScheduler.Inline,
-                pauseWriterThreshold: 0,
-                resumeWriterThreshold: 0,
-                minimumSegmentSize: 16384,
-                useSynchronizationContext: false
-            ));
         }
+
+        internal Pipe? ResponseBodyPipeForTests => Volatile.Read(ref _pipeResponseBody);
 
         public int StreamIdentifier { get; }
 
@@ -82,7 +79,8 @@ namespace Fluxzy.Clients.H2
 
         public void Dispose()
         {
-            _disposed = true;
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
             
             RemoteWindowSize?.Dispose();
 
@@ -189,7 +187,9 @@ namespace Fluxzy.Clients.H2
             if (!_resetTokenSource.IsCancellationRequested)
                 _resetTokenSource.Cancel();
 
-            _pipeResponseBody.Writer.Complete();
+            var error = new ExchangeException($"Receive RST : {errorCode} from server");
+
+            CompleteResponseBody(error);
 
             if (errorCode != H2ErrorCode.NoError) {
                 var value = _exchange.Request.Header.GetHttp11Header().ToString();
@@ -199,7 +199,7 @@ namespace Fluxzy.Clients.H2
             }
 
             _exchange.ExchangeCompletionSource
-                     .TrySetException(new ExchangeException($"Receive RST : {errorCode} from server"));
+                     .TrySetException(error);
 
             Parent.NotifyDispose(this);
         }
@@ -211,7 +211,8 @@ namespace Fluxzy.Clients.H2
             Exclusive = priorityFrame.Exclusive;
         }
 
-        public Task EnqueueRequestHeader(Exchange exchange, RsBuffer buffer, CancellationToken token)
+        public (Task Sent, bool EndStream) EnqueueRequestHeader(
+            Exchange exchange, RsBuffer buffer, CancellationToken token)
         {
             var endStream = exchange.Request.Header.ContentLength == 0 ||
                             exchange.Request.Body == null ||
@@ -233,10 +234,12 @@ namespace Fluxzy.Clients.H2
 
             Parent.Context.UpStreamChannel(ref writeHeaderTask);
 
-            return writeHeaderTask.DoneTask
-                                  .ContinueWith(t => {
-                                      return _exchange.Metrics.TotalSent += readyToBeSent.Length;
-                                  }, token);
+            return (
+                writeHeaderTask.DoneTask
+                               .ContinueWith(t => {
+                                   return _exchange.Metrics.TotalSent += readyToBeSent.Length;
+                               }, token),
+                endStream);
         }
 
         public async ValueTask ProcessRequestBody(Exchange exchange, RsBuffer buffer, CancellationToken token)
@@ -261,9 +264,11 @@ namespace Fluxzy.Clients.H2
             if (requestBodyStream != null
                 && (!requestBodyStream.CanSeek || requestBodyStream.Length > 0)) {
                 while (true) {
-                    var bookedSize = Math.Min(Parent.Context.Setting.Local.MaxFrameSize, buffer.Buffer.Length) - 9;
+                    var bookedSize = Math.Min(
+                        Parent.Context.Setting.Remote.MaxFrameSize,
+                        Math.Min(H2ConnectionPool.MaxUploadPayloadSize, buffer.Buffer.Length - 9));
 
-                    if (_disposed)
+                    if (Volatile.Read(ref _disposed) != 0)
                         throw new TaskCanceledException("Stream cancellation request");
 
                     // We check wait for available Window Size from remote
@@ -305,6 +310,7 @@ namespace Fluxzy.Clients.H2
                     _exchange.Metrics.TotalSent += dataFramePayloadLength;
 
                     if (dataFramePayloadLength == 0 || endStream) {
+                        await writeTaskBody.DoneTask.ConfigureAwait(false);
                         exchange.Metrics.RequestBodySent = ITimingProvider.Default.Instant();
                         FluxzyLogEvents.LogRequestSent(Parent.Context.Logger, exchange, earlyResponse: false);
                         return;
@@ -443,7 +449,7 @@ namespace Fluxzy.Clients.H2
                     _exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
 
                 try {
-                    _pipeResponseBody.Writer.Complete();
+                    CompleteResponseBody();
                 }
                 catch {
                     // Pipe may already be completed
@@ -514,10 +520,10 @@ namespace Fluxzy.Clients.H2
                 throw;
             }
 
-            var responseBodyStream = _pipeResponseBody.Reader.AsStream();
+            var responseBodyStream = GetResponseBodyStream();
             var bodyIdleTimeout = Parent.Context.Setting.ResponseBodyIdleTimeout;
 
-            if (!_noBodyStream
+            if (!ReferenceEquals(responseBodyStream, Stream.Null)
                 && bodyIdleTimeout > TimeSpan.Zero
                 && bodyIdleTimeout != Timeout.InfiniteTimeSpan) {
                 _exchange.Response.Body = new ReadIdleTimeoutStream(responseBodyStream, bodyIdleTimeout,
@@ -531,7 +537,7 @@ namespace Fluxzy.Clients.H2
 
             if (_noBodyStream) {
                 // This stream as no more body
-                await _pipeResponseBody.Writer.CompleteAsync().ConfigureAwait(false);
+                CompleteResponseBody();
 
                 _exchange.ExchangeCompletionSource.TrySetResult(false);
                 Parent.NotifyDispose(this);
@@ -551,7 +557,7 @@ namespace Fluxzy.Clients.H2
             _exchange.ExchangeCompletionSource.TrySetException(
                 new ExchangeException("Response body idle timeout reached"));
 
-            _pipeResponseBody.Reader.CancelPendingRead();
+            Volatile.Read(ref _pipeResponseBody)?.Reader.CancelPendingRead();
 
             Parent.NotifyDispose(this);
         }
@@ -579,10 +585,11 @@ namespace Fluxzy.Clients.H2
             _exchange.Metrics.TotalReceived += buffer.Length;
 
             var cancelled = false;
+            var responseBodyPipe = GetResponseBodyPipe();
 
             try {
-                _pipeResponseBody.Writer.Write(buffer.Span);
-                _pipeResponseBody.Writer.FlushAsync().GetAwaiter().GetResult();
+                responseBodyPipe.Writer.Write(buffer.Span);
+                responseBodyPipe.Writer.FlushAsync().GetAwaiter().GetResult();
             }
             catch {
                 cancelled = true;
@@ -595,7 +602,7 @@ namespace Fluxzy.Clients.H2
                     _exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
 
                 if (!cancelled)
-                    _pipeResponseBody.Writer.Complete();
+                    CompleteResponseBody();
                 
                 _exchange.ExchangeCompletionSource.TrySetResult(false);
 
@@ -604,6 +611,65 @@ namespace Fluxzy.Clients.H2
                 // await Task.Yield();
                 Parent.NotifyDispose(this);
             }
+        }
+
+        private Stream GetResponseBodyStream()
+        {
+            lock (this) {
+                if (_noBodyStream ||
+                    _responseBodyCompleted &&
+                    _responseBodyCompletionError == null &&
+                    _pipeResponseBody == null)
+                    return Stream.Null;
+
+                return GetResponseBodyPipe().Reader.AsStream();
+            }
+        }
+
+        private Pipe GetResponseBodyPipe()
+        {
+            var pipe = Volatile.Read(ref _pipeResponseBody);
+
+            if (pipe != null)
+                return pipe;
+
+            lock (this) {
+                pipe = _pipeResponseBody;
+
+                if (pipe != null)
+                    return pipe;
+
+                pipe = new Pipe(new PipeOptions(
+                    pool: MemoryPool<byte>.Shared,
+                    readerScheduler: PipeScheduler.ThreadPool,
+                    writerScheduler: PipeScheduler.Inline,
+                    pauseWriterThreshold: 0,
+                    resumeWriterThreshold: 0,
+                    minimumSegmentSize: 16384,
+                    useSynchronizationContext: false));
+
+                if (_responseBodyCompleted)
+                    pipe.Writer.Complete(_responseBodyCompletionError);
+
+                Volatile.Write(ref _pipeResponseBody, pipe);
+                return pipe;
+            }
+        }
+
+        private void CompleteResponseBody(Exception? error = null)
+        {
+            Pipe? pipe;
+
+            lock (this) {
+                if (_responseBodyCompleted)
+                    return;
+
+                _responseBodyCompleted = true;
+                _responseBodyCompletionError = error;
+                pipe = _pipeResponseBody;
+            }
+
+            pipe?.Writer.Complete(error);
         }
 
         internal void OnDataConsumedByCaller(int dataSize)

--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -25,7 +25,6 @@ namespace Fluxzy.Clients.H2
         private readonly CancellationTokenSource _resetTokenSource;
 
         private bool _responseBodyCompleted;
-        private Exception? _responseBodyCompletionError;
 
         private int _disposed;
         private bool _firstBodyFragment = true;
@@ -189,7 +188,10 @@ namespace Fluxzy.Clients.H2
 
             var error = new ExchangeException($"Receive RST : {errorCode} from server");
 
-            CompleteResponseBody(error);
+            // Complete the body cleanly: some servers reset instead of sending
+            // END_STREAM after a full response, and the proxy must relay what was
+            // received. The reset still faults ExchangeCompletionSource below.
+            CompleteResponseBody();
 
             if (errorCode != H2ErrorCode.NoError) {
                 var value = _exchange.Request.Header.GetHttp11Header().ToString();
@@ -628,10 +630,7 @@ namespace Fluxzy.Clients.H2
         private Stream GetResponseBodyStream()
         {
             lock (this) {
-                if (_noBodyStream ||
-                    _responseBodyCompleted &&
-                    _responseBodyCompletionError == null &&
-                    _pipeResponseBody == null)
+                if (_noBodyStream || (_responseBodyCompleted && _pipeResponseBody == null))
                     return Stream.Null;
 
                 return GetResponseBodyPipe().Reader.AsStream();
@@ -661,14 +660,14 @@ namespace Fluxzy.Clients.H2
                     useSynchronizationContext: false));
 
                 if (_responseBodyCompleted)
-                    pipe.Writer.Complete(_responseBodyCompletionError);
+                    pipe.Writer.Complete();
 
                 Volatile.Write(ref _pipeResponseBody, pipe);
                 return pipe;
             }
         }
 
-        private void CompleteResponseBody(Exception? error = null)
+        private void CompleteResponseBody()
         {
             Pipe? pipe;
 
@@ -677,11 +676,10 @@ namespace Fluxzy.Clients.H2
                     return;
 
                 _responseBodyCompleted = true;
-                _responseBodyCompletionError = error;
                 pipe = _pipeResponseBody;
             }
 
-            pipe?.Writer.Complete(error);
+            pipe?.Writer.Complete();
         }
 
         internal void OnDataConsumedByCaller(int dataSize)

--- a/src/Fluxzy.Core/Clients/H2/WriteTask.cs
+++ b/src/Fluxzy.Core/Clients/H2/WriteTask.cs
@@ -38,7 +38,13 @@ namespace Fluxzy.Clients.H2
             }
 
             if (ex != null) {
-                CompletionSource.TrySetException(ex);
+                if (CompletionSource.TrySetException(ex)) {
+                    // Fire and forget frames (RST, ping, window updates,
+                    // settings ack) never await DoneTask. Read Exception so a
+                    // faulted task cannot raise UnobservedTaskException.
+                    _ = CompletionSource.Task.Exception;
+                }
+
                 return;
             }
 

--- a/src/Fluxzy.Core/Clients/H2/WriteTask.cs
+++ b/src/Fluxzy.Core/Clients/H2/WriteTask.cs
@@ -28,13 +28,21 @@ namespace Fluxzy.Clients.H2
 
         public void OnComplete(Exception? ex)
         {
-            if (ex != null) {
-                CompletionSource.SetException(ex);
+            if (ex is OperationCanceledException cancellation) {
+                if (cancellation.CancellationToken.CanBeCanceled)
+                    CompletionSource.TrySetCanceled(cancellation.CancellationToken);
+                else
+                    CompletionSource.TrySetCanceled();
 
                 return;
             }
 
-            CompletionSource.SetResult(null);
+            if (ex != null) {
+                CompletionSource.TrySetException(ex);
+                return;
+            }
+
+            CompletionSource.TrySetResult(null);
         }
 
         public Task DoneTask => CompletionSource.Task;

--- a/src/Fluxzy.Core/FluxzySharedSetting.cs
+++ b/src/Fluxzy.Core/FluxzySharedSetting.cs
@@ -46,6 +46,15 @@ namespace Fluxzy
             EnvironmentUtility.GetInt32("FLUXZY_RESPONSE_BODY_COPY_BUFFER", 64 * 1024);
 
         /// <summary>
+        ///     Cap applied to HTTP/2 upload DATA frame payloads, even when the remote peer
+        ///     advertises a larger SETTINGS_MAX_FRAME_SIZE. Also sizes the pooled buffer rented
+        ///     for each request body upload. Values below 16 KiB reduce upload throughput.
+        ///     Can be set by environment variable FLUXZY_H2_MAX_UPLOAD_PAYLOAD_SIZE.
+        /// </summary>
+        public static int H2MaxUploadPayloadSize { get; set; } =
+            EnvironmentUtility.GetInt32("FLUXZY_H2_MAX_UPLOAD_PAYLOAD_SIZE", 64 * 1024);
+
+        /// <summary>
         ///     The maximum number of concurrent connections allowed
         /// </summary>
         public static int OverallMaxConcurrentConnections { get; } = 102400;

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerResponsePipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerResponsePipeTests.cs
@@ -92,7 +92,7 @@ namespace Fluxzy.Tests.UnitTests.H2Client
         }
 
         [Fact]
-        public async Task ConcurrentResetAndDispose_FaultBodyOnceWithoutThrowing()
+        public async Task ConcurrentResetAndDispose_CompleteBodyOnceWithoutThrowing()
         {
             using var fixture = new WorkerFixture();
 
@@ -104,10 +104,28 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 Task.Run(fixture.Worker.Dispose),
                 Task.Run(fixture.Worker.Dispose));
 
-            await Assert.ThrowsAsync<ExchangeException>(() =>
-                fixture.Exchange.Response.Body!.ReadAsync(new byte[1]).AsTask());
+            Assert.Equal(0, await fixture.Exchange.Response.Body!.ReadAsync(new byte[1]));
 
             fixture.Worker.ResetRequest(H2ErrorCode.Cancel);
+            await Assert.ThrowsAsync<ExchangeException>(() => fixture.Exchange.Complete);
+        }
+
+        [Fact]
+        public async Task ResetAfterDataRelaysReceivedBodyWithCleanEndOfStream()
+        {
+            using var fixture = new WorkerFixture();
+            var body = new byte[] { 1, 2, 3 };
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+            fixture.Worker.ReceiveBodyFragmentFromConnection(body, endStream: false);
+
+            // Some servers reset instead of sending END_STREAM after a full
+            // response. The received body must be relayed as a clean EOF while
+            // the exchange itself records the reset.
+            fixture.Worker.ResetRequest(H2ErrorCode.InternalError);
+
+            Assert.Equal(body, await ReadAllBytes(fixture.Exchange.Response.Body!));
             await Assert.ThrowsAsync<ExchangeException>(() => fixture.Exchange.Complete);
         }
 

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerResponsePipeTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerResponsePipeTests.cs
@@ -1,0 +1,249 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Clients.H2.Frames;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    public class StreamWorkerResponsePipeTests
+    {
+        [Fact]
+        public async Task HeadersEndingStream_PublishStreamNullWithoutCreatingPipe()
+        {
+            using var fixture = new WorkerFixture();
+
+            fixture.ReceiveResponseHeaders(endStream: true);
+
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            Assert.Same(Stream.Null, fixture.Exchange.Response.Body);
+            Assert.Null(fixture.Worker.ResponseBodyPipeForTests);
+        }
+
+        [Fact]
+        public async Task DataBeforeProcessResponse_CreatesOnePipeAndPreservesBody()
+        {
+            using var fixture = new WorkerFixture();
+            var body = new byte[] { 1, 2, 3, 4 };
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+            fixture.Worker.ReceiveBodyFragmentFromConnection(body, endStream: true);
+            var pipe = fixture.Worker.ResponseBodyPipeForTests;
+
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            Assert.NotNull(pipe);
+            Assert.Same(pipe, fixture.Worker.ResponseBodyPipeForTests);
+            Assert.Equal(body, await ReadAllBytes(fixture.Exchange.Response.Body!));
+        }
+
+        [Fact]
+        public async Task DataAfterProcessResponse_ReusesPublishedPipe()
+        {
+            using var fixture = new WorkerFixture();
+            var body = new byte[] { 5, 6, 7, 8 };
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+            var pipe = fixture.Worker.ResponseBodyPipeForTests;
+
+            fixture.Worker.ReceiveBodyFragmentFromConnection(body, endStream: true);
+
+            Assert.NotNull(pipe);
+            Assert.Same(pipe, fixture.Worker.ResponseBodyPipeForTests);
+            Assert.Equal(body, await ReadAllBytes(fixture.Exchange.Response.Body!));
+        }
+
+        [Fact]
+        public async Task ConcurrentDataAndProcessResponse_CreateOnePipe()
+        {
+            using var fixture = new WorkerFixture();
+            using var start = new ManualResetEventSlim();
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+
+            var processResponse = Task.Run(async () => {
+                start.Wait();
+                await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+            });
+            var receiveData = Task.Run(() => {
+                start.Wait();
+                fixture.Worker.ReceiveBodyFragmentFromConnection(new byte[] { 9 }, endStream: true);
+            });
+
+            start.Set();
+            await Task.WhenAll(processResponse, receiveData);
+
+            var pipe = fixture.Worker.ResponseBodyPipeForTests;
+            Assert.NotNull(pipe);
+            Assert.Equal(new byte[] { 9 }, await ReadAllBytes(fixture.Exchange.Response.Body!));
+            Assert.Same(pipe, fixture.Worker.ResponseBodyPipeForTests);
+        }
+
+        [Fact]
+        public async Task ConcurrentResetAndDispose_FaultBodyOnceWithoutThrowing()
+        {
+            using var fixture = new WorkerFixture();
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            await Task.WhenAll(
+                Task.Run(() => fixture.Worker.ResetRequest(H2ErrorCode.Cancel)),
+                Task.Run(fixture.Worker.Dispose),
+                Task.Run(fixture.Worker.Dispose));
+
+            await Assert.ThrowsAsync<ExchangeException>(() =>
+                fixture.Exchange.Response.Body!.ReadAsync(new byte[1]).AsTask());
+
+            fixture.Worker.ResetRequest(H2ErrorCode.Cancel);
+            await Assert.ThrowsAsync<ExchangeException>(() => fixture.Exchange.Complete);
+        }
+
+        [Fact]
+        public async Task ResetBeforeResponsePublication_DoesNotCreatePipe()
+        {
+            using var fixture = new WorkerFixture();
+
+            fixture.Worker.ResetRequest(H2ErrorCode.Cancel);
+
+            Assert.Null(fixture.Worker.ResponseBodyPipeForTests);
+            await Assert.ThrowsAsync<ExchangeException>(() => fixture.Exchange.Complete);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TrailersCompleteBodyBeforeOrAfterResponsePublication(bool publishFirst)
+        {
+            using var fixture = new WorkerFixture();
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+
+            if (publishFirst)
+                await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            fixture.ReceiveTrailers(new HeaderField("x-result", "complete"));
+
+            if (!publishFirst)
+                await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            Assert.Equal("complete", Assert.Single(fixture.Exchange.Response.Trailers!).Value.ToString());
+            Assert.Empty(await ReadAllBytes(fixture.Exchange.Response.Body!));
+
+            if (publishFirst)
+                Assert.NotNull(fixture.Worker.ResponseBodyPipeForTests);
+            else
+                Assert.Null(fixture.Worker.ResponseBodyPipeForTests);
+        }
+
+        [Fact]
+        public async Task EmptyDataBeforeProcessResponse_CreatesCompletedPipe()
+        {
+            using var fixture = new WorkerFixture();
+
+            fixture.ReceiveResponseHeaders(endStream: false);
+            fixture.Worker.ReceiveBodyFragmentFromConnection(ReadOnlyMemory<byte>.Empty, endStream: true);
+            var pipe = fixture.Worker.ResponseBodyPipeForTests;
+
+            await fixture.Worker.ProcessResponse(CancellationToken.None, null!);
+
+            Assert.NotNull(pipe);
+            Assert.Same(pipe, fixture.Worker.ResponseBodyPipeForTests);
+            Assert.NotSame(Stream.Null, fixture.Exchange.Response.Body);
+            Assert.Empty(await ReadAllBytes(fixture.Exchange.Response.Body!));
+        }
+
+        private static async Task<byte[]> ReadAllBytes(Stream stream)
+        {
+            await using var destination = new MemoryStream();
+            await stream.CopyToAsync(destination);
+            return destination.ToArray();
+        }
+
+        private sealed class WorkerFixture : IDisposable
+        {
+            private readonly HPackEncoder _responseEncoder;
+            private readonly StreamPool _streamPool;
+            private readonly WindowSizeHolder _overallWindow;
+            private readonly CancellationTokenSource _resetTokenSource;
+
+            public WorkerFixture()
+            {
+                var authority = new Authority("test.local", 443, true);
+                var setting = new H2StreamSetting();
+                var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
+                var requestEncoder = new HPackEncoder(new EncodingContext(memoryProvider));
+                var responseDecoder = new HPackDecoder(new DecodingContext(authority, memoryProvider));
+                var headerEncoder = new HeaderEncoder(requestEncoder, responseDecoder, setting);
+
+                _responseEncoder = new HPackEncoder(new EncodingContext(memoryProvider));
+                _overallWindow = new WindowSizeHolder(setting.OverallWindowSize, 0);
+                _resetTokenSource = new CancellationTokenSource();
+
+                var context = new StreamContext(
+                    connectionId: 1,
+                    authority: authority,
+                    setting: setting,
+                    headerEncoder: headerEncoder,
+                    upStreamChannel: static (ref WriteTask _) => { },
+                    overallWindowSizeHolder: _overallWindow);
+
+                _streamPool = new StreamPool(context);
+                Exchange = new Exchange(
+                    IIdProvider.FromZero,
+                    authority,
+                    "GET / HTTP/2.0\r\nhost: test.local\r\n\r\n".AsMemory(),
+                    "HTTP/2",
+                    DateTime.UtcNow);
+                Worker = new StreamWorker(1, _streamPool, Exchange, _resetTokenSource);
+            }
+
+            public Exchange Exchange { get; }
+
+            public StreamWorker Worker { get; }
+
+            public void ReceiveResponseHeaders(bool endStream)
+            {
+                var fields = new List<HeaderField> { new(":status", "200") };
+                ReceiveHeaders(fields, endStream);
+            }
+
+            public void ReceiveTrailers(params HeaderField[] trailers)
+            {
+                ReceiveHeaders(trailers, endStream: true);
+            }
+
+            public void Dispose()
+            {
+                Worker.Dispose();
+                _streamPool.Dispose();
+                _overallWindow.Dispose();
+                _resetTokenSource.Dispose();
+                _responseEncoder.Dispose();
+            }
+
+            private void ReceiveHeaders(IList<HeaderField> fields, bool endStream)
+            {
+                var buffer = new byte[1024];
+                var encodedLength = _responseEncoder.EncodeFields(fields, buffer).Length;
+                var flags = HeaderFlags.EndHeaders |
+                            (endStream ? HeaderFlags.EndStream : HeaderFlags.None);
+                var frame = new HeadersFrame(buffer.AsMemory(0, encodedLength), flags);
+
+                Worker.ReceiveHeaderFragmentFromConnection(ref frame);
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
@@ -180,6 +181,141 @@ namespace Fluxzy.Tests.UnitTests.H2Client
             }
 
             Assert.True(processing.IsCompleted);
+        }
+
+        [Fact]
+        public async Task RejectedWriterChannelEntrySettlesImmediately()
+        {
+            var authority = new Authority("test.local", 443, true);
+            var pool = new H2ConnectionPool(
+                Stream.Null,
+                new H2StreamSetting(),
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+            await pool.DisposeAsync();
+
+            var writeTask = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, new byte[9]);
+
+            EnqueueForPool(pool, writeTask);
+
+            Assert.True(writeTask.DoneTask.IsCompleted);
+            await Assert.ThrowsAsync<ConnectionCloseException>(() => writeTask.DoneTask);
+        }
+
+        [Fact]
+        public async Task CancelledSingleTransportWriteSettlesDequeuedTask()
+        {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            var writeTask = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, new byte[9]);
+            using var stream = new ThrowingWriteStream(
+                new OperationCanceledException(cancellation.Token));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                H2ConnectionPool.WriteSingleNonWindowUpdateAsync(
+                    writeTask, stream, cancellation.Token).AsTask());
+
+            Assert.True(writeTask.DoneTask.IsCompleted);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => writeTask.DoneTask);
+        }
+
+        [Fact]
+        public async Task CancelledBatchTransportWriteSettlesEveryDequeuedTask()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var authority = new Authority("test.local", 443, true);
+            await using var pool = new H2ConnectionPool(
+                new ThrowingWriteStream(new OperationCanceledException(cancellation.Token)),
+                new H2StreamSetting(),
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+            var first = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, new byte[9]);
+            var second = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 3, priority: 0,
+                streamDependency: 0, new byte[9]);
+
+            EnqueueForPool(pool, first);
+            EnqueueForPool(pool, second);
+
+            await RunWriterLoopForTest(pool, cancellation.Token)
+                .WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(first.DoneTask.IsCompleted);
+            Assert.True(second.DoneTask.IsCompleted);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first.DoneTask);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second.DoneTask);
+        }
+
+        [Fact]
+        public async Task SuccessfulWindowUpdateSettlesDequeuedTask()
+        {
+            using var cancellation = new CancellationTokenSource();
+            var authority = new Authority("test.local", 443, true);
+            var stream = new SignalingWriteStream();
+            await using var pool = new H2ConnectionPool(
+                stream,
+                new H2StreamSetting(),
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+            var writeTask = new WriteTask(
+                H2FrameType.WindowUpdate, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, ReadOnlyMemory<byte>.Empty, value: 1);
+
+            EnqueueForPool(pool, writeTask);
+            var loop = RunWriterLoopForTest(pool, cancellation.Token);
+
+            try {
+                await stream.Written.Task.WaitAsync(TimeSpan.FromSeconds(2));
+                Assert.True(writeTask.DoneTask.IsCompletedSuccessfully);
+            }
+            finally {
+                cancellation.Cancel();
+                await loop.WaitAsync(TimeSpan.FromSeconds(2));
+            }
+        }
+
+        [Fact]
+        public async Task DisposedSingleTransportWriteSettlesDequeuedTask()
+        {
+            var writeTask = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, new byte[9]);
+            using var stream = new ThrowingWriteStream(
+                new ObjectDisposedException("transport"));
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                H2ConnectionPool.WriteSingleNonWindowUpdateAsync(
+                    writeTask, stream, CancellationToken.None).AsTask());
+
+            Assert.True(writeTask.DoneTask.IsCompleted);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => writeTask.DoneTask);
+        }
+
+        private static void EnqueueForPool(H2ConnectionPool pool, WriteTask writeTask)
+        {
+            var method = typeof(H2ConnectionPool).GetMethod(
+                "UpStreamChannel", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            method.Invoke(pool, new object[] { writeTask });
+        }
+
+        private static Task RunWriterLoopForTest(
+            H2ConnectionPool pool, CancellationToken cancellationToken)
+        {
+            var method = typeof(H2ConnectionPool).GetMethod(
+                "InternalWriteLoop", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return Assert.IsAssignableFrom<Task>(
+                method.Invoke(pool, new object[] { cancellationToken }));
         }
 
         private static async Task NegotiateMaxFrameSize(DuplexPipe pipe, int remoteMaxFrameSize)
@@ -418,6 +554,45 @@ namespace Fluxzy.Tests.UnitTests.H2Client
 
             public void Cancel(CancellationToken token) =>
                 _pending.CompletionSource.SetCanceled(token);
+        }
+
+        private sealed class SignalingWriteStream : MemoryStream
+        {
+            public TaskCompletionSource Written { get; } = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public override Task WriteAsync(
+                byte[] buffer, int offset, int count,
+                CancellationToken cancellationToken)
+            {
+                var write = base.WriteAsync(buffer, offset, count, cancellationToken);
+                Written.TrySetResult();
+                return write;
+            }
+        }
+
+        private sealed class ThrowingWriteStream : MemoryStream
+        {
+            private readonly Exception _exception;
+
+            public ThrowingWriteStream(Exception exception)
+            {
+                _exception = exception;
+            }
+
+            public override ValueTask WriteAsync(
+                ReadOnlyMemory<byte> buffer,
+                CancellationToken cancellationToken = default)
+            {
+                return ValueTask.FromException(_exception);
+            }
+
+            public override Task WriteAsync(
+                byte[] buffer, int offset, int count,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromException(_exception);
+            }
         }
 
         private sealed class WorkerFixture : IDisposable

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
@@ -1,0 +1,456 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Clients.H2;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Clients.H2.Encoder.Utils;
+using Fluxzy.Clients.H2.Frames;
+using Fluxzy.Core;
+using Fluxzy.Misc.Streams;
+using Fluxzy.Tests._Fixtures;
+using Xunit;
+using ResizableBuffer = Fluxzy.Misc.ResizableBuffers.RsBuffer;
+
+namespace Fluxzy.Tests.UnitTests.H2Client
+{
+    public class StreamWorkerUploadTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task BodylessRequestSkipsUploadBufferAndTask(bool nonSeekableBody)
+        {
+            using var pipe = new DuplexPipe();
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting();
+            var body = nonSeekableBody ? new NonSeekableEmptyStream() : null;
+
+            await using var pool = new H2ConnectionPool(
+                new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream),
+                setting,
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+            var requestBodyWorkStarted = 0;
+            pool.RequestBodyWorkStartedForTests = () => requestBodyWorkStarted++;
+            pool.Init();
+
+            await NegotiateMaxFrameSize(pipe, 128 * 1024);
+
+            var exchange = MakeBodylessExchange(authority, body);
+            using var sharedBuffer = ResizableBuffer.Allocate(4096);
+            var headersReceived = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var requestHeaders = ReadRequestHeadersAsync(pipe.ServerReadStream, headersReceived);
+            var response = WriteResponseHeadersAsync(pipe.ServerWriteStream, headersReceived.Task);
+
+            await Task.WhenAll(
+                pool.Send(exchange, null!, sharedBuffer, null!, CancellationToken.None).AsTask(),
+                response).WaitAsync(TimeSpan.FromSeconds(5));
+            await WriteResponseEndStreamAsync(pipe.ServerWriteStream);
+
+            Assert.True((await requestHeaders).Flags.HasFlag(HeaderFlags.EndStream));
+            Assert.Equal(0, requestBodyWorkStarted);
+            Assert.Equal(0, body?.ReadCount ?? 0);
+            Assert.Equal(exchange.Metrics.RequestHeaderSent, exchange.Metrics.RequestBodySent);
+        }
+
+        [Theory]
+        [InlineData(32 * 1024, 32 * 1024)]
+        [InlineData(128 * 1024, 64 * 1024)]
+        public async Task UploadUsesNegotiatedFrameSizeAnd64KiBPayloadCap(
+            int remoteMaxFrameSize, int expectedPayloadSize)
+        {
+            var payload = CreatePayload(expectedPayloadSize * 2 + 123);
+            using var pipe = new DuplexPipe();
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting {
+                OverallWindowSize = payload.Length + remoteMaxFrameSize
+            };
+            setting.Remote.WindowSize = payload.Length + remoteMaxFrameSize;
+
+            await using var pool = new H2ConnectionPool(
+                new RecomposedStream(pipe.ClientReadStream, pipe.ClientWriteStream),
+                setting,
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+            pool.Init();
+
+            await NegotiateMaxFrameSize(pipe, remoteMaxFrameSize);
+
+            var exchange = MakeExchange(authority, payload);
+            using var sharedBuffer = ResizableBuffer.Allocate(4096);
+            var headersReceived = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var upload = ReadUploadAsync(pipe.ServerReadStream, payload.Length, headersReceived);
+            var response = WriteResponseHeadersAsync(pipe.ServerWriteStream, headersReceived.Task);
+            var send = pool.Send(
+                exchange, null!, sharedBuffer, null!, CancellationToken.None).AsTask();
+
+            await Task.WhenAll(send, response).WaitAsync(TimeSpan.FromSeconds(5));
+            var frames = await upload.WaitAsync(TimeSpan.FromSeconds(5));
+            await WriteResponseEndStreamAsync(pipe.ServerWriteStream);
+
+            Assert.Equal(
+                new[] { expectedPayloadSize, expectedPayloadSize, 123 },
+                frames.Select(frame => frame.Payload.Length));
+            Assert.Equal(payload, frames.SelectMany(frame => frame.Payload).ToArray());
+            Assert.All(frames.Take(frames.Count - 1), frame => Assert.False(frame.EndStream));
+            Assert.True(frames[^1].EndStream);
+        }
+
+        [Fact]
+        public async Task RequestBodyOwnerWaitsUntilFinalWriteConsumesBuffer()
+        {
+            var payload = CreatePayload(12345);
+            var writer = new GatedWriter();
+            using var fixture = CreateWorker(payload, writer.Enqueue);
+            var bodyBuffer = ResizableBuffer.Allocate(32 * 1024 + 9);
+
+            var owner = ProcessAndDisposeAsync(fixture.Worker, fixture.Exchange, bodyBuffer);
+
+            await writer.Enqueued.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.False(owner.IsCompleted);
+
+            writer.Complete();
+            await owner.WaitAsync(TimeSpan.FromSeconds(2));
+
+            var frame = ParseDataFrame(writer.FrameBytes!);
+            Assert.Equal(payload, frame.Payload);
+            Assert.True(frame.EndStream);
+        }
+
+        [Fact]
+        public async Task PooledBodyBufferCannotBeOverwrittenBeforeFinalWrite()
+        {
+            var payload = CreatePayload(8192);
+            var writer = new GatedWriter();
+            using var fixture = CreateWorker(payload, writer.Enqueue);
+            var bodyBuffer = ResizableBuffer.Allocate(32 * 1024 + 9);
+            var rentedBytes = bodyBuffer.Buffer;
+
+            var owner = ProcessAndDisposeAsync(fixture.Worker, fixture.Exchange, bodyBuffer);
+
+            await writer.Enqueued.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            // Models the corruption possible when an owner returns the body array while
+            // the writer still holds its memory and a subsequent pool consumer overwrites it.
+            if (owner.IsCompleted)
+                rentedBytes.AsSpan().Fill(0xA5);
+
+            writer.Complete();
+            await owner.WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(payload, ParseDataFrame(writer.FrameBytes!).Payload);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task FinalWriteFailureOrCancellationSettlesRequestBody(bool cancel)
+        {
+            var payload = CreatePayload(4096);
+            var writer = new GatedWriter();
+            using var fixture = CreateWorker(payload, writer.Enqueue);
+            using var bodyBuffer = ResizableBuffer.Allocate(32 * 1024 + 9);
+            using var cancellation = new CancellationTokenSource();
+
+            var processing = fixture.Worker
+                                    .ProcessRequestBody(
+                                        fixture.Exchange, bodyBuffer, cancellation.Token)
+                                    .AsTask();
+            await writer.Enqueued.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            if (cancel) {
+                cancellation.Cancel();
+                writer.Cancel(cancellation.Token);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => processing);
+            }
+            else {
+                writer.Fail(new IOException("write failed"));
+                await Assert.ThrowsAsync<IOException>(() => processing);
+            }
+
+            Assert.True(processing.IsCompleted);
+        }
+
+        private static async Task NegotiateMaxFrameSize(DuplexPipe pipe, int remoteMaxFrameSize)
+        {
+            var preface = new byte[H2Constants.Preface.Length];
+            await ReadExactlyAsync(pipe.ServerReadStream, preface);
+            Assert.Equal(H2Constants.Preface, preface);
+
+            var welcome = await ReadFrameAsync(pipe.ServerReadStream);
+            Assert.Equal(H2FrameType.Settings, welcome.Header.BodyType);
+
+            await pipe.ServerWriteStream.WriteAsync(H2FrameHelper.BuildSettingsFrame(
+                (SettingIdentifier.SettingsMaxFrameSize, remoteMaxFrameSize)));
+            await pipe.ServerWriteStream.FlushAsync();
+
+            (H2Frame Header, byte[] Body) acknowledgement;
+
+            do {
+                acknowledgement = await ReadFrameAsync(pipe.ServerReadStream);
+            } while (acknowledgement.Header.BodyType != H2FrameType.Settings);
+
+            Assert.True(acknowledgement.Header.Flags.HasFlag(HeaderFlags.Ack));
+        }
+
+        private static async Task<List<UploadFrame>> ReadUploadAsync(
+            Stream stream, int payloadLength, TaskCompletionSource headersReceived)
+        {
+            var frames = new List<UploadFrame>();
+            var received = 0;
+
+            while (received < payloadLength) {
+                var frame = await ReadFrameAsync(stream);
+
+                if (frame.Header.BodyType == H2FrameType.Headers) {
+                    headersReceived.TrySetResult();
+                    continue;
+                }
+
+                if (frame.Header.BodyType != H2FrameType.Data)
+                    continue;
+
+                var uploadFrame = new UploadFrame(
+                    frame.Body,
+                    frame.Header.Flags.HasFlag(HeaderFlags.EndStream));
+                frames.Add(uploadFrame);
+                received += frame.Body.Length;
+            }
+
+            return frames;
+        }
+
+        private static async Task<H2Frame> ReadRequestHeadersAsync(
+            Stream stream, TaskCompletionSource headersReceived)
+        {
+            while (true) {
+                var frame = await ReadFrameAsync(stream);
+
+                if (frame.Header.BodyType != H2FrameType.Headers)
+                    continue;
+
+                headersReceived.TrySetResult();
+                return frame.Header;
+            }
+        }
+
+        private static async Task WriteResponseHeadersAsync(Stream stream, Task headersReceived)
+        {
+            await headersReceived;
+            var response = new byte[10];
+            H2Frame.Write(
+                response, 1, H2FrameType.Headers, HeaderFlags.EndHeaders, streamIdentifier: 1);
+            response[9] = 0x88;
+            await stream.WriteAsync(response);
+            await stream.FlushAsync();
+        }
+
+        private static async Task WriteResponseEndStreamAsync(Stream stream)
+        {
+            var endStream = new byte[9];
+            H2Frame.Write(
+                endStream, 0, H2FrameType.Data, HeaderFlags.EndStream, streamIdentifier: 1);
+            await stream.WriteAsync(endStream);
+            await stream.FlushAsync();
+        }
+
+        private static async Task<(H2Frame Header, byte[] Body)> ReadFrameAsync(Stream stream)
+        {
+            var headerBytes = new byte[9];
+            await ReadExactlyAsync(stream, headerBytes);
+            var header = new H2Frame(headerBytes);
+            var body = new byte[header.BodyLength];
+            await ReadExactlyAsync(stream, body);
+            return (header, body);
+        }
+
+        private static async Task ReadExactlyAsync(Stream stream, byte[] destination)
+        {
+            var offset = 0;
+
+            while (offset < destination.Length) {
+                var read = await stream.ReadAsync(destination.AsMemory(offset));
+
+                if (read == 0)
+                    throw new EndOfStreamException();
+
+                offset += read;
+            }
+        }
+
+        private static async Task ProcessAndDisposeAsync(
+            StreamWorker worker, Exchange exchange, ResizableBuffer bodyBuffer)
+        {
+            using (bodyBuffer)
+                await worker.ProcessRequestBody(exchange, bodyBuffer, CancellationToken.None);
+        }
+
+        private static WorkerFixture CreateWorker(byte[] payload, UpStreamChannel channel)
+        {
+            var authority = new Authority("test.local", 443, true);
+            var setting = new H2StreamSetting {
+                OverallWindowSize = payload.Length + 32 * 1024
+            };
+            setting.Remote.MaxFrameSize = 32 * 1024;
+            setting.Remote.WindowSize = payload.Length + 32 * 1024;
+            var memoryProvider = ArrayPoolMemoryProvider<char>.Default;
+            var headerEncoder = new HeaderEncoder(
+                new HPackEncoder(new EncodingContext(memoryProvider)),
+                new HPackDecoder(new DecodingContext(authority, memoryProvider)),
+                setting);
+            var overallWindow = new WindowSizeHolder(setting.OverallWindowSize, 0);
+            var context = new StreamContext(
+                connectionId: 1,
+                authority: authority,
+                setting: setting,
+                headerEncoder: headerEncoder,
+                upStreamChannel: channel,
+                overallWindowSizeHolder: overallWindow);
+            var streamPool = new StreamPool(context);
+            var resetTokenSource = new CancellationTokenSource();
+            var exchange = MakeExchange(authority, payload);
+            var worker = new StreamWorker(1, streamPool, exchange, resetTokenSource);
+            return new WorkerFixture(
+                worker, exchange, streamPool, overallWindow, resetTokenSource);
+        }
+
+        private static Exchange MakeExchange(Authority authority, byte[] payload)
+        {
+            var exchange = new Exchange(
+                new TestIdProvider(),
+                authority,
+                $"POST /upload HTTP/2.0\r\nhost: test.local\r\ncontent-length: {payload.Length}\r\n\r\n".AsMemory(),
+                "HTTP/2",
+                DateTime.UtcNow);
+            exchange.Request.Body = new MemoryStream(payload);
+            return exchange;
+        }
+
+        private static Exchange MakeBodylessExchange(Authority authority, Stream? body)
+        {
+            var request = body == null
+                ? "GET / HTTP/2.0\r\nhost: test.local\r\n\r\n"
+                : "POST /upload HTTP/2.0\r\nhost: test.local\r\ncontent-length: 0\r\n\r\n";
+            var exchange = new Exchange(
+                new TestIdProvider(), authority, request.AsMemory(), "HTTP/2", DateTime.UtcNow);
+            exchange.Request.Body = body;
+            return exchange;
+        }
+
+        private static byte[] CreatePayload(int length)
+        {
+            var payload = new byte[length];
+            new Random(42).NextBytes(payload);
+            return payload;
+        }
+
+        private static UploadFrame ParseDataFrame(byte[] frameBytes)
+        {
+            var header = new H2Frame(frameBytes.AsSpan(0, 9));
+            Assert.Equal(H2FrameType.Data, header.BodyType);
+            Assert.Equal(frameBytes.Length - 9, header.BodyLength);
+            return new UploadFrame(
+                frameBytes.AsSpan(9).ToArray(),
+                header.Flags.HasFlag(HeaderFlags.EndStream));
+        }
+
+        private sealed record UploadFrame(byte[] Payload, bool EndStream);
+
+        private sealed class NonSeekableEmptyStream : Stream
+        {
+            public int ReadCount { get; private set; }
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() { }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                ReadCount++;
+                return 0;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) =>
+                throw new NotSupportedException();
+        }
+
+        private sealed class GatedWriter
+        {
+            private WriteTask _pending;
+
+            public TaskCompletionSource Enqueued { get; } = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public byte[]? FrameBytes { get; private set; }
+
+            public void Enqueue(ref WriteTask writeTask)
+            {
+                _pending = writeTask;
+                Enqueued.TrySetResult();
+            }
+
+            public void Complete()
+            {
+                FrameBytes = _pending.BufferBytes.ToArray();
+                _pending.OnComplete(null);
+            }
+
+            public void Fail(Exception exception) => _pending.OnComplete(exception);
+
+            public void Cancel(CancellationToken token) =>
+                _pending.CompletionSource.SetCanceled(token);
+        }
+
+        private sealed class WorkerFixture : IDisposable
+        {
+            private readonly StreamPool _streamPool;
+            private readonly WindowSizeHolder _overallWindow;
+            private readonly CancellationTokenSource _resetTokenSource;
+
+            public WorkerFixture(
+                StreamWorker worker,
+                Exchange exchange,
+                StreamPool streamPool,
+                WindowSizeHolder overallWindow,
+                CancellationTokenSource resetTokenSource)
+            {
+                Worker = worker;
+                Exchange = exchange;
+                _streamPool = streamPool;
+                _overallWindow = overallWindow;
+                _resetTokenSource = resetTokenSource;
+            }
+
+            public StreamWorker Worker { get; }
+
+            public Exchange Exchange { get; }
+
+            public void Dispose()
+            {
+                Worker.Dispose();
+                _streamPool.Dispose();
+                _overallWindow.Dispose();
+                _resetTokenSource.Dispose();
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
@@ -212,6 +211,8 @@ namespace Fluxzy.Tests.UnitTests.H2Client
         [Fact]
         public async Task WriterChannelSupportsConcurrentTeardownDrain()
         {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
             var authority = new Authority("test.local", 443, true);
             var pool = new H2ConnectionPool(
                 Stream.Null,
@@ -219,20 +220,25 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 authority,
                 new Connection(authority, new TestIdProvider()),
                 _ => { });
+            var first = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 1, priority: 0,
+                streamDependency: 0, new byte[9]);
+            var second = new WriteTask(
+                H2FrameType.Data, streamIdentifier: 3, priority: 0,
+                streamDependency: 0, new byte[9]);
 
-            try {
-                var field = typeof(H2ConnectionPool).GetField(
-                    "_writerChannel", BindingFlags.Instance | BindingFlags.NonPublic);
-                Assert.NotNull(field);
-                var channel = field.GetValue(pool);
-                Assert.NotNull(channel);
+            pool.EnqueueWriteTaskForTests(ref first);
+            pool.EnqueueWriteTaskForTests(ref second);
 
-                Assert.DoesNotContain(
-                    "SingleConsumer", channel.GetType().Name, StringComparison.Ordinal);
-            }
-            finally {
-                await pool.DisposeAsync();
-            }
+            // Disposal and the exiting writer loop both drain the channel,
+            // which requires the channel to allow more than one reader.
+            await Task.WhenAll(
+                pool.DisposeAsync().AsTask(),
+                pool.RunWriterLoopForTests(cancellation.Token))
+                      .WaitAsync(TimeSpan.FromSeconds(2));
+
+            Assert.True(first.DoneTask.IsCompleted);
+            Assert.True(second.DoneTask.IsCompleted);
         }
 
         [Fact]
@@ -251,7 +257,7 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 H2FrameType.Data, streamIdentifier: 1, priority: 0,
                 streamDependency: 0, new byte[9]);
 
-            EnqueueForPool(pool, writeTask);
+            pool.EnqueueWriteTaskForTests(ref writeTask);
 
             Assert.True(writeTask.DoneTask.IsCompleted);
             await Assert.ThrowsAsync<ConnectionCloseException>(() => writeTask.DoneTask);
@@ -294,10 +300,10 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 H2FrameType.Data, streamIdentifier: 3, priority: 0,
                 streamDependency: 0, new byte[9]);
 
-            EnqueueForPool(pool, first);
-            EnqueueForPool(pool, second);
+            pool.EnqueueWriteTaskForTests(ref first);
+            pool.EnqueueWriteTaskForTests(ref second);
 
-            await RunWriterLoopForTest(pool, cancellation.Token)
+            await pool.RunWriterLoopForTests(cancellation.Token)
                 .WaitAsync(TimeSpan.FromSeconds(2));
 
             Assert.True(first.DoneTask.IsCompleted);
@@ -322,8 +328,8 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 H2FrameType.WindowUpdate, streamIdentifier: 1, priority: 0,
                 streamDependency: 0, ReadOnlyMemory<byte>.Empty, value: 1);
 
-            EnqueueForPool(pool, writeTask);
-            var loop = RunWriterLoopForTest(pool, cancellation.Token);
+            pool.EnqueueWriteTaskForTests(ref writeTask);
+            var loop = pool.RunWriterLoopForTests(cancellation.Token);
 
             try {
                 await stream.Written.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -350,24 +356,6 @@ namespace Fluxzy.Tests.UnitTests.H2Client
 
             Assert.True(writeTask.DoneTask.IsCompleted);
             await Assert.ThrowsAsync<ObjectDisposedException>(() => writeTask.DoneTask);
-        }
-
-        private static void EnqueueForPool(H2ConnectionPool pool, WriteTask writeTask)
-        {
-            var method = typeof(H2ConnectionPool).GetMethod(
-                "UpStreamChannel", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
-            method.Invoke(pool, new object[] { writeTask });
-        }
-
-        private static Task RunWriterLoopForTest(
-            H2ConnectionPool pool, CancellationToken cancellationToken)
-        {
-            var method = typeof(H2ConnectionPool).GetMethod(
-                "InternalWriteLoop", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
-            return Assert.IsAssignableFrom<Task>(
-                method.Invoke(pool, new object[] { cancellationToken }));
         }
 
         private static async Task NegotiateMaxFrameSize(DuplexPipe pipe, int remoteMaxFrameSize)

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerUploadTests.cs
@@ -130,6 +130,32 @@ namespace Fluxzy.Tests.UnitTests.H2Client
         }
 
         [Fact]
+        public async Task RequestHeaderOwnsBytesAfterCallerCancellation()
+        {
+            var payload = CreatePayload(128);
+            var writer = new GatedWriter();
+            using var fixture = CreateWorker(payload, writer.Enqueue);
+            using var headerBuffer = ResizableBuffer.Allocate(32 * 1024);
+            using var cancellation = new CancellationTokenSource();
+
+            var (sent, _) = fixture.Worker.EnqueueRequestHeader(
+                fixture.Exchange, headerBuffer, cancellation.Token);
+            await writer.Enqueued.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            var expectedFrame = writer.SnapshotFrameBytes();
+
+            cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => sent.WaitAsync(TimeSpan.FromSeconds(2)));
+
+            // Model the caller returning its pooled RsBuffer and a subsequent renter
+            // overwriting it while the transport write is still pending.
+            headerBuffer.Buffer.AsSpan().Fill(0xA5);
+            writer.Complete();
+
+            Assert.Equal(expectedFrame, writer.FrameBytes);
+        }
+
+        [Fact]
         public async Task PooledBodyBufferCannotBeOverwrittenBeforeFinalWrite()
         {
             var payload = CreatePayload(8192);
@@ -181,6 +207,32 @@ namespace Fluxzy.Tests.UnitTests.H2Client
             }
 
             Assert.True(processing.IsCompleted);
+        }
+
+        [Fact]
+        public async Task WriterChannelSupportsConcurrentTeardownDrain()
+        {
+            var authority = new Authority("test.local", 443, true);
+            var pool = new H2ConnectionPool(
+                Stream.Null,
+                new H2StreamSetting(),
+                authority,
+                new Connection(authority, new TestIdProvider()),
+                _ => { });
+
+            try {
+                var field = typeof(H2ConnectionPool).GetField(
+                    "_writerChannel", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(field);
+                var channel = field.GetValue(pool);
+                Assert.NotNull(channel);
+
+                Assert.DoesNotContain(
+                    "SingleConsumer", channel.GetType().Name, StringComparison.Ordinal);
+            }
+            finally {
+                await pool.DisposeAsync();
+            }
         }
 
         [Fact]
@@ -543,6 +595,8 @@ namespace Fluxzy.Tests.UnitTests.H2Client
                 _pending = writeTask;
                 Enqueued.TrySetResult();
             }
+
+            public byte[] SnapshotFrameBytes() => _pending.BufferBytes.ToArray();
 
             public void Complete()
             {


### PR DESCRIPTION
## Problem

Each upstream HTTP/2 stream eagerly creates a response `Pipe`, including bodyless responses that only need `Stream.Null`. Uploads also size DATA frames from an approximately 4 KiB pooled buffer rather than the peer's advertised frame size, causing thousands of writes for large bodies. The final DATA frame can release its pooled buffer before the write completes.

## Solution

Create the response pipe only when DATA, trailers, or reset handling needs it. Bodyless terminal HEADERS publish `Stream.Null` without allocating a pipe.

For request bodies, size the payload from `Remote.MaxFrameSize` with a 64 KiB cap, reserve the frame header in the same rental, and await the terminal write before returning the buffer. Skip the dedicated upload buffer entirely when request HEADERS already carry `END_STREAM`.

## Benefits

- Bodyless HTTP/2 throughput improved 2.6% and allocation fell 5.6%.
- 16 MiB upload throughput improved 113%, from a median 112.8 MiB/s to 240.3 MiB/s.
- 16 MiB upload CPU fell 52% and allocation fell 9.8%.
- DATA/TLS writes fell 75%: 4,107 to 1,025 at 16 MiB and 258 to 65 at 1 MiB.
- Exact body length and SHA-256 remained unchanged.

## Changes

- Lazily and synchronously publish one response pipe per H2 stream.
- Preserve reset, empty-DATA, trailer, and disposal completion semantics.
- Increase upload DATA payloads up to the peer limit with a 64 KiB cap.
- Await final write ownership before returning pooled memory.
- Avoid body-buffer allocation when request HEADERS end the stream.

## Verification

- Release test-project build completed with zero errors.
- 33 focused and adjacent H2 client tests passed.
- 16 alternating exact-upload samples passed at 1 MiB and 16 MiB, validating both H2 legs, body length, and SHA-256.
- Four narrowed bodyless-response BenchmarkDotNet launches completed successfully after building the external benchmark dependency; the two earlier setup-only `NA` reports are retained but contain no candidate workload.

## Line Count

| Category | Additions | Removals | Net |
|---|---:|---:|---:|
| Documentation | 0 | 0 | 0 |
| Configuration | 0 | 0 | 0 |
| Runtime | 109 | 36 | +73 |
| Tests | 705 | 0 | +705 |
| **Total** | **814** | **36** | **+778** |

Generated or vendored content: none.
