### PR TITLE
Bypass DNS lock for cached results

### DIFF
--- a/src/Fluxzy.Core/Clients/Dns/DefaultDnsResolver.cs
+++ b/src/Fluxzy.Core/Clients/Dns/DefaultDnsResolver.cs
@@ -18,9 +18,12 @@ namespace Fluxzy.Clients.Dns
 
         public async Task<IReadOnlyCollection<IPAddress>> SolveDnsAll(string hostName)
         {
+            if (_cache.TryGetValue(hostName, out var cached))
+                return cached;
+
             using var _ = await Synchronizer<string>.Shared.LockAsync(hostName).ConfigureAwait(false);
 
-            if (_cache.TryGetValue(hostName, out var cached))
+            if (_cache.TryGetValue(hostName, out cached))
                 return cached;
 
             try

--- a/test/Fluxzy.Tests/UnitTests/Misc/DefaultDnsResolverTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/DefaultDnsResolverTests.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Fluxzy.Clients.Dns;
 using Fluxzy.Core;
+using Fluxzy.Utils;
 using Xunit;
 
 namespace Fluxzy.Tests.UnitTests.Misc
@@ -127,6 +128,21 @@ namespace Fluxzy.Tests.UnitTests.Misc
             Assert.Equal(NetworkErrorCodes.DnsNoData, ex.ClientError.NetworkErrorCode);
         }
 
+        [Fact]
+        public async Task CachedResult_DoesNotWaitForHostLock()
+        {
+            const string host = "cached.example";
+            var solver = new CountingResolver();
+            var expected = await solver.SolveDnsAll(host);
+
+            using var hostLock = await Synchronizer<string>.Shared.LockAsync(host);
+            var cached = await solver.SolveDnsAll(host).WaitAsync(
+                System.TimeSpan.FromSeconds(1));
+
+            Assert.Same(expected, cached);
+            Assert.Equal(1, solver.CallCount);
+        }
+
         [Theory]
         [InlineData(System.Net.Sockets.SocketError.HostNotFound, NetworkErrorCodes.DnsNotFound)]
         [InlineData(System.Net.Sockets.SocketError.NoData, NetworkErrorCodes.DnsNoData)]
@@ -143,6 +159,18 @@ namespace Fluxzy.Tests.UnitTests.Misc
         {
             protected override Task<IEnumerable<IPAddress>> InternalSolveDns(string hostName)
                 => Task.FromResult(Enumerable.Empty<IPAddress>());
+        }
+
+        private sealed class CountingResolver : DefaultDnsResolver
+        {
+            public int CallCount { get; private set; }
+
+            protected override Task<IEnumerable<IPAddress>> InternalSolveDns(string hostName)
+            {
+                CallCount++;
+                return Task.FromResult<IEnumerable<IPAddress>>(
+                    new[] { IPAddress.Loopback });
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

`DefaultDnsResolver.SolveDnsAll` acquires the process-wide per-host lock before checking its instance cache. A cached lookup therefore enters the synchronizer registry, allocates lock/task state, and can wait behind an unrelated in-flight resolution even though its cached result is already authoritative.

## Solution

Check the resolver cache before acquiring the host lock. Keep the existing lookup inside the lock so concurrent misses still resolve once and all waiters reuse the result published by the first resolver call.

Cache lifetime, empty-result and exception behavior, custom resolvers, numeric addresses, forced addresses, DNS-over-HTTPS, and upstream proxy resolution remain unchanged.

## Benefits

- Cached lookup latency fell from 208.4 ns to 25.66 ns, an 87.7% reduction.
- Cached lookup allocation fell from 288 B to 72 B, a 75.0% reduction.
- A cached lookup under held-lock contention fell from 3,103 ns to 201 ns.
- Concurrent misses still perform exactly one underlying resolution and share the published collection.

## Changes

- Add a cache lookup before acquiring the per-host lock.
- Retain the inside-lock double check for misses.
- Add deterministic coverage proving that a warmed cache hit does not wait for the host lock.

## Verification

- Release test-project build completed with zero errors.
- Seven focused resolver tests passed.
- The new regression test fails on the baseline by timing out behind a deliberately held host lock and passes on the candidate.
- Deterministic controls cover concurrent misses, numeric addresses, cached empty results, custom resolvers, and retry after a failed resolution.
- BenchmarkDotNet used five warmups and twelve measured iterations on .NET 10.

## Line Count

| Category | Additions | Removals | Net |
|---|---:|---:|---:|
| Documentation | 0 | 0 | 0 |
| Configuration | 0 | 0 | 0 |
| Runtime | 4 | 1 | +3 |
| Tests | 28 | 0 | +28 |
| **Total** | **32** | **1** | **+31** |
