### PR TITLE
Deliver the response when a reset races the header signal

### DIFF
--- a/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
+++ b/src/Fluxzy.Core/Clients/H2/StreamWorker.cs
@@ -38,7 +38,10 @@ namespace Fluxzy.Clients.H2
 
         private bool _headerEndedStream;
         private bool _noBodyStream;
-        private bool _responseHeadersComplete;
+
+        // Written by the read loop before the signal, read cross-thread by the
+        // skip gate and the post-wait re-checks in ProcessResponse.
+        private volatile bool _responseHeadersComplete;
 
         private volatile bool _abandonedByGoAway;
         private Exception? _abandonInnerCause;
@@ -503,7 +506,9 @@ namespace Fluxzy.Clients.H2
                                 acquired = true;
                             }
                             catch (TimeoutException) {
-                                acquired = false;
+                                // A timeout that raced the signal must not discard an
+                                // arrived response; the flag is written before the signal.
+                                acquired = _responseHeadersComplete;
                             }
 
                             if (acquired)
@@ -533,9 +538,17 @@ namespace Fluxzy.Clients.H2
                         _abandonInnerCause);
                 }
 
-                throw new ClientErrorException(1,
-                    "The connection was interrupted before receiving response header",
-                    networkErrorCode: NetworkErrorCodes.ProtocolError);
+                // A reset right behind the response (RST after headers, as some
+                // servers do) cancels the stream token while the signal is in
+                // flight. Task.WaitAsync runs the cancellation callback inline but
+                // the completion continuation queued, so cancellation can win
+                // against an already-fired signal. SemaphoreSlim served the signal
+                // first; keep that behavior by delivering the arrived response.
+                if (!_responseHeadersComplete) {
+                    throw new ClientErrorException(1,
+                        "The connection was interrupted before receiving response header",
+                        networkErrorCode: NetworkErrorCodes.ProtocolError);
+                }
             }
             catch (Exception) {
                 Parent.NotifyDispose(this);

--- a/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerHeaderSignalTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H2Client/StreamWorkerHeaderSignalTests.cs
@@ -79,6 +79,30 @@ namespace Fluxzy.Tests.UnitTests.H2Client
         }
 
         [Fact]
+        public async Task HeadersDeliveredThenReset_StillDeliversResponse()
+        {
+            // sandbox-style upstream: response followed by an immediate RST. The
+            // reset cancels the stream token right behind the header signal; the
+            // arrived response must be delivered whichever side wins the race
+            // inside Task.WaitAsync.
+            for (var i = 0; i < 300; i++) {
+                using var fixture = new WorkerFixture();
+
+                var processResponse = Task.Run(
+                    () => fixture.Worker.ProcessResponse(fixture.ResetToken, null!).AsTask());
+
+                await Task.Delay(1); // let the waiter park on the signal
+
+                fixture.ReceiveResponseHeaders(endStream: false);
+                fixture.Worker.ResetRequest(H2ErrorCode.NoError);
+
+                await processResponse;
+
+                Assert.NotNull(fixture.Exchange.Response.Header);
+            }
+        }
+
+        [Fact]
         public async Task ProcessResponseCancelledBeforeHeaders_SurfacesClientError()
         {
             using var fixture = new WorkerFixture();
@@ -132,6 +156,8 @@ namespace Fluxzy.Tests.UnitTests.H2Client
             public Exchange Exchange { get; }
 
             public StreamWorker Worker { get; }
+
+            public CancellationToken ResetToken => _resetTokenSource.Token;
 
             public void ReceiveResponseHeaders(bool endStream)
             {


### PR DESCRIPTION
Fixes the intermittent SimpleH2Request 528 introduced by #773.

Some servers (sandbox.fluxzy.io among them) send RST_STREAM right after the response. ResetRequest then cancels the stream token just behind the header signal. SemaphoreSlim served an already fired signal before cancellation, but Task.WaitAsync runs the cancellation callback inline while the completion continuation is queued, so cancellation could win and an arrived response surfaced as a spurious 528.

ProcessResponse now re-checks the completed-headers flag after a cancelled or timed out wait and delivers the response when it did arrive. The flag is written before the signal and is now volatile.

New regression test (parked waiter, headers then immediate reset) fails on main and passes here. A cancelled wait without headers still surfaces as ClientErrorException.