### PR TITLE
Fix response connection persistence handling

### DIFF
--- a/src/Fluxzy.Core/Core/Header.cs
+++ b/src/Fluxzy.Core/Core/Header.cs
@@ -209,6 +209,34 @@ namespace Fluxzy.Core
             return false;
         }
 
+        protected bool HasHeaderValueToken(ReadOnlyMemory<char> name, string value)
+        {
+            foreach (var field in _rawHeaderFields) {
+                if (!field.Name.Span.Equals(name.Span, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                var remaining = field.Value.Span;
+
+                while (true) {
+                    var commaIndex = remaining.IndexOf(',');
+                    var token = (commaIndex < 0 ? remaining : remaining.Slice(0, commaIndex)).Trim();
+
+                    if (token.Equals(value, StringComparison.OrdinalIgnoreCase)) {
+                        return true;
+                    }
+
+                    if (commaIndex < 0) {
+                        break;
+                    }
+
+                    remaining = remaining.Slice(commaIndex + 1);
+                }
+            }
+
+            return false;
+        }
+
         protected bool HasHeaderValueContains(ReadOnlyMemory<char> name, string value)
         {
             foreach (var f in _rawHeaderFields) {

--- a/src/Fluxzy.Core/Core/ResponseHeader.cs
+++ b/src/Fluxzy.Core/Core/ResponseHeader.cs
@@ -13,6 +13,9 @@ namespace Fluxzy.Core
 {
     public class ResponseHeader : Header
     {
+        private readonly bool _hasCloseDelimitedTransferEncoding;
+        private readonly bool _isHttp10Response;
+
         /// <summary>
         ///     Building from flat header
         /// </summary>
@@ -24,6 +27,8 @@ namespace Fluxzy.Core
             bool isSecure, bool parseConnectionInfo)
             : base(headerContent, isSecure)
         {
+            _isHttp10Response = IsHttp10Response(headerContent.Span);
+            _hasCloseDelimitedTransferEncoding = NormalizeCloseDelimitedTransferEncoding();
             StatusCode = ParseStatusCode();
 
             if (parseConnectionInfo) {
@@ -42,6 +47,8 @@ namespace Fluxzy.Core
         public ResponseHeader(IEnumerable<HeaderField> headers)
             : base(headers)
         {
+            _isHttp10Response = false;
+            _hasCloseDelimitedTransferEncoding = NormalizeCloseDelimitedTransferEncoding();
             StatusCode = ParseStatusCode();
 
             ConnectionCloseRequest = ReadConnectionCloseRequest();
@@ -60,7 +67,39 @@ namespace Fluxzy.Core
             return int.Parse(field.Value.Span);
         }
 
-        public int TimeoutIdleSeconds { get; set; } = 1;
+        private bool NormalizeCloseDelimitedTransferEncoding()
+        {
+            if (ChunkedBody || !TryGetFirstHeader(Http11Constants.TransferEncodingVerb, out _)) {
+                return false;
+            }
+
+            // Any Transfer-Encoding overrides Content-Length. A response whose final
+            // transfer coding is not chunked is delimited by closing the connection.
+            RemoveHeader("content-length");
+            ContentLength = -1;
+
+            return true;
+        }
+
+        private static bool IsHttp10Response(ReadOnlySpan<char> headerContent)
+        {
+            var lineStart = 0;
+
+            while (lineStart < headerContent.Length &&
+                   (headerContent[lineStart] == '\r' || headerContent[lineStart] == '\n')) {
+                lineStart++;
+            }
+
+            const string protocol = "HTTP/1.0";
+            var firstLine = headerContent.Slice(lineStart);
+
+            return firstLine.Length > protocol.Length &&
+                   firstLine.Slice(0, protocol.Length)
+                       .Equals(protocol.AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                   (firstLine[protocol.Length] == ' ' || firstLine[protocol.Length] == '\t');
+        }
+
+        public int TimeoutIdleSeconds { get; set; } = -1;
 
         public int MaxConnection { get; set; } = -1;
 
@@ -70,21 +109,34 @@ namespace Fluxzy.Core
 
         private bool ReadConnectionCloseRequest()
         {
-            if (HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "close")) {
+            if (HasHeaderValueToken(Http11Constants.ConnectionVerb, "close")) {
+                return true;
+            }
+
+            if (_hasCloseDelimitedTransferEncoding) {
+                return true;
+            }
+
+            if (_isHttp10Response &&
+                (!HasHeaderValueToken(Http11Constants.ConnectionVerb, "keep-alive") ||
+                 !HasSelfDelimitedHttp10Response())) {
                 return true;
             }
 
             // upgrade token only ends the http/1.1 usage when the protocol switch
             // actually happens (101); on any other status it is a mere advertisement
             return StatusCode == 101 &&
-                   HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "upgrade");
+                   HasHeaderValueToken(Http11Constants.ConnectionVerb, "upgrade");
         }
+
+        private bool HasSelfDelimitedHttp10Response() =>
+            ContentLength >= 0 || StatusCode < 200 || StatusCode is 204 or 304;
 
         private bool ReadKeepAliveSettings()
         {
             var immediateClose = false;
 
-            if (HasHeaderValueEqualsAny(Http11Constants.ConnectionVerb, "keep-alive")) {
+            if (HasHeaderValueToken(Http11Constants.ConnectionVerb, "keep-alive")) {
                 if (TryGetLastHeader(Http11Constants.KeepAliveVerb, out var keepHeaderValue)
                     && !keepHeaderValue.Value.IsEmpty) {
                     if (HeaderUtility.TryParseKeepAlive(keepHeaderValue.Value.Span, out var max, out var timeout)) {

--- a/test/Fluxzy.Tests/UnitTests/Core/ResponseHeaderKeepAliveTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/ResponseHeaderKeepAliveTests.cs
@@ -1,9 +1,18 @@
 // Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
 
 using System;
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Fluxzy.Clients.H2.Encoder;
 using Fluxzy.Core;
+using Fluxzy.Rules.Actions;
+using Fluxzy.Tests._Fixtures;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Xunit;
 
 namespace Fluxzy.Tests.UnitTests.Core
@@ -149,14 +158,52 @@ namespace Fluxzy.Tests.UnitTests.Core
             Assert.Equal(-1, header.TimeoutIdleSeconds);
         }
 
-        private static ResponseHeader Parse(
-            string fields,
-            string protocol = "HTTP/1.1",
-            int statusCode = 200)
+        [Fact]
+        public async Task Requests_Over_One_Second_Apart_Reuse_Upstream_Tls_Connection()
         {
-            var rawHeader = $"{protocol} {statusCode} Test\r\n{fields}\r\n";
+            var connectionIds = new ConcurrentDictionary<string, byte>();
+            await using var origin = await InProcessHost.Create(app =>
+                app.MapGet("/", (HttpContext context) => {
+                    var connectionId = context.Connection.Id;
+                    connectionIds.TryAdd(connectionId, 0);
+                    context.Response.Headers["X-Connection-Id"] = connectionId;
+                    return Results.Text("ok");
+                }), suppressLogging: true, protocols: HttpProtocols.Http1);
 
-            return new ResponseHeader(rawHeader.AsMemory(), false, true);
+            var setting = FluxzySetting.CreateLocalRandomPort();
+            setting.ConfigureRule().WhenAny()
+                   .Do(new SkipRemoteCertificateValidationAction());
+
+            await using var proxy = new Proxy(setting);
+            using var client = HttpClientUtility.CreateHttpClient(proxy.Run(), setting,
+                handler => handler.ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator);
+            client.DefaultRequestVersion = HttpVersion.Version11;
+            client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+            var url = $"https://localhost:{origin.Port}/";
+            var firstConnection = await GetConnectionId(client, url);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(1250));
+
+            var secondConnection = await GetConnectionId(client, url);
+
+            Assert.Equal(firstConnection, secondConnection);
+            Assert.Single(connectionIds);
+        }
+
+        private static ResponseHeader Parse(
+            string fields, string protocol = "HTTP/1.1", int statusCode = 200) =>
+            new($"{protocol} {statusCode} OK\r\n{fields}\r\n".AsMemory(), true, true);
+
+        private static async Task<string> GetConnectionId(HttpClient client, string url)
+        {
+            using var response = await client.GetAsync(url);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("ok", await response.Content.ReadAsStringAsync());
+
+            return response.Headers.GetValues("X-Connection-Id").Single();
         }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/Core/ResponseHeaderKeepAliveTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/ResponseHeaderKeepAliveTests.cs
@@ -1,0 +1,162 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Linq;
+using Fluxzy.Clients.H2.Encoder;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    public class ResponseHeaderKeepAliveTests
+    {
+        [Fact]
+        public void Response_Without_KeepAlive_Has_No_Protocol_Idle_Timeout()
+        {
+            var header = Parse("Content-Length: 2\r\n");
+
+            Assert.Equal(-1, header.TimeoutIdleSeconds);
+            Assert.Equal(-1, header.MaxConnection);
+            Assert.False(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Explicit_KeepAlive_Timeout_And_Max_Are_Parsed()
+        {
+            var header = Parse(
+                "Connection: custom, keep-alive\r\n" +
+                "Keep-Alive: timeout=9, max=7\r\n");
+
+            Assert.Equal(9, header.TimeoutIdleSeconds);
+            Assert.Equal(7, header.MaxConnection);
+            Assert.False(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void KeepAlive_Max_One_Requests_Connection_Close()
+        {
+            var header = Parse(
+                "Connection: keep-alive\r\n" +
+                "Keep-Alive: timeout=30, max=1\r\n");
+
+            Assert.Equal(30, header.TimeoutIdleSeconds);
+            Assert.Equal(1, header.MaxConnection);
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Theory]
+        [InlineData("Connection: close\r\n")]
+        [InlineData("Connection: custom, close\r\n")]
+        [InlineData("Connection: close, custom\r\n")]
+        [InlineData("Connection: keep-alive, close\r\n")]
+        [InlineData("Connection: custom, \tclose \r\n")]
+        [InlineData("Connection: custom\r\nConnection: close\r\n")]
+        public void Http11_Close_Connection_Option_Is_Recognized(string fields)
+        {
+            var header = Parse(fields);
+
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Switching_Protocols_Recognizes_Upgrade_In_Connection_Option_List()
+        {
+            var header = Parse("Connection: keep-alive, upgrade\r\n", statusCode: 101);
+
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Http10_Without_KeepAlive_Requests_Connection_Close()
+        {
+            var header = Parse("Content-Length: 2\r\n", protocol: "HTTP/1.0");
+
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Theory]
+        [InlineData("Connection: keep-alive\r\nContent-Length: 2\r\n")]
+        [InlineData("Connection: custom, keep-alive\r\nContent-Length: 2\r\n")]
+        [InlineData("Connection: custom\r\nConnection: keep-alive\r\nContent-Length: 2\r\n")]
+        public void Self_Delimited_Http10_KeepAlive_Can_Be_Reused(string fields)
+        {
+            var header = Parse(fields, protocol: "HTTP/1.0");
+
+            Assert.False(header.ConnectionCloseRequest);
+            Assert.Equal(-1, header.TimeoutIdleSeconds);
+        }
+
+        [Fact]
+        public void Http10_KeepAlive_Without_Self_Delimited_Body_Requests_Close()
+        {
+            var header = Parse("Connection: keep-alive\r\n", protocol: "HTTP/1.0");
+
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Theory]
+        [InlineData("HTTP/1.0")]
+        [InlineData("HTTP/1.1")]
+        public void Close_Delimited_Transfer_Encoding_Overrides_Content_Length(string protocol)
+        {
+            var header = Parse(
+                "Connection: keep-alive\r\n" +
+                "Transfer-Encoding: gzip\r\n" +
+                "Content-Length: 2\r\n",
+                protocol: protocol);
+
+            Assert.True(header.ConnectionCloseRequest);
+            Assert.Equal(-1, header.ContentLength);
+            Assert.DoesNotContain(header.HeaderFields,
+                field => field.Name.Span.Equals("content-length", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Theory]
+        [InlineData(199)]
+        [InlineData(204)]
+        [InlineData(304)]
+        public void Bodyless_Http10_KeepAlive_Can_Be_Reused(int statusCode)
+        {
+            var header = Parse("Connection: keep-alive\r\n", protocol: "HTTP/1.0", statusCode: statusCode);
+
+            Assert.False(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Unframed_Http10_205_Requests_Close()
+        {
+            var header = Parse("Connection: keep-alive\r\n", protocol: "HTTP/1.0", statusCode: 205);
+
+            Assert.True(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Explicitly_Empty_Http10_205_Can_Be_Reused()
+        {
+            var header = Parse(
+                "Connection: keep-alive\r\nContent-Length: 0\r\n",
+                protocol: "HTTP/1.0", statusCode: 205);
+
+            Assert.False(header.ConnectionCloseRequest);
+        }
+
+        [Fact]
+        public void Direct_H2_Header_Does_Not_Inherit_Http10_Close_By_Default()
+        {
+            var header = new ResponseHeader(new[] { new HeaderField(":status", "200") });
+
+            Assert.False(header.ConnectionCloseRequest);
+            Assert.Equal(-1, header.TimeoutIdleSeconds);
+        }
+
+        private static ResponseHeader Parse(
+            string fields,
+            string protocol = "HTTP/1.1",
+            int statusCode = 200)
+        {
+            var rawHeader = $"{protocol} {statusCode} Test\r\n{fields}\r\n";
+
+            return new ResponseHeader(rawHeader.AsMemory(), false, true);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/_Fixtures/InProcessHost.cs
+++ b/test/Fluxzy.Tests/_Fixtures/InProcessHost.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,8 @@ public class InProcessHost : IAsyncDisposable
 
     public static async Task<InProcessHost> Create(
         Action<WebApplication>? configureRoutes = null,
-        bool suppressLogging = false)
+        bool suppressLogging = false,
+        HttpProtocols protocols = HttpProtocols.Http1AndHttp2)
     {
         var certificate = CreateSelfSignedCertificate();
 
@@ -50,6 +52,7 @@ public class InProcessHost : IAsyncDisposable
         {
             k.Listen(IPAddress.Loopback, 0, listenOptions =>
             {
+                listenOptions.Protocols = protocols;
                 listenOptions.UseHttps(certificate);
             });
         });


### PR DESCRIPTION
## Problem

HTTP/1.1 connections are persistent unless either peer requests closure. Fluxzy instead gives a response without an explicit `Keep-Alive: timeout` an implicit one-second protocol idle timeout. The pool subtracts 200 ms from that value, so a healthy connection can be discarded after roughly 800 ms even though the origin never limited its lifetime.

Changing that default without considering HTTP/1.0 would make HTTP/1.0 responses persistent even when they did not negotiate `Connection: keep-alive`. Connection options are also comma-separated token lists, but the existing whole-value comparison misses values such as `Connection: custom, close` and `Connection: custom, keep-alive`.

HTTP/1.0 persistence is safe only when the response has a self-defined message length. Treating an unbounded HTTP/1.0 body as persistent can leave the proxy waiting for EOF while the origin waits for the next request. A non-final-chunked `Transfer-Encoding` is likewise close-delimited and overrides any accompanying `Content-Length`; trusting that length can recycle a connection with unread transfer-coded bytes. A bare `205 Reset Content` is not self-delimiting without explicit zero-length framing.

## Solution

Represent an absent HTTP/1.1 protocol idle limit as `-1`, matching the pool's existing "no peer-supplied limit" sentinel. Preserve explicit `Keep-Alive` timeout/max handling and the existing global unused-pool timeout.

Retain the source response version while parsing flat HTTP/1 headers. HTTP/1.0 remains close-by-default and is reusable only when `Connection: keep-alive` is present and the response is self-delimiting through `Content-Length` or valid no-body status semantics. Direct field-based responses are H2 and do not inherit HTTP/1.0 behavior.

Parse `Connection` as a comma-separated, case-insensitive token list with optional whitespace. Use that parser consistently for `close`, `keep-alive`, and `upgrade` decisions.

For a response whose final transfer coding is not `chunked`, remove `Content-Length`, reset the parsed length, and force close-delimited handling for both HTTP/1.0 and HTTP/1.1.

## Benefits

- Preserves ordinary HTTP/1.1 connections until the peer or configured global idle policy closes them.
- Keeps HTTP/1.0 close-by-default and prevents indefinite reads of non-self-delimited HTTP/1.0 bodies.
- Prevents connection desynchronization when non-final-chunked transfer coding accompanies a misleading content length.
- Honors compound and repeated `Connection` fields without substring matching.
- Retains explicit timeout, maximum-request, close, and protocol-upgrade behavior.
- Keeps H2/direct-header response semantics unchanged.

The original current-master performance campaign used four request waves separated by 1.25 seconds:

| Workload | Current master | Candidate | Paired median effect |
|---|---:|---:|---:|
| Idle-wave H1 empty, c16 | 1.27k req/s | 3.26k req/s | +170.3% (pair range +149.9% to +230.5%) |
| Idle-wave H1 8 KiB, c16 | 1.09k req/s | 3.21k req/s | +123.0% (pair range +112.5% to +259.8%) |
| Idle-wave H1 8 KiB, c56 | 1.93k req/s | 4.35k req/s | +164.6% (pair range +104.0% to +184.4%) |

New measured upstream TLS connections fell from 64/61/224 to zero. Across all three workloads p99 fell 58-65%, allocation/request fell 53-69%, and CPU/request fell 34-38%. The later HTTP/1.0, token-parsing, and transfer-framing hardening does not alter the measured HTTP/1.1 path, but was not separately benchmarked.

## Changes

- Default `ResponseHeader.TimeoutIdleSeconds` to the existing unlimited sentinel.
- Detect HTTP/1.0 response status lines and require explicitly negotiated, self-delimited persistence.
- Add allocation-free token parsing for comma-separated header values.
- Apply token parsing to response `close`, `keep-alive`, and `upgrade` options.
- Normalize non-final-chunked transfer coding as close-delimited and discard conflicting content length.
- Cover implicit and explicit HTTP/1.1 persistence, HTTP/1.0 framing, compound/repeated connection options, H2 construction, transfer-coding precedence, status 205, and real TLS connection reuse.
- Allow the in-process HTTPS fixture to force HTTP/1.1.

## Verification

The updated branch was built and tested locally with .NET 10.0.101. Existing compiler, analyzer, and obsolete-API warnings remain; no new errors were introduced.

- Debug focused parser/framing/pool/upgrade/keep-alive set: 66 passed, 0 failed, 0 skipped.
- Release focused parser/framing/pool/upgrade/keep-alive set: 66 passed, 0 failed, 0 skipped.
- Debug complete `Fluxzy.Tests.UnitTests.Core` set: 189 passed, 0 failed, 0 skipped.
- Release complete `Fluxzy.Tests.UnitTests.Core` set: 189 passed, 0 failed, 0 skipped.
- Debug complete `Fluxzy.Tests.UnitTests.H11Client` set: 10 passed, 0 failed, 0 skipped.
- Independent final read-only review found no remaining medium-or-higher correctness issues after the transfer-framing and status-205 follow-up.
- The real TLS test verifies that two HTTP/1.1 requests 1.25 seconds apart reuse one upstream connection.
- Git whitespace validation passes with the repository's CRLF convention (`core.whitespace=cr-at-eol`).

The complete repository test suite was not run because it includes environment-dependent external-network, certificate-installation, and raw-capture cases. The test startup reported the expected inability to install its development CA in the unprivileged DevPod; the selected tests still completed successfully.

## Line Count

| Category | Additions | Removals | Net |
|---|---:|---:|---:|
| Documentation | 0 | 0 | 0 |
| Configuration | 0 | 0 | 0 |
| Runtime | 84 | 4 | +80 |
| Tests | 213 | 1 | +212 |
| **Total** | **297** | **5** | **+292** |

