### PR TITLE
Batch bodyless HEADERS flushes in the H2 downstream write loop

### DIFF
--- a/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
+++ b/src/Fluxzy.Core/Core/H2DownStreamPipe.cs
@@ -62,6 +62,11 @@ namespace Fluxzy.Core
         private TaskCompletionSource<object?>? _writeLoopGateForTests;
         private TaskCompletionSource<object?>? _writeLoopIdleForTests;
 
+        // Bodyless responses whose HEADERS are encoded into the ring buffer but not yet
+        // flushed. Completed in FlushRingBufferAsync after the bytes reach the wire, so
+        // a single flush settles a whole batch instead of one write per response.
+        private readonly List<ServerStreamWorker> _pendingBodylessCompletions = new();
+
         private readonly CancellationToken _mainLoopToken;
         private readonly CancellationTokenSource _mainLoopTokenSource;
 
@@ -468,6 +473,15 @@ namespace Fluxzy.Core
 
                 _ringBuffer.Advance(total);
             }
+
+            if (_pendingBodylessCompletions.Count > 0) {
+                foreach (var worker in _pendingBodylessCompletions) {
+                    if (worker.CompleteResponse())
+                        CheckoutServerStreamWorker(worker);
+                }
+
+                _pendingBodylessCompletions.Clear();
+            }
         }
 
         /// <summary>
@@ -591,7 +605,7 @@ namespace Fluxzy.Core
                         var bodylessWorker = EncodePendingHeader(pending);
 
                         if (bodylessWorker != null)
-                            await CompleteBodylessHeaderAsync(bodylessWorker, token).ConfigureAwait(false);
+                            _pendingBodylessCompletions.Add(bodylessWorker);
 
                         didWork = true;
                     }
@@ -620,7 +634,7 @@ namespace Fluxzy.Core
                             var bodylessWorker = EncodePendingHeader(pending);
 
                             if (bodylessWorker != null)
-                                await CompleteBodylessHeaderAsync(bodylessWorker, token).ConfigureAwait(false);
+                                _pendingBodylessCompletions.Add(bodylessWorker);
 
                             didWork = true;
                         }
@@ -833,15 +847,6 @@ namespace Fluxzy.Core
             _ringBuffer.Write(encoded.Span);
 
             return pending.HasBody ? null : worker;
-        }
-
-        private async ValueTask CompleteBodylessHeaderAsync(
-            ServerStreamWorker worker, CancellationToken token)
-        {
-            await FlushRingBufferAsync(token).ConfigureAwait(false);
-
-            if (worker.CompleteResponse())
-                CheckoutServerStreamWorker(worker);
         }
 
         private void CompleteWrittenResponse(int streamIdentifier)


### PR DESCRIPTION
Fixes a bodyless H2 throughput regression introduced by d7840df2 (#764).

The write loop flushed the ring buffer once per bodyless response header so the stream could be completed after its bytes reached the wire. That broke HEADERS batching: every 0-byte response paid its own TLS record and syscall. With-body responses were unaffected.

This defers the CompleteResponse/checkout calls into a list drained at the end of the existing batched flush. Completion ordering is preserved: it still runs only after the wire write.

Measured with benchmark-throughput (ServeH2 True, body 0, proxy on): 82k ops/s before, 135k ops/s after, matching the pre-regression level. All 59 H2Serve tests pass.