### PR TITLE
Add HTTP/1.1 connection disposition barrier

### DIFF
--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading;
@@ -259,80 +258,19 @@ namespace Fluxzy.Clients.H11
                     if (exchange.Response.Header != null)
                         exchange.Connection.TimeoutIdleSeconds = exchange.Response.Header.TimeoutIdleSeconds;
 
-                    void OnExchangeCompleteFunction(Task<bool> completeTask)
-                    {
-                        try {
-                            abortRegistration.Dispose();
+                    var connection = exchange.Connection!;
+                    var maxConnection = exchange.Response.Header!.MaxConnection;
+                    var closeForConnectionAuth =
+                        !_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange);
 
-                            // A faulted or cancelled completion means the body read failed:
-                            // never recycle, always free. Reading .Result unguarded would
-                            // rethrow here and skip the teardown entirely.
-                            var closeConnectionRequest =
-                                !completeTask.IsCompletedSuccessfully || completeTask.Result;
-
-                            if (exchange.Response.Header!.MaxConnection != -1 &&
-                                exchange.Response.Header!.MaxConnection <= exchange.Connection.RequestProcessed) {
-                                closeConnectionRequest = true;
-                            }
-
-                            // Leakage guard: a shared connection that carried NTLM/Negotiate auth
-                            // is bound to one client's identity. Never return it to the shared pool.
-                            // Dedicated (pinned) pools keep it since they serve a single client.
-                            if (!_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange)) {
-                                closeConnectionRequest = true;
-                            }
-
-                            if (exchange.Metrics.ResponseBodyEnd == default)
-                                exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
-
-                            if (completeTask.Exception != null && completeTask.Exception.InnerExceptions.Any()) {
-                                foreach (var exception in completeTask.Exception.InnerExceptions) {
-                                    exchange.Errors.Add(new Error("Error while reading response", exception));
-                                }
-                            }
-                            else if (completeTask.IsCompletedSuccessfully && !closeConnectionRequest) { //
-
-                                // Idle age starts when the response body has been consumed, not
-                                // when its headers arrived. With connection-oriented auth, using
-                                // the header timestamp can make a slow response recycle an
-                                // already-expired authenticated connection.
-                                var lastUsed = _timingProvider.Instant();
-
-                                if (_pendingConnections.Writer.TryWrite(
-                                        new Http11ProcessingState(exchange.Connection, lastUsed)))
-                                {
-                                    return;
-                                }
-                            }
-                            else {
-                                // should close connection
-                            }
-
-                            FreeConnectionStreams(exchange.Connection);
-                        }
-                        finally {
-                            // Send returns after response headers, while the connection remains
-                            // occupied until the response body completes. Keep the pool active
-                            // through that whole lifetime so idle teardown cannot remove the pin
-                            // or dispose the pool underneath this continuation.
-                            lock (_idleGate) {
-                                _activeRequestCount--;
-                                _lastActivity = _timingProvider.Instant();
-                            }
-
-                            // Released only here on the success path: the connection is now
-                            // back in the channel (or freed), so the next pinned Send can
-                            // dequeue it instead of racing ahead and opening a fresh one.
-                            _pinnedLease?.Release();
-                        }
-                    }
-
-                    // CancellationToken.None: the cleanup must run even when the caller
-                    // has already cancelled, otherwise an aborted exchange leaks its
-                    // connection (the continuation would be cancelled instead of run).
-                    var _ = exchange.Complete.ContinueWith(OnExchangeCompleteFunction, CancellationToken.None);
+                    // The disposition task owns the active-request and pinned-lease cleanup.
+                    // Publish that ownership before starting it because exchange.Complete may
+                    // already be finished and the async method can run synchronously.
                     activityHandedToContinuation = true;
                     leaseHandedToContinuation = leaseAcquired;
+                    exchange.RegisterConnectionDisposition(DisposeConnectionAfterExchange(
+                        exchange, connection, maxConnection, closeForConnectionAuth,
+                        abortRegistration, cancellationToken));
                 }
                 catch (Exception ex) {
 
@@ -394,6 +332,61 @@ namespace Fluxzy.Clients.H11
                     _pinnedLease!.Release();
 
                 ITimingProvider.Default.Instant();
+            }
+        }
+
+        private async Task DisposeConnectionAfterExchange(
+            Exchange exchange, Connection connection, int maxConnection,
+            bool closeForConnectionAuth, CancellationTokenRegistration abortRegistration,
+            CancellationToken cancellationToken)
+        {
+            var closeConnection = true;
+            var completionSucceeded = false;
+
+            try {
+                closeConnection = await exchange.Complete.ConfigureAwait(false);
+                completionSucceeded = true;
+            }
+            catch (Exception exception) {
+                exchange.Errors.Add(new Error("Error while reading response", exception));
+            }
+
+            try {
+                abortRegistration.Dispose();
+
+                if (cancellationToken.IsCancellationRequested)
+                    closeConnection = true;
+
+                if (maxConnection != -1 && maxConnection <= connection.RequestProcessed)
+                    closeConnection = true;
+
+                if (closeForConnectionAuth)
+                    closeConnection = true;
+
+                if (exchange.Metrics.ResponseBodyEnd == default)
+                    exchange.Metrics.ResponseBodyEnd = ITimingProvider.Default.Instant();
+
+                if (completionSucceeded && !closeConnection &&
+                    _pendingConnections.Writer.TryWrite(
+                        new Http11ProcessingState(connection, _timingProvider.Instant()))) {
+                    return;
+                }
+
+                FreeConnectionStreams(connection);
+            }
+            catch (Exception exception) {
+                exchange.Errors.Add(new Error("Error while disposing remote connection", exception));
+            }
+            finally {
+                // Send returns after response headers, so disposition owns pool activity and
+                // the pinned lease until the body is consumed and the connection is recycled
+                // or closed.
+                lock (_idleGate) {
+                    _activeRequestCount--;
+                    _lastActivity = _timingProvider.Instant();
+                }
+
+                _pinnedLease?.Release();
             }
         }
 

--- a/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
+++ b/src/Fluxzy.Core/Clients/H11/Http11ConnectionPool.cs
@@ -263,14 +263,11 @@ namespace Fluxzy.Clients.H11
                     var closeForConnectionAuth =
                         !_dedicated && ConnectionAuthHeuristic.InvolvesConnectionAuth(exchange);
 
-                    // The disposition task owns the active-request and pinned-lease cleanup.
-                    // Publish that ownership before starting it because exchange.Complete may
-                    // already be finished and the async method can run synchronously.
-                    activityHandedToContinuation = true;
-                    leaseHandedToContinuation = leaseAcquired;
                     exchange.RegisterConnectionDisposition(DisposeConnectionAfterExchange(
                         exchange, connection, maxConnection, closeForConnectionAuth,
                         abortRegistration, cancellationToken));
+                    activityHandedToContinuation = true;
+                    leaseHandedToContinuation = leaseAcquired;
                 }
                 catch (Exception ex) {
 
@@ -337,30 +334,38 @@ namespace Fluxzy.Clients.H11
 
         private async Task DisposeConnectionAfterExchange(
             Exchange exchange, Connection connection, int maxConnection,
-            bool closeForConnectionAuth, CancellationTokenRegistration abortRegistration,
+            bool closeForConnectionAuth,
+            CancellationTokenRegistration abortRegistration,
             CancellationToken cancellationToken)
         {
             var closeConnection = true;
             var completionSucceeded = false;
 
             try {
-                closeConnection = await exchange.Complete.ConfigureAwait(false);
-                completionSucceeded = true;
-            }
-            catch (Exception exception) {
-                exchange.Errors.Add(new Error("Error while reading response", exception));
-            }
+                try {
+                    closeConnection = await exchange.Complete.ConfigureAwait(false);
+                    completionSucceeded = true;
+                }
+                catch {
+                    if (exchange.Complete.Exception != null) {
+                        foreach (var exception in exchange.Complete.Exception.InnerExceptions) {
+                            exchange.Errors.Add(new Error("Error while reading response", exception));
+                        }
+                    }
+                }
 
-            try {
-                abortRegistration.Dispose();
+                try {
+                    abortRegistration.Dispose();
+                }
+                catch (Exception exception) {
+                    exchange.Errors.Add(new Error("Error while releasing response cancellation", exception));
+                    closeConnection = true;
+                }
 
-                if (cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested || closeForConnectionAuth)
                     closeConnection = true;
 
                 if (maxConnection != -1 && maxConnection <= connection.RequestProcessed)
-                    closeConnection = true;
-
-                if (closeForConnectionAuth)
                     closeConnection = true;
 
                 if (exchange.Metrics.ResponseBodyEnd == default)
@@ -372,20 +377,21 @@ namespace Fluxzy.Clients.H11
                     return;
                 }
 
-                FreeConnectionStreams(connection);
-            }
-            catch (Exception exception) {
-                exchange.Errors.Add(new Error("Error while disposing remote connection", exception));
+                try {
+                    FreeConnectionStreams(connection);
+                }
+                catch (Exception exception) {
+                    exchange.Errors.Add(new Error("Error while disposing remote connection", exception));
+                }
             }
             finally {
-                // Send returns after response headers, so disposition owns pool activity and
-                // the pinned lease until the body is consumed and the connection is recycled
-                // or closed.
+                // The request remains active until its connection is reusable or closed.
                 lock (_idleGate) {
                     _activeRequestCount--;
                     _lastActivity = _timingProvider.Instant();
                 }
 
+                // A pinned sender can proceed only after disposition is complete.
                 _pinnedLease?.Release();
             }
         }
@@ -492,3 +498,4 @@ namespace Fluxzy.Clients.H11
         public DateTime LastUsed { get; set; }
     }
 }
+

--- a/src/Fluxzy.Core/Core/Exchange.cs
+++ b/src/Fluxzy.Core/Core/Exchange.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Fluxzy.Clients;
 using Fluxzy.Clients.H11;
@@ -17,6 +18,8 @@ namespace Fluxzy.Core
 {
     public class Exchange : IExchange
     {
+        private Task? _connectionDisposition;
+
         private Exchange(
             IIdProvider idProvider,
             ExchangeContext context,
@@ -115,6 +118,17 @@ namespace Fluxzy.Core
         ///     This tasks indicates the status of the exchange
         /// </summary>
         internal Task<bool> Complete => ExchangeCompletionSource.Task;
+
+        internal Task ConnectionDisposition =>
+            Volatile.Read(ref _connectionDisposition) ?? Task.CompletedTask;
+
+        internal void RegisterConnectionDisposition(Task disposition)
+        {
+            ArgumentNullException.ThrowIfNull(disposition);
+
+            if (Interlocked.CompareExchange(ref _connectionDisposition, disposition, null) != null)
+                throw new InvalidOperationException("Connection disposition is already registered.");
+        }
 
         /// <summary>
         /// </summary>

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -833,6 +833,8 @@ namespace Fluxzy.Core
                         // Enhance your calm
                     }
 
+                    await exchange.ConnectionDisposition.ConfigureAwait(false);
+
                     FluxzyLogEvents.LogExchangeCompleted(_logger, exchange, _proxyRuntimeSetting.StartupSetting);
                 }
                 else

--- a/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
+++ b/src/Fluxzy.Core/Core/ProxyOrchestrator.cs
@@ -707,7 +707,7 @@ namespace Fluxzy.Core
                         if (_archiveWriter?.CapturesBodyContent == true)
                         {
                             var dispatchStream = new DispatchStream(responseBodyStream,
-                                true,
+                                true, DispatchStreamOwnership.OwnBaseStream,
                                 _archiveWriter.CreateResponseBodyStream(exchange.Id));
 
                             exchange.Response.Body = dispatchStream;
@@ -966,3 +966,4 @@ namespace Fluxzy.Core
         }
     }
 }
+

--- a/src/Fluxzy.Core/Misc/Streams/DispatchStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/DispatchStream.cs
@@ -8,6 +8,12 @@ using System.Threading.Tasks;
 
 namespace Fluxzy.Misc.Streams
 {
+    public enum DispatchStreamOwnership
+    {
+        LeaveBaseStreamOpen,
+        OwnBaseStream
+    }
+
     /// <summary>
     ///     Read stream and dispatch read bytes to listener streams
     /// </summary>
@@ -15,7 +21,9 @@ namespace Fluxzy.Misc.Streams
     {
         private readonly Stream _baseStream;
         private readonly bool _closeOnDone;
+        private readonly DispatchStreamOwnership _ownership;
         private List<Stream>? _destinations;
+        private int _disposed;
 
         /// <summary>
         ///     Constructor
@@ -26,9 +34,25 @@ namespace Fluxzy.Misc.Streams
         public DispatchStream(
             Stream baseStream, bool closeOnDone,
             params Stream[] listenerStreams)
+            : this(baseStream, closeOnDone, DispatchStreamOwnership.LeaveBaseStreamOpen, listenerStreams)
+        {
+        }
+
+        /// <summary>
+        ///     Constructor with explicit base stream ownership
+        /// </summary>
+        /// <param name="baseStream">Read stream</param>
+        /// <param name="closeOnDone">When readStream reach EOF, close listener streams</param>
+        /// <param name="ownership">Whether disposing this stream also disposes the base stream</param>
+        /// <param name="listenerStreams">List of listenerStreams</param>
+        public DispatchStream(
+            Stream baseStream, bool closeOnDone,
+            DispatchStreamOwnership ownership,
+            params Stream[] listenerStreams)
         {
             _baseStream = baseStream;
             _closeOnDone = closeOnDone;
+            _ownership = ownership;
             _destinations = new List<Stream>(listenerStreams);
         }
 
@@ -62,13 +86,13 @@ namespace Fluxzy.Misc.Streams
             var read = _baseStream.Read(buffer, offset, count);
 
             if (read == 0 && _closeOnDone) {
-                if (_destinations != null) {
-                    foreach (var dest in _destinations) {
+                var destinations = Interlocked.Exchange(ref _destinations, null);
+
+                if (destinations != null) {
+                    foreach (var dest in destinations) {
                         dest.Dispose();
                     }
                 }
-
-                _destinations = null;
             }
             else {
                 if (_destinations != null) {
@@ -95,13 +119,13 @@ namespace Fluxzy.Misc.Streams
             var read = await _baseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 
             if (read == 0 && _closeOnDone) {
-                if (_destinations != null) {
-                    foreach (var dest in _destinations) {
+                var destinations = Interlocked.Exchange(ref _destinations, null);
+
+                if (destinations != null) {
+                    foreach (var dest in destinations) {
                         await dest.DisposeAsync().ConfigureAwait(false);
                     }
                 }
-
-                _destinations = null;
 
                 if (OnDisposeDoneTask != null) {
                     await OnDisposeDoneTask().ConfigureAwait(false);
@@ -138,32 +162,52 @@ namespace Fluxzy.Misc.Streams
 
         public override async ValueTask DisposeAsync()
         {
-            // Console.WriteLine($"Dispatched stream realeased async {_closeOnDone}");
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
 
-            if (_destinations != null && _closeOnDone) {
-                foreach (var dest in _destinations) {
-                    await dest.DisposeAsync().ConfigureAwait(false);
+            try {
+                var destinations = _closeOnDone
+                    ? Interlocked.Exchange(ref _destinations, null)
+                    : null;
+
+                if (destinations != null) {
+                    foreach (var dest in destinations) {
+                        await dest.DisposeAsync().ConfigureAwait(false);
+                    }
                 }
-
-                _destinations = null;
             }
+            finally {
+                if (_ownership == DispatchStreamOwnership.OwnBaseStream)
+                    await _baseStream.DisposeAsync().ConfigureAwait(false);
 
-            await base.DisposeAsync().ConfigureAwait(false);
+                base.Dispose(true);
+                GC.SuppressFinalize(this);
+            }
         }
 
         protected override void Dispose(bool disposing)
         {
-            // Console.WriteLine($"Dispatched stream realeased sync {_closeOnDone}");
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
 
-            if (_destinations != null && _closeOnDone) {
-                foreach (var dest in _destinations) {
-                    dest.Dispose();
+            try {
+                var destinations = disposing && _closeOnDone
+                    ? Interlocked.Exchange(ref _destinations, null)
+                    : null;
+
+                if (destinations != null) {
+                    foreach (var dest in destinations) {
+                        dest.Dispose();
+                    }
                 }
-
-                _destinations = null;
             }
+            finally {
+                if (disposing && _ownership == DispatchStreamOwnership.OwnBaseStream)
+                    _baseStream.Dispose();
 
-            base.Dispose(disposing);
+                base.Dispose(disposing);
+            }
         }
     }
 }
+

--- a/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
+++ b/src/Fluxzy.Core/Misc/Streams/MetricsStream.cs
@@ -176,28 +176,21 @@ namespace Fluxzy.Misc.Streams
             _firstBytesRead();
         }
 
-        private void NotifyFinalRead()
+        private void NotifyFinalRead(bool? endConnection = null)
         {
             if (_finalReadNotified)
                 return; 
 
             _finalReadNotified = true;
 
-            _endRead(EndConnection, TotalRead);
+            _endRead(endConnection ?? EndConnection, TotalRead);
         }
 
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
 
-            // Notify only when the body was fully read. A partially read body
-            // must not report a successful final read: the completion callback
-            // marks the exchange reusable and the connection pool would recycle
-            // a connection still carrying unread body bytes.
-            if (_expectedLength != null && TotalRead >= _expectedLength)
-            {
-                NotifyFinalRead();
-            }
+            NotifyFinalRead(_expectedLength == null || TotalRead < _expectedLength || EndConnection);
         }
     }
 }

--- a/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
@@ -1,3 +1,5 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
 using System;
 using System.Threading.Tasks;
 using Fluxzy.Clients;

--- a/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
@@ -1,5 +1,3 @@
-// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
-
 using System;
 using System.Threading.Tasks;
 using Fluxzy.Clients;

--- a/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/ExchangeConnectionDispositionTests.cs
@@ -1,0 +1,49 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System;
+using System.Threading.Tasks;
+using Fluxzy.Clients;
+using Fluxzy.Core;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Core
+{
+    public class ExchangeConnectionDispositionTests
+    {
+        [Fact]
+        public async Task RegisteredDisposition_RemainsObservableAfterResponseCompletion()
+        {
+            var exchange = CreateExchange();
+            var disposition = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            exchange.RegisterConnectionDisposition(disposition.Task);
+
+            exchange.ExchangeCompletionSource.SetResult(false);
+
+            Assert.True(exchange.Complete.IsCompletedSuccessfully);
+            Assert.False(exchange.ConnectionDisposition.IsCompleted);
+
+            disposition.SetResult();
+            await exchange.ConnectionDisposition;
+        }
+
+        [Fact]
+        public void Disposition_CanOnlyBeRegisteredOnce()
+        {
+            var exchange = CreateExchange();
+            exchange.RegisterConnectionDisposition(Task.CompletedTask);
+
+            Assert.Throws<InvalidOperationException>(
+                () => exchange.RegisterConnectionDisposition(Task.CompletedTask));
+        }
+
+        private static Exchange CreateExchange()
+        {
+            var authority = new Authority("localhost", 443, true);
+            return new Exchange(
+                IIdProvider.FromZero, authority,
+                "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n".AsMemory(),
+                "HTTP/1.1", DateTime.UtcNow);
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Core/UpgradeAdvertisementConnectionReuseTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Core/UpgradeAdvertisementConnectionReuseTests.cs
@@ -57,14 +57,11 @@ namespace Fluxzy.Tests.UnitTests.Core
                 UseProxy = true
             });
 
-            for (var i = 0; i < 2; i++) {
+            for (var i = 0; i < 100; i++) {
                 using var response = await httpClient.GetAsync($"http://127.0.0.1:{origin.Port}/");
 
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 Assert.Equal("OK", await response.Content.ReadAsStringAsync());
-
-                // recycling happens on a completion continuation, leave it time to land
-                await Task.Delay(250);
             }
 
             Assert.Equal(1, origin.ConnectionCount);

--- a/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/H11Client/DedicatedPoolSingleConnectionTests.cs
@@ -41,11 +41,16 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             // Contrast case: the ordinary shared pool has no single-connection lease, so two
             // concurrent sends fan out onto two sockets. This is what made simply dedicating a
             // shared pool to one client insufficient for connection-oriented auth.
-            await using var server = CountingHttpServer.Start();
+            await using var server = CountingHttpServer.Start(gateResponseBodies: true);
 
             await using var pool = BuildPool(server.Port, dedicated: false);
 
-            await SendConcurrently(pool, server.Port);
+            await SendConcurrently(pool, server.Port, () => {
+                var acceptedConnections = server.AcceptedConnections;
+                server.ReleaseResponseBodies();
+
+                Assert.Equal(2, acceptedConnections);
+            });
 
             Assert.Equal(2, server.AcceptedConnections);
         }
@@ -113,7 +118,8 @@ namespace Fluxzy.Tests.UnitTests.H11Client
             return pool;
         }
 
-        private static async Task SendConcurrently(Http11ConnectionPool pool, int port)
+        private static async Task SendConcurrently(
+            Http11ConnectionPool pool, int port, Action? beforeBodyDrain = null)
         {
             var authority = new Authority("127.0.0.1", port, false);
 
@@ -127,8 +133,12 @@ namespace Fluxzy.Tests.UnitTests.H11Client
 
             await Task.WhenAll(task1, task2);
 
-            // Content-Length: 0 responses complete synchronously inside Send, so awaiting here
-            // just observes the already-set result and any recycle exception.
+            beforeBodyDrain?.Invoke();
+
+            await Task.WhenAll(
+                exchange1.Response.Body!.CopyToAsync(Stream.Null),
+                exchange2.Response.Body!.CopyToAsync(Stream.Null));
+
             await exchange1.Complete;
             await exchange2.Complete;
         }

--- a/test/Fluxzy.Tests/UnitTests/Misc/DispatchStreamTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/DispatchStreamTests.cs
@@ -1,0 +1,72 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc
+{
+    public class DispatchStreamTests
+    {
+        [Fact]
+        public async Task ExistingConstructor_LeavesBaseStreamOpen()
+        {
+            var baseStream = new TrackingStream("base", new List<string>());
+            var dispatch = new DispatchStream(baseStream, closeOnDone: true, Stream.Null);
+
+            await dispatch.DisposeAsync();
+
+            Assert.Equal(0, baseStream.DisposeCount);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task OwningMode_DisposesDestinationsBeforeBaseExactlyOnce(bool disposeAsync)
+        {
+            var disposalOrder = new List<string>();
+            var baseStream = new TrackingStream("base", disposalOrder);
+            var destination = new TrackingStream("destination", disposalOrder);
+            var dispatch = new DispatchStream(
+                baseStream, closeOnDone: true, DispatchStreamOwnership.OwnBaseStream, destination);
+
+            if (disposeAsync)
+                await dispatch.DisposeAsync();
+            else
+                dispatch.Dispose();
+
+            dispatch.Dispose();
+            await dispatch.DisposeAsync();
+
+            Assert.Equal(1, destination.DisposeCount);
+            Assert.Equal(1, baseStream.DisposeCount);
+            Assert.Equal(new[] { "destination", "base" }, disposalOrder);
+        }
+
+        private sealed class TrackingStream : MemoryStream
+        {
+            private readonly string _name;
+            private readonly List<string> _disposalOrder;
+            private int _disposeCount;
+
+            public TrackingStream(string name, List<string> disposalOrder)
+            {
+                _name = name;
+                _disposalOrder = disposalOrder;
+            }
+
+            public int DisposeCount => Volatile.Read(ref _disposeCount);
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing && Interlocked.Increment(ref _disposeCount) == 1)
+                    _disposalOrder.Add(_name);
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/test/Fluxzy.Tests/UnitTests/Misc/MetricsStreamDispositionTests.cs
+++ b/test/Fluxzy.Tests/UnitTests/Misc/MetricsStreamDispositionTests.cs
@@ -1,0 +1,69 @@
+// Copyright 2021 - Haga Rakotoharivelo - https://github.com/haga-rak
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluxzy.Misc.Streams;
+using Xunit;
+
+namespace Fluxzy.Tests.UnitTests.Misc;
+
+public class MetricsStreamDispositionTests
+{
+    [Theory]
+    [InlineData(10, 2, true)]
+    [InlineData(-1, 2, true)]
+    [InlineData(2, 2, false)]
+    public async Task DisposalCompletesOnceWithCorrectConnectionDisposition(
+        long expectedLength, int bytesToRead, bool expectedClose)
+    {
+        var completionCount = 0;
+        var closeConnection = false;
+        var stream = new MetricsStream(
+            new MemoryStream(new byte[10]),
+            () => { },
+            (close, _) => {
+                completionCount++;
+                closeConnection = close;
+            },
+            _ => { },
+            endConnection: false,
+            expectedLength: expectedLength < 0 ? null : expectedLength,
+            parentToken: CancellationToken.None);
+        var buffer = new byte[bytesToRead];
+
+        Assert.Equal(bytesToRead, await stream.ReadAsync(buffer));
+        await stream.DisposeAsync();
+        stream.Dispose();
+
+        Assert.Equal(1, completionCount);
+        Assert.Equal(expectedClose, closeConnection);
+    }
+
+    [Fact]
+    public async Task OwningDispatchPropagatesPartialBodyCloseDisposition()
+    {
+        var completed = false;
+        var closeConnection = false;
+        var metrics = new MetricsStream(
+            new MemoryStream(new byte[10]),
+            () => { },
+            (close, _) => {
+                completed = true;
+                closeConnection = close;
+            },
+            _ => { },
+            endConnection: false,
+            expectedLength: 10,
+            parentToken: CancellationToken.None);
+        var dispatch = new DispatchStream(
+            metrics, closeOnDone: true, DispatchStreamOwnership.OwnBaseStream, Stream.Null);
+        var buffer = new byte[2];
+
+        Assert.Equal(2, await dispatch.ReadAsync(buffer));
+        await dispatch.DisposeAsync();
+
+        Assert.True(completed);
+        Assert.True(closeConnection);
+    }
+}


### PR DESCRIPTION
## Problem

HTTP/1.1 response completion and upstream connection cleanup happen asynchronously. `Http11PoolProcessing` completes the response, while `Http11ConnectionPool` subsequently recycles or closes the connection. A persistent downstream connection can therefore dispatch its next request before the previous upstream connection has returned to the pool, opening an unnecessary replacement connection.

Partial-response disposal has a related lifecycle gap. Preventing a partially consumed body from being reused is necessary, but disposal must also settle exchange completion. Otherwise, the upstream connection, active-request count, and dedicated-pool lease can remain occupied indefinitely. Response capture adds another ownership boundary because its `DispatchStream` wrapper can leave the underlying response stream open.

## Solution

Track upstream connection disposition separately from response completion.

Each successful HTTP/1.1 exchange registers an internal task that completes after its connection has been recycled or closed. The existing persistent downstream completion barrier awaits that task before reading the next request. This ordering is scoped to the exchange, allowing shared pools to continue serving independent clients concurrently.

The finalizer captures the connection and relevant keep-alive and connection-authentication decisions before response processing can mutate exchange state. It handles response failures, cancellation, connection limits, pool shutdown, error recording, active-request accounting, and dedicated-pool lease release.

Disposing an incomplete response body completes the exchange with a connection-close decision. Fully consumed responses retain their normal reuse behavior. `DispatchStream` gains explicit base-stream ownership, which response capture uses to propagate disposal to the underlying body stream. Request capture retains leave-open behavior for full-duplex forwarding.

## Benefits

- Reduces unnecessary upstream connections and TLS handshakes during sequential keep-alive traffic.
- Ensures relinquished partial responses complete instead of remaining pending.
- Prevents connections containing unread response bytes from being reused.
- Releases sockets, active-request counts, and dedicated-pool leases after response abandonment.
- Preserves public exchange/archive completion semantics and full-duplex request streaming.

## Performance

Three alternating baseline/candidate benchmark pairs measured HTTP/1.1 workloads with 8 KiB responses:

| Concurrency | Baseline throughput | Candidate throughput | Median paired change |
|---|---:|---:|---|
| 16 | 15.9k requests/s | 16.0k requests/s | Throughput within run-to-run variance; p99 latency **−11.4%** |
| 56 | 9.19k requests/s | 10.1k requests/s | Throughput **+4.8%**; p99 latency **−9.9%** |

The throughput improvement at concurrency 56 ranged from **+2.4% to +11.0%** across the three pairs. Paired changes were calculated within each baseline/candidate pair, so their median differs from the percentage change between the aggregate throughput medians shown above.

Additional measurements:

- At concurrency 16, the median number of new upstream TLS connections per run fell from **547 to zero**, and allocation per request fell **1.4%**.
- At concurrency 56, the median number of new upstream TLS connections per run fell from **6,782 to 6,413**, allocation per request fell **1.6%**, and CPU per request fell **3.4%**.

These measurements isolate the connection-disposition ordering change. Fresh-connection and reused-connection control workloads varied between runs, so no throughput improvement is claimed for those controls. The results indicate reduced connection churn and tail latency for these workloads; they are not a general throughput guarantee.

## Changes

- Add one-shot internal connection-disposition registration to `Exchange`.
- Replace detached HTTP/1.1 cleanup with a tracked asynchronous finalizer.
- Await connection disposition at the persistent downstream completion barrier.
- Capture the connection, keep-alive limit, and connection-authentication decision before asynchronous cleanup.
- Complete disposed partial or unknown-length response bodies with a connection-close decision.
- Add explicit leave-open and own-base-stream modes to `DispatchStream`.
- Use owning mode for captured responses.
- Make the shared-pool concurrency test deterministic by holding response bodies until both sends have received headers.
- Add regression coverage for disposition registration, partial-response disposal, stream ownership, and immediate sequential connection reuse.

## Verification

- Combined disposition, partial-response, stream-ownership, authentication, idle-lifetime, event-ordering, and shared/dedicated-pool tests: **36 passed, 0 failed**.
- Complete Core test suite: **167 passed, 0 failed**.
- Shared-pool concurrency regression: **20 consecutive isolated runs passed**; it also passed in the combined suite.
- Immediate sequential-reuse regression: **five consecutive runs passed**.
- Release build on **.NET 10.0.101** completed with existing warnings and no errors.
- Git whitespace validation passed.

The complete repository test suite was not run because it includes external-network, system certificate-installation, and raw-capture tests requiring additional environment setup. Test startup reported insufficient permissions to install the development CA; the selected suites nevertheless completed successfully.